### PR TITLE
Fix audio reset bug

### DIFF
--- a/components/audio-generator.tsx
+++ b/components/audio-generator.tsx
@@ -97,13 +97,24 @@ export function AudioGenerator({
   };
 
   const resetPlayer = () => {
-    if (audio) {
+    if (!audio) {
+      setIsPlaying(false);
+      return;
+    }
+
+    try {
       audio.pause();
       audio.currentTime = 0;
-      URL.revokeObjectURL(audio.src);
+
+      if (audio.src.startsWith('blob:')) {
+        URL.revokeObjectURL(audio.src);
+      }
+    } catch (error) {
+      console.error('Failed to reset audio', error);
+    } finally {
       setAudio(null);
+      setIsPlaying(false);
     }
-    setIsPlaying(false);
   };
 
   const downloadAudio = () => {


### PR DESCRIPTION
## Summary
- prevent URL.revokeObjectURL from throwing when resetting audio playback
- ensure audio resets correctly using try/catch/finally

## Testing
- `pnpm run lint:fix` *(fails: existing lint errors in repo)*
- `pnpm run format`
- `pnpm run type-check` *(fails: existing type errors in repo)*
- `pnpm run test`


------
https://chatgpt.com/codex/tasks/task_e_6842bbe37780832c97062290c0e25662