### PR TITLE
Add explore page with audio voting

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 <!-- - Generate AI voices in multiple languages (English & Spanish) -->
 - Voice selection system with customizable options
 - Public library of generated voices ranked by usage and votes
+- Explore page to browse and vote on public audio files
 - Credit-based usage system
 - User authentication and profile management (Google, Facebook and Apple login coming soon)
 

--- a/app/[lang]/explore/page.tsx
+++ b/app/[lang]/explore/page.tsx
@@ -1,0 +1,20 @@
+import Footer from '@/components/footer';
+import { Header } from '@/components/header';
+import { ExploreAudios } from '@/components/explore-audios';
+import { getDictionary } from '@/lib/i18n/get-dictionary';
+import type { Locale } from '@/lib/i18n/i18n-config';
+
+export default async function ExplorePage(props: { params: Promise<{ lang: Locale }> }) {
+  const { lang } = await props.params;
+  const dict = await getDictionary(lang);
+  return (
+    <>
+      <Header lang={lang} />
+      <div className="container mx-auto py-8 space-y-6">
+        <h1 className="text-3xl font-bold text-white">{dict.explore.title}</h1>
+        <ExploreAudios dict={dict.explore} />
+      </div>
+      <Footer />
+    </>
+  );
+}

--- a/app/api/public-audios/route.ts
+++ b/app/api/public-audios/route.ts
@@ -1,0 +1,56 @@
+import { NextResponse } from 'next/server';
+import hotRanking from '@/lib/hot-ranking';
+import { createClient } from '@/lib/supabase/server';
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const filter = searchParams.get('filter') || 'day';
+  const supabase = await createClient();
+
+  let query = supabase
+    .from('audio_files')
+    .select(
+      'id, url, text_content, created_at, voice_id, voices(id, name), audio_votes(vote)'
+    )
+    .eq('is_public', true);
+
+  const now = new Date();
+
+  if (filter === 'day') {
+    const d = new Date(now);
+    d.setDate(d.getDate() - 1);
+    query = query.gte('created_at', d.toISOString());
+  } else if (filter === 'week') {
+    const d = new Date(now);
+    d.setDate(d.getDate() - 7);
+    query = query.gte('created_at', d.toISOString());
+  } else if (filter === 'month') {
+    const d = new Date(now);
+    d.setMonth(d.getMonth() - 1);
+    query = query.gte('created_at', d.toISOString());
+  }
+
+  const { data, error } = await query;
+  if (error) {
+    console.error(error);
+    return NextResponse.json({ error: 'Failed to fetch audio files' }, { status: 500 });
+  }
+
+  const audioFiles = (data as any[]).map((item) => {
+    const votes = item.audio_votes as { vote: number }[] | null;
+    const ups = votes?.filter((v) => v.vote === 1).length || 0;
+    const downs = votes?.filter((v) => v.vote === -1).length || 0;
+    const score = ups - downs;
+    const trending = hotRanking(ups, downs, new Date(item.created_at));
+    return { ...item, ups, downs, score, trending };
+  });
+
+  let sorted = audioFiles;
+  if (filter === 'trending') {
+    sorted = audioFiles.sort((a, b) => b.trending - a.trending);
+  } else {
+    sorted = audioFiles.sort((a, b) => b.score - a.score);
+  }
+
+  return NextResponse.json(sorted.slice(0, 50));
+}

--- a/app/api/vote/route.ts
+++ b/app/api/vote/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+
+export async function POST(req: Request) {
+  const { audioId, vote } = await req.json();
+  if (!audioId || ![1, -1].includes(vote)) {
+    return NextResponse.json({ error: 'Invalid payload' }, { status: 400 });
+  }
+
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { data: existing } = await supabase
+    .from('audio_votes')
+    .select('id, vote')
+    .eq('audio_id', audioId)
+    .eq('user_id', user.id)
+    .single();
+
+  try {
+    if (!existing) {
+      await supabase.from('audio_votes').insert({ audio_id: audioId, user_id: user.id, vote });
+    } else if (existing.vote === vote) {
+      await supabase.from('audio_votes').delete().eq('id', existing.id);
+    } else {
+      await supabase.from('audio_votes').update({ vote }).eq('id', existing.id);
+    }
+
+    const { data: votes } = await supabase
+      .from('audio_votes')
+      .select('vote')
+      .eq('audio_id', audioId);
+
+    const ups = votes?.filter((v) => v.vote === 1).length ?? 0;
+    const downs = votes?.filter((v) => v.vote === -1).length ?? 0;
+
+    return NextResponse.json({ ups, downs });
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json({ error: 'Failed' }, { status: 500 });
+  }
+}

