### PR TITLE
Add historical voice demo scripts and sample players

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ yarn-error.log*
 .env.sentry-build-plugin
 
 .contentlayer
+tsconfig.tsbuildinfo

--- a/VOICE_SCRIPTS.md
+++ b/VOICE_SCRIPTS.md
@@ -1,0 +1,15 @@
+# Sample Voiceover Scripts
+
+This file contains short scripts for voice cloning demos.
+
+## Theodore Roosevelt
+
+Fellow citizens, we stand at the dawn of a new century, and it is ours to shape with courage and resolve. Remember, the only man who never makes mistakes is the man who never does anything.
+
+## Queen Victoria
+
+It is my steadfast wish that we move forward with dignity and compassion. May our empire continue to flourish through unity and understanding.
+
+## Winston Churchill
+
+We shall go forward together with resolute hearts. Let us face our challenges with the firmness and courage that have always defined our people.

--- a/app/[lang]/(dashboard)/dashboard/clone/new.client.tsx
+++ b/app/[lang]/(dashboard)/dashboard/clone/new.client.tsx
@@ -142,11 +142,10 @@ export default function NewVoiceClient({
         err.message === 'signal is aborted without reason'
       ) {
         return;
-      } else {
-        setErrorMessage(
-          err instanceof Error ? err.message : 'Unexpected error occurred',
-        );
       }
+      setErrorMessage(
+        err instanceof Error ? err.message : 'Unexpected error occurred',
+      );
       setStatus('error');
     }
   }, [dict, file, textToConvert, clearErrors]);

--- a/app/[lang]/page.tsx
+++ b/app/[lang]/page.tsx
@@ -69,6 +69,27 @@ I mean, imagine a dog just trying to plop down in perfect 90-degree angles. <sni
       'Bienvenido a SexyVoice.ai <resoplido> , tu puerta de entrada a la vanguardia de la innovación y el mundo de la tecnología. Soy tu anfitrión, Javi, y cada semana exploramos las últimas tendencias, avances y las personas que están dando forma al futuro de la tecnología.',
     audioSrc: 'javi_anfitrion.mp3',
   },
+  {
+    id: 7,
+    name: 'Theodore Roosevelt',
+    prompt:
+      'Fellow citizens, we stand at the dawn of a new century, and it is ours to shape with courage and resolve. Remember, the only man who never makes mistakes is the man who never does anything.',
+    audioSrc: 'roosevelt_demo.mp3',
+  },
+  {
+    id: 8,
+    name: 'Queen Victoria',
+    prompt:
+      'It is my steadfast wish that we move forward with dignity and compassion. May our empire continue to flourish through unity and understanding.',
+    audioSrc: 'victoria_demo.mp3',
+  },
+  {
+    id: 9,
+    name: 'Winston Churchill',
+    prompt:
+      'We shall go forward together with resolute hearts. Let us face our challenges with the firmness and courage that have always defined our people.',
+    audioSrc: 'churchill_demo.mp3',
+  },
 ];
 
 const getAllPostsByLang = (lang: Locale) => {


### PR DESCRIPTION
## Summary
- provide short voiceover scripts for Roosevelt, Victoria, and Churchill
- showcase new demos on the landing page
- ignore TypeScript build artifacts
- minor formatting fix from Biome

## Testing
- `pnpm run lint:fix`
- `pnpm run format`
- `pnpm run build:content`
- `pnpm run type-check`
- `pnpm run check-translations`


------
https://chatgpt.com/codex/tasks/task_e_685d9402bbec832cbf46712070c8fec2