### PR TITLE
Fix loader for text enhance button

### DIFF
--- a/components/audio-generator.tsx
+++ b/components/audio-generator.tsx
@@ -9,6 +9,7 @@ import {
   Play,
   RotateCcw,
   Sparkles,
+  Loader2,
 } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 import { toast } from 'sonner';
@@ -245,9 +246,11 @@ export function AudioGenerator({
                   disabled={!text.trim() || isEnhancingText || isGenerating}
                   title="Enhance text with AI emotion tags"
                 >
-                  <Sparkles
-                    className={`h-4 w-4 text-yellow-300 ${isEnhancingText ? 'animate-spin' : ''}`}
-                  />
+                  {isEnhancingText ? (
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                  ) : (
+                    <Sparkles className="h-4 w-4 text-yellow-300" />
+                  )}
                 </Button>
               </>
             )}


### PR DESCRIPTION
## Summary
- show a spinning loader icon while enhancing text in `AudioGenerator`

## Testing
- `pnpm run lint:fix`
- `pnpm run format:write`
- `pnpm run type-check` *(fails: Cannot find module 'contentlayer/generated')*
- `pnpm run check-translations`


------
https://chatgpt.com/codex/tasks/task_e_685c2aeb2444832cac2b0638a0b4e5bc