### PR TITLE
fix: resolve 500 error for apple-touch-icon-precomposed.png requests

### DIFF
--- a/app/[lang]/page.tsx
+++ b/app/[lang]/page.tsx
@@ -2,10 +2,11 @@ import { allPosts } from 'contentlayer/generated';
 import { ArrowRightIcon, Globe2, Mic2, Shield, Sparkles } from 'lucide-react';
 import Image from 'next/image';
 import Link from 'next/link';
+import { redirect } from 'next/navigation';
 import type { ReactNode } from 'react';
 import { Suspense } from 'react';
 import { getDictionary } from '@/lib/i18n/get-dictionary';
-import type { Locale } from '@/lib/i18n/i18n-config';
+import { i18n, type Locale } from '@/lib/i18n/i18n-config';
 
 // import { VoiceGenerator } from "@/components/voice-generator";
 // import { PopularAudios } from '@/components/popular-audios';
@@ -79,6 +80,11 @@ export default async function LandingPage(props: {
   const params = await props.params;
 
   const { lang } = params;
+
+  // Validate that the language is a supported locale
+  if (!i18n.locales.includes(lang as Locale)) {
+    redirect(`/${i18n.defaultLocale}`);
+  }
 
   const dict = await getDictionary(lang);
 

--- a/lib/i18n/get-dictionary.ts
+++ b/lib/i18n/get-dictionary.ts
@@ -6,4 +6,11 @@ const dictionaries = {
   es: () => import('./dictionaries/es.json').then((module) => module.default),
 };
 
-export const getDictionary = async (locale: Locale) => dictionaries[locale]();
+export const getDictionary = async (locale: Locale) => {
+  const dictionary = dictionaries[locale];
+  if (!dictionary) {
+    // Fall back to default locale if locale is invalid
+    return dictionaries.en();
+  }
+  return dictionary();
+};

--- a/middleware.ts
+++ b/middleware.ts
@@ -20,6 +20,11 @@ const publicRoutesWithoutLocale = ['/privacy-policy', '/terms'];
 export async function middleware(req: NextRequest) {
   const { pathname } = req.nextUrl;
 
+  // Skip middleware for static files that should be served directly
+  if (pathname.match(/\.(ico|png|jpg|jpeg|gif|webp|svg|mp3)$/)) {
+    return NextResponse.next();
+  }
+
   if (publicRoutesWithoutLocale.includes(pathname)) {
     return NextResponse.next();
   }


### PR DESCRIPTION
Fixes #34

This PR resolves the 500 error "n[e] is not a function" that occurs when browsers request `/apple-touch-icon-precomposed.png`.

## Root Cause
The issue occurred because:
1. Browsers request `/apple-touch-icon-precomposed.png` but only `/apple-touch-icon.png` exists
2. This request gets routed to the `[lang]` dynamic route with "apple-touch-icon-precomposed.png" as the language parameter
3. `getDictionary()` tries to access an undefined dictionary function, causing the error

## Changes
- **Enhanced `getDictionary()` function**: Added fallback to default locale for invalid locales
- **Improved middleware**: Added explicit static file detection before i18n processing
- **Added page validation**: Page component now validates locales and redirects invalid ones

## Testing
The fixes prevent the 500 error by handling invalid locale requests gracefully at multiple levels.

Generated with [Claude Code](https://claude.ai/code)