--- a/components/explore-audios.tsx
+++ b/components/explore-audios.tsx
@@ -1,0 +1,160 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Pause, Play, ThumbsUp, ThumbsDown } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+
+interface AudioFile {
+  id: string;
+  url: string;
+  text_content: string;
+  created_at: string;
+  voices: { id: string; name: string };
+  ups: number;
+  downs: number;
+  score: number;
+}
+
+const filters = [
+  { value: 'day', label: 'Top Day' },
+  { value: 'week', label: 'Top Week' },
+  { value: 'month', label: 'Top Month' },
+  { value: 'all', label: 'All Time' },
+  { value: 'trending', label: 'Trending' },
+];
+
+export function ExploreAudios({ dict }: { dict: any }) {
+  const [filter, setFilter] = useState<string>('day');
+  const [audioFiles, setAudioFiles] = useState<AudioFile[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [playing, setPlaying] = useState<string | null>(null);
+  const [audioEl, setAudioEl] = useState<HTMLAudioElement | null>(null);
+
+  useEffect(() => {
+    async function load() {
+      setLoading(true);
+      try {
+        const res = await fetch(`/api/public-audios?filter=${filter}`);
+        if (res.ok) {
+          const data = await res.json();
+          setAudioFiles(data);
+        }
+      } finally {
+        setLoading(false);
+      }
+    }
+    load();
+  }, [filter]);
+
+  const handlePlay = (audio: AudioFile) => {
+    if (playing === audio.id) {
+      audioEl?.pause();
+      setPlaying(null);
+      return;
+    }
+    audioEl?.pause();
+    const el = new Audio(audio.url);
+    el.play();
+    el.onended = () => setPlaying(null);
+    setAudioEl(el);
+    setPlaying(audio.id);
+  };
+
+  const vote = async (audioId: string, value: 1 | -1) => {
+    const res = await fetch('/api/vote', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ audioId, vote: value }),
+    });
+    if (res.ok) {
+      const data = await res.json();
+      setAudioFiles((prev) =>
+        prev.map((a) =>
+          a.id === audioId
+            ? { ...a, ups: data.ups, downs: data.downs, score: data.ups - data.downs }
+            : a,
+        ),
+      );
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="max-w-40">
+        <Select value={filter} onValueChange={setFilter}>
+          <SelectTrigger>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {filters.map((f) => (
+              <SelectItem key={f.value} value={f.value}>
+                {dict.filter[f.value] || f.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+      {loading ? (
+        <p className="text-gray-400">{dict.loading}</p>
+      ) : audioFiles.length === 0 ? (
+        <p className="text-gray-400">{dict.noFiles}</p>
+      ) : (
+        <div className="grid gap-4">
+          {audioFiles.map((audio) => (
+            <Card key={audio.id} className="bg-white/10 border-white/20">
+              <CardContent className="p-4 space-y-2">
+                <div className="flex items-center justify-between">
+                  <div className="space-y-1 overflow-hidden">
+                    <p className="text-white line-clamp-1">{audio.voices.name}</p>
+                    <p className="text-sm text-gray-400 line-clamp-2">
+                      {audio.text_content}
+                    </p>
+                  </div>
+                  <Button
+                    variant="outline"
+                    size="icon"
+                    className="bg-white/10 border-white/20 text-white hover:bg-white/20"
+                    onClick={() => handlePlay(audio)}
+                  >
+                    {playing === audio.id ? (
+                      <Pause className="size-4" />
+                    ) : (
+                      <Play className="size-4" />
+                    )}
+                  </Button>
+                </div>
+                <div className="flex items-center gap-2">
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    onClick={() => vote(audio.id, 1)}
+                    title={dict.voteUp}
+                  >
+                    <ThumbsUp className="size-4" />
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    onClick={() => vote(audio.id, -1)}
+                    title={dict.voteDown}
+                  >
+                    <ThumbsDown className="size-4" />
+                  </Button>
+                  <span className="text-sm text-gray-300">{audio.score}</span>
+                </div>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/popular-audios.tsx
+++ b/components/popular-audios.tsx
@@ -17,7 +17,6 @@ interface AudioFile {
   storage_key: string;
   duration: number;
   text_content: string;
-  total_votes: number;
   total_plays: number;
   is_public: boolean;
   created_at: string;
@@ -130,10 +129,7 @@ export function PopularAudios({ dict }: PopularAudiosProps) {
                 </p>
               </div>
               <div className="flex items-center space-x-4">
-                {/* <div className="flex items-center space-x-1 text-gray-400">
-                  <ThumbsUp className="size-4" />
-                  <span className="text-sm">{audio.total_votes}</span>
-                </div> */}
+                {/* Vote count could go here */}
                 <Button
                   variant="outline"
                   size="icon"

--- a/lib/hot-ranking.ts
+++ b/lib/hot-ranking.ts
@@ -1,0 +1,17 @@
+export default function hotRanking(ups: number, downs: number, date: Date): number {
+  const upvotes = ups || 0;
+  const downvotes = downs || 0;
+  const score = upvotes - downvotes;
+  if (Object.prototype.toString.call(date) !== '[object Date]') {
+    throw new Error('You must pass a valid date object');
+  }
+  const order = Math.log10(Math.max(Math.abs(score), 1));
+  const sign = score > 0 ? 1 : score < 0 ? -1 : 0;
+  const seconds = epochSeconds(date) - 1134028003;
+  const rank = sign * order + seconds / 45000;
+  return Number(rank.toPrecision(11));
+}
+
+function epochSeconds(date: Date): number {
+  return (date.getTime() - new Date(1970, 1, 1).getTime()) / 1000;
+}

--- a/lib/i18n/dictionaries/en.json
+++ b/lib/i18n/dictionaries/en.json
@@ -176,6 +176,15 @@
       }
     }
   },
+  
+  "explore": {
+    "title": "Explore Audio Files",
+    "loading": "Loading audio files...",
+    "noFiles": "No public audio files found",
+    "voteUp": "Vote up",
+    "voteDown": "Vote down",
+    "filter": {"day": "Top Day", "week": "Top Week", "month": "Top Month", "all": "All Time", "trending": "Trending"}
+  },
   "generate": {
     "notEnoughCredits": "You don't have enough credits to generate audio.",
     "success": "Audio generated successfully!",

--- a/lib/i18n/dictionaries/es.json
+++ b/lib/i18n/dictionaries/es.json
@@ -178,6 +178,15 @@
       }
     }
   },
+  
+  "explore": {
+    "title": "Explorar Audios",
+    "loading": "Cargando audios...",
+    "noFiles": "No se encontraron audios públicos",
+    "voteUp": "Votar positivo",
+    "voteDown": "Votar negativo",
+    "filter": {"day": "Top Día", "week": "Top Semana", "month": "Top Mes", "all": "Todo el tiempo", "trending": "Tendencias"}
+  },
   "generate": {
     "notEnoughCredits": "No tienes suficientes créditos para generar audio.",
     "success": "Audio generado con éxito!",

--- a/lib/supabase/types.d.ts
+++ b/lib/supabase/types.d.ts
@@ -20,7 +20,6 @@ declare type Database = {
           prediction_id: string | null;
           storage_key: string;
           text_content: string;
-          total_votes: number;
           url: string;
           user_id: string | null;
           voice_id: string;
@@ -35,7 +34,6 @@ declare type Database = {
           prediction_id?: string | null;
           storage_key: string;
           text_content: string;
-          total_votes?: number;
           url: string;
           user_id?: string | null;
           voice_id: string;
@@ -50,7 +48,6 @@ declare type Database = {
           prediction_id?: string | null;
           storage_key?: string;
           text_content?: string;
-          total_votes?: number;
           url?: string;
           user_id?: string | null;
           voice_id?: string;
@@ -70,6 +67,33 @@ declare type Database = {
             referencedRelation: 'voices';
             referencedColumns: ['id'];
           },
+        ];
+      };
+      audio_votes: {
+        Row: {
+          id: string;
+          audio_id: string;
+          user_id: string;
+          vote: number;
+          created_at: string;
+        };
+        Insert: {
+          id?: string;
+          audio_id: string;
+          user_id: string;
+          vote: number;
+          created_at?: string;
+        };
+        Update: {
+          id?: string;
+          audio_id?: string;
+          user_id?: string;
+          vote?: number;
+          created_at?: string;
+        };
+        Relationships: [
+          { foreignKeyName: "audio_votes_audio_id_fkey"; columns: ["audio_id"]; isOneToOne: false; referencedRelation: "audio_files"; referencedColumns: [id]; },
+          { foreignKeyName: "audio_votes_user_id_fkey"; columns: ["user_id"]; isOneToOne: false; referencedRelation: "profiles"; referencedColumns: [id]; }
         ];
       };
       credit_transactions: {

--- a/supabase/migrations/20250446000000_create_audio_votes_table.sql
+++ b/supabase/migrations/20250446000000_create_audio_votes_table.sql
@@ -1,0 +1,28 @@
+/*
+  # Create audio_votes table
+
+  1. Changes:
+    - Add audio_votes table to track user votes on audio files
+
+  2. Security:
+    - Enable RLS and allow users to manage their own votes
+*/
+
+create table audio_votes (
+  id uuid primary key default gen_random_uuid(),
+  audio_id uuid references audio_files(id) not null,
+  user_id uuid references profiles(id) not null,
+  vote integer not null,
+  created_at timestamp with time zone default timezone('utc', now()) not null,
+  constraint audio_votes_unique unique (audio_id, user_id)
+);
+
+alter table audio_votes enable row level security;
+
+create policy "Public can view votes" on audio_votes for select using (true);
+create policy "Users can insert votes" on audio_votes for insert with check (auth.uid() = user_id);
+create policy "Users can update own votes" on audio_votes for update using (auth.uid() = user_id);
+create policy "Users can delete own votes" on audio_votes for delete using (auth.uid() = user_id);
+
+create index audio_votes_audio_id_idx on audio_votes(audio_id);
+create index audio_votes_user_id_idx on audio_votes(user_id);

--- a/supabase/migrations/20250607000000_remove_total_votes_from_audio_files.sql
+++ b/supabase/migrations/20250607000000_remove_total_votes_from_audio_files.sql
@@ -1,0 +1,12 @@
+/*
+  # Remove total_votes column from audio_files table
+
+  1. Changes:
+    - Drop total_votes column from audio_files table
+
+  2. Security:
+    - No changes to RLS policies
+*/
+
+ALTER TABLE audio_files
+DROP COLUMN IF EXISTS total_votes;


### PR DESCRIPTION
## Summary
- add SQL migration for `audio_votes` table
- implement hot-ranking algorithm
- expose `/api/public-audios` and `/api/vote`
- add `ExploreAudios` component and explore page
- update supabase types and translations
- document explore page in README
- remove legacy `total_votes` column and update APIs

## Testing
- `pnpm run lint:fix` *(fails: some pre-existing lint errors)*
- `pnpm run format` *(fails: formatter reported issues)*
- `pnpm run type-check` *(fails: missing modules / implicit any errors)*
- `pnpm run test`
- `pnpm run check-translations`


------
https://chatgpt.com/codex/tasks/task_e_6842c24f856c832ca42afa60e912e8b6