### PR TITLE
Add audio retention notice and cleanup script docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ SexyVoice.ai is a cutting-edge AI voice generation platform that empowers users 
 | `pnpm check-translations` | Validate translation files |
 | `pnpm build:content` | Build content layer |
 | `pnpm clean` | Clean unused dependencies with Knip |
+| `pnpm clean-old-audio` | Delete generated audio older than a specified number of days |
 
 ### Testing
 

--- a/app/[lang]/(auth)/protected/update-password/page.tsx
+++ b/app/[lang]/(auth)/protected/update-password/page.tsx
@@ -12,7 +12,7 @@ export default async function UpdatePasswordPage(props: {
   const searchParams = await props.searchParams;
 
   const { lang } = params;
-  const dict = await getDictionary(lang);
+  const dict = await getDictionary(lang, 'auth');
 
   return (
     <>
@@ -21,13 +21,13 @@ export default async function UpdatePasswordPage(props: {
         <div className="w-full max-w-md">
           <div className="rounded-2xl p-8 bg-background shadow-xl">
             <h1 className="mb-2 text-center text-3xl font-bold">
-              {dict.auth.updatePassword.title}
+              {dict.updatePassword.title}
             </h1>
             <p className="text-sm text-muted-foreground mb-8">
-              {dict.auth.updatePassword.subtitle}
+              {dict.updatePassword.subtitle}
             </p>
             <UpdatePasswordForm
-              dict={dict.auth.updatePassword}
+              dict={dict.updatePassword}
               lang={lang}
               message={searchParams}
             />

--- a/app/[lang]/(auth)/protected/update-password/update-password-form.tsx
+++ b/app/[lang]/(auth)/protected/update-password/update-password-form.tsx
@@ -2,6 +2,7 @@
 
 import { useFormStatus } from 'react-dom';
 
+import type dictLang from '@/lib/i18n/dictionaries/en.json';
 import { updatePasswordAction } from '@/app/actions';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -13,8 +14,7 @@ export function UpdatePasswordForm({
   lang,
   message,
 }: {
-  // biome-ignore lint/suspicious/noExplicitAny: dictionary can contain various keys
-  dict: any;
+  dict: (typeof dictLang)['auth']['updatePassword'];
   lang: string;
   message: Message;
 }) {

--- a/app/[lang]/(auth)/protected/update-password/update-password-form.tsx
+++ b/app/[lang]/(auth)/protected/update-password/update-password-form.tsx
@@ -13,7 +13,7 @@ export function UpdatePasswordForm({
   lang,
   message,
 }: {
-  // biome-ignore lint/suspicious/noExplicitAny: <explanation>
+  // biome-ignore lint/suspicious/noExplicitAny: dictionary can contain various keys
   dict: any;
   lang: string;
   message: Message;

--- a/app/[lang]/(auth)/reset-password/page.tsx
+++ b/app/[lang]/(auth)/reset-password/page.tsx
@@ -11,7 +11,7 @@ export default async function ResetPasswordPage(props: {
   const searchParams = await props.searchParams;
 
   const { lang } = params;
-  const dict = await getDictionary(lang);
+  const dict = await getDictionary(lang, 'auth');
 
   return (
     <>
@@ -20,13 +20,13 @@ export default async function ResetPasswordPage(props: {
         <div className="w-full max-w-md">
           <div className="rounded-2xl p-8 bg-background shadow-xl">
             <h1 className="mb-2 text-center text-3xl font-bold">
-              {dict.auth.resetPassword.title}
+              {dict.resetPassword.title}
             </h1>
             <p className="text-sm text-muted-foreground mb-8">
-              {dict.auth.resetPassword.subtitle}
+              {dict.resetPassword.subtitle}
             </p>
             <ResetPasswordForm
-              dict={dict.auth.resetPassword}
+              dict={dict.resetPassword}
               lang={lang}
               message={searchParams}
             />

--- a/app/[lang]/(auth)/reset-password/reset-password-form.tsx
+++ b/app/[lang]/(auth)/reset-password/reset-password-form.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link';
 import { useFormStatus } from 'react-dom';
 
+import type dictLang from '@/lib/i18n/dictionaries/en.json';
 import { forgotPasswordAction } from '@/app/actions';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -18,8 +19,7 @@ export function ResetPasswordForm({
   lang,
   message,
 }: {
-  // biome-ignore lint/suspicious/noExplicitAny: dictionary can contain various keys
-  dict: any;
+  dict: (typeof dictLang)['auth']['resetPassword'];
   lang: string;
   message: Message;
 }) {

--- a/app/[lang]/(auth)/reset-password/reset-password-form.tsx
+++ b/app/[lang]/(auth)/reset-password/reset-password-form.tsx
@@ -18,7 +18,7 @@ export function ResetPasswordForm({
   lang,
   message,
 }: {
-  // biome-ignore lint/suspicious/noExplicitAny: <explanation>
+  // biome-ignore lint/suspicious/noExplicitAny: dictionary can contain various keys
   dict: any;
   lang: string;
   message: Message;

--- a/app/[lang]/(dashboard)/dashboard/clone/new.client.tsx
+++ b/app/[lang]/(dashboard)/dashboard/clone/new.client.tsx
@@ -142,11 +142,10 @@ export default function NewVoiceClient({
         err.message === 'signal is aborted without reason'
       ) {
         return;
-      } else {
-        setErrorMessage(
-          err instanceof Error ? err.message : 'Unexpected error occurred',
-        );
       }
+      setErrorMessage(
+        err instanceof Error ? err.message : 'Unexpected error occurred',
+      );
       setStatus('error');
     }
   }, [dict, file, textToConvert, clearErrors]);

--- a/app/[lang]/(dashboard)/dashboard/credits/credit-topup.tsx
+++ b/app/[lang]/(dashboard)/dashboard/credits/credit-topup.tsx
@@ -15,7 +15,7 @@ import { Loader2, Zap } from 'lucide-react';
 import { createCheckoutSession } from '@/app/actions/stripe';
 import type lang from '@/lib/i18n/dictionaries/en.json';
 
-const getTopupPackages = (dict: any) => [
+const getTopupPackages = (dict: (typeof lang)['credits']) => [
   {
     id: 'standard',
     name: dict.topup.packages.standard.name,

--- a/app/[lang]/(dashboard)/dashboard/credits/topup-status.tsx
+++ b/app/[lang]/(dashboard)/dashboard/credits/topup-status.tsx
@@ -96,45 +96,41 @@ export function TopupStatus({ dict }: TopupStatusProps) {
       )}
 
       {status === 'canceled' && (
-        <Alert className="border-yellow-200 bg-yellow-50 text-yellow-800">
+        <Alert className="border-yellow-200 bg-yellow-900">
           <XCircle className="h-4 w-4 text-yellow-600" />
-          <AlertTitle className="text-yellow-800">
+          <AlertTitle className="text-yellow-500">
             {dict.status.canceled.title}
           </AlertTitle>
-          <AlertDescription className="text-yellow-700">
-            {dict.status.canceled.description}
-            <div className="mt-2">
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={handleDismiss}
-                className="border-yellow-300 text-yellow-700 hover:bg-yellow-100"
-              >
-                {dict.status.canceled.dismiss}
-              </Button>
-            </div>
+          <AlertDescription className="text-yellow-400">
+            <p>{dict.status.canceled.description}</p>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleDismiss}
+              className="border-yellow-300 text-yellow-700 hover:bg-yellow-600 mt-2"
+            >
+              {dict.status.canceled.dismiss}
+            </Button>
           </AlertDescription>
         </Alert>
       )}
 
       {status === 'error' && (
-        <Alert className="border-red-200 bg-red-50 text-red-800">
-          <XCircle className="h-4 w-4 text-red-600" />
-          <AlertTitle className="text-red-800">
+        <Alert className="border-red-200 bg-red-950 text-red-800">
+          <XCircle className="h-4 w-4" />
+          <AlertTitle className="text-red-500">
             {dict.status.error.title}
           </AlertTitle>
-          <AlertDescription className="text-red-700">
-            {dict.status.error.description}
-            <div className="mt-2">
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={handleDismiss}
-                className="border-red-300 text-red-700 hover:bg-red-100"
-              >
-                {dict.status.error.dismiss}
-              </Button>
-            </div>
+          <AlertDescription className="text-red-400">
+            <p>{dict.status.error.description}</p>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleDismiss}
+              className="border-red-300 text-red-700 hover:bg-red-900 mt-2"
+            >
+              {dict.status.error.dismiss}
+            </Button>
           </AlertDescription>
         </Alert>
       )}

--- a/app/[lang]/(dashboard)/dashboard/history/page.tsx
+++ b/app/[lang]/(dashboard)/dashboard/history/page.tsx
@@ -8,9 +8,17 @@ import { getMyAudioFiles } from '@/lib/supabase/queries.client';
 import { createClient } from '@/lib/supabase/server';
 import { columns } from './columns';
 import { DataTable } from './data-table';
+import { getDictionary } from '@/lib/i18n/get-dictionary';
+import type { Locale } from '@/lib/i18n/i18n-config';
+import { Alert, AlertDescription } from '@/components/ui/alert';
 
-export default async function HistoryPage() {
+export default async function HistoryPage(props: {
+  params: Promise<{ lang: Locale }>;
+}) {
   const queryClient = new QueryClient();
+
+  const { lang } = await props.params;
+  const dict = await getDictionary(lang, 'historyPage');
 
   const supabase = await createClient();
 
@@ -24,6 +32,9 @@ export default async function HistoryPage() {
   return (
     <div className="container mx-auto pb-10">
       <h2 className="text-2xl font-bold mb-4">Generation History</h2>
+      <Alert className="mb-4">
+        <AlertDescription>{dict.retentionInfo}</AlertDescription>
+      </Alert>
       <HydrationBoundary state={dehydrate(queryClient)}>
         <DataTable columns={columns} userId={user.id} />
       </HydrationBoundary>

--- a/app/[lang]/(dashboard)/dashboard/history/page.tsx
+++ b/app/[lang]/(dashboard)/dashboard/history/page.tsx
@@ -11,6 +11,7 @@ import { DataTable } from './data-table';
 import { getDictionary } from '@/lib/i18n/get-dictionary';
 import type { Locale } from '@/lib/i18n/i18n-config';
 import { Alert, AlertDescription } from '@/components/ui/alert';
+import { AlertCircle } from 'lucide-react';
 
 export default async function HistoryPage(props: {
   params: Promise<{ lang: Locale }>;
@@ -33,6 +34,7 @@ export default async function HistoryPage(props: {
     <div className="container mx-auto pb-10">
       <h2 className="text-2xl font-bold mb-4">Generation History</h2>
       <Alert className="mb-4">
+        <AlertCircle className="h-4 w-4 -mt-1" />
         <AlertDescription>{dict.retentionInfo}</AlertDescription>
       </Alert>
       <HydrationBoundary state={dehydrate(queryClient)}>

--- a/app/[lang]/(dashboard)/dashboard/profile/security-form.tsx
+++ b/app/[lang]/(dashboard)/dashboard/profile/security-form.tsx
@@ -12,7 +12,7 @@ import { createClient } from '@/lib/supabase/client';
 
 export function SecurityForm({
   email,
-  lang,
+  lang: _lang,
 }: {
   email?: string;
   lang: string;
@@ -21,7 +21,7 @@ export function SecurityForm({
   const [currentPassword, setCurrentPassword] = useState('');
   const [newPassword, setNewPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
-  const router = useRouter();
+  const _router = useRouter();
   const supabase = createClient();
 
   const handlePasswordUpdate = async (e: React.FormEvent) => {

--- a/app/[lang]/(dashboard)/layout.tsx
+++ b/app/[lang]/(dashboard)/layout.tsx
@@ -61,7 +61,7 @@ export default function DashboardLayout(props: {
   };
   const posthog = usePostHog();
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
+  // biome-ignore lint/correctness/useExhaustiveDependencies: effect should run once on mount
   useEffect(() => {
     const getData = async () => {
       const { data } = await supabase.auth.getUser();

--- a/app/[lang]/blog/[slug]/page.tsx
+++ b/app/[lang]/blog/[slug]/page.tsx
@@ -208,7 +208,7 @@ const PostLayout = async (props: {
         <meta itemProp="learningResourceType" content="Tutorial" />
       </div>
 
-      <main role="main" itemScope itemType="https://schema.org/WebPage">
+      <main itemScope itemType="https://schema.org/WebPage">
         <article
           className="py-8 px-4 md:px-0 md:mx-auto max-w-2xl prose dark:prose-invert"
           itemScope

--- a/app/[lang]/page.tsx
+++ b/app/[lang]/page.tsx
@@ -7,7 +7,7 @@ import type { ReactNode } from 'react';
 import { Suspense } from 'react';
 import type { Metadata } from 'next';
 import Script from 'next/script';
-import { FAQPage, WithContext } from 'schema-dts';
+import type { FAQPage, WithContext } from 'schema-dts';
 
 import { getDictionary } from '@/lib/i18n/get-dictionary';
 import { i18n, type Locale } from '@/lib/i18n/i18n-config';

--- a/app/api/generate-voice/route.ts
+++ b/app/api/generate-voice/route.ts
@@ -1,7 +1,7 @@
 import { GoogleGenAI } from '@google/genai';
 import * as Sentry from '@sentry/nextjs';
 import { Redis } from '@upstash/redis';
-import { put } from '@vercel/blob';
+import { put, type PutBlobResult } from '@vercel/blob';
 import { after, NextResponse } from 'next/server';
 import Replicate, { type Prediction } from 'replicate';
 
@@ -166,7 +166,7 @@ export async function POST(request: Request) {
 
     let predictionResult: Prediction | undefined;
     let modelUsed = voiceObj.model;
-    let blobResult: any;
+    let blobResult: PutBlobResult | undefined;
 
     if (GEMINI_VOICES.includes(voice.toLowerCase())) {
       const ai = new GoogleGenAI({

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -642,10 +642,9 @@ export default function TermsAndCondition() {
 
         <h2>Audio File Retention</h2>
         <p>
-          Generated audio files are stored for 30 days. After this period the
-          audio files and all associated information are permanently removed
-          from our systems, including Vercel Blob Storage, Redis cache, and our
-          Supabase database.
+          For free accounts, generated audio files are stored for 30 days. After
+          this period the audio files and all associated information are
+          permanently removed from our systems.
         </p>
 
         <h2>Contact Us</h2>

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -640,6 +640,14 @@ export default function TermsAndCondition() {
           uncorrupted, timely, or error-free.
         </p>
 
+        <h2>Audio File Retention</h2>
+        <p>
+          Generated audio files are stored for 30 days. After this period the
+          audio files and all associated information are permanently removed
+          from our systems, including Vercel Blob Storage, Redis cache, and our
+          Supabase database.
+        </p>
+
         <h2>Contact Us</h2>
         <p>Don't hesitate to contact us if you have any questions.</p>
         <ul>

--- a/components/audio-generator.tsx
+++ b/components/audio-generator.tsx
@@ -124,7 +124,7 @@ export function AudioGenerator({
   };
 
   // Keyboard shortcut handler
-  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
+  // biome-ignore lint/correctness/useExhaustiveDependencies: dependencies are static
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
       // Check for CMD+Enter on Mac or Ctrl+Enter on other platforms

--- a/components/language-selector.tsx
+++ b/components/language-selector.tsx
@@ -20,7 +20,7 @@ export function LanguageSelector({
   currentLang: string;
   isMobile: boolean;
 }) {
-  const currentLanguage =
+  const _currentLanguage =
     languages.find((lang) => lang.code === currentLang)?.label || 'Language';
 
   return (

--- a/components/popular-audios.tsx
+++ b/components/popular-audios.tsx
@@ -48,7 +48,7 @@ export function PopularAudios({ dict }: PopularAudiosProps) {
         }
         const data = await response.json();
         setAudioFiles(data);
-      } catch (error) {
+      } catch (_error) {
       } finally {
         setIsLoading(false);
       }

--- a/components/popular-audios.tsx
+++ b/components/popular-audios.tsx
@@ -2,6 +2,7 @@
 
 import { Download, Pause, Play } from 'lucide-react';
 import { useEffect, useState } from 'react';
+
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 
@@ -48,7 +49,6 @@ export function PopularAudios({ dict }: PopularAudiosProps) {
         }
         const data = await response.json();
         setAudioFiles(data);
-      } catch (_error) {
       } finally {
         setIsLoading(false);
       }

--- a/components/ui/sidebar.tsx
+++ b/components/ui/sidebar.tsx
@@ -89,6 +89,7 @@ const SidebarProvider = React.forwardRef<
         }
 
         // This sets the cookie to keep the sidebar state.
+        // biome-ignore lint/suspicious/noDocumentCookie: persistent sidebar preference
         document.cookie = `${SIDEBAR_COOKIE_NAME}=${openState}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}`;
       },
       [setOpenProp, open],

--- a/hooks/use-toast.ts
+++ b/hooks/use-toast.ts
@@ -171,7 +171,7 @@ function toast({ ...props }: Toast) {
 function useToast() {
   const [state, setState] = React.useState<State>(memoryState);
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
+  // biome-ignore lint/correctness/useExhaustiveDependencies: listener list persists across renders
   React.useEffect(() => {
     listeners.push(setState);
     return () => {

--- a/lib/i18n/dictionaries/en.json
+++ b/lib/i18n/dictionaries/en.json
@@ -249,5 +249,8 @@
     "resetForm": "Reset Form",
     "downloadAudio": "Download Audio",
     "abortedCloning": "Voice generation aborted."
+  },
+  "historyPage": {
+    "retentionInfo": "Generated audio files are deleted from all systems after 30 days."
   }
 }

--- a/lib/i18n/dictionaries/en.json
+++ b/lib/i18n/dictionaries/en.json
@@ -31,6 +31,7 @@
       "error": "Invalid email address",
       "success": "Check your email for a password reset link",
       "backToLogin": "Back to Login",
+      "loading": "Updating...",
       "errors": {
         "generic": "Could not reset password",
         "email_required": "Email is required"

--- a/lib/i18n/dictionaries/en.json
+++ b/lib/i18n/dictionaries/en.json
@@ -251,6 +251,6 @@
     "abortedCloning": "Voice generation aborted."
   },
   "historyPage": {
-    "retentionInfo": "Generated audio files are deleted from all systems after 30 days."
+    "retentionInfo": "For free accounts: Generated audio files are deleted from all systems after 30 days."
   }
 }

--- a/lib/i18n/dictionaries/es.json
+++ b/lib/i18n/dictionaries/es.json
@@ -31,6 +31,7 @@
       "error": "Correo electrónico inválido",
       "success": "Revisa tu correo electrónico para restablecer tu contraseña",
       "backToLogin": "Volver al inicio de sesión",
+      "loading": "Actualizando...",
       "errors": {
         "generic": "No se pudo restablecer la contraseña",
         "email_required": "Correo electrónico requerido"

--- a/lib/i18n/dictionaries/es.json
+++ b/lib/i18n/dictionaries/es.json
@@ -251,5 +251,8 @@
     "resetForm": "Reiniciar Formulario",
     "downloadAudio": "Descargar Audio",
     "abortedCloning": "Clonación de voz cancelada"
+  },
+  "historyPage": {
+    "retentionInfo": "Los archivos de audio generados se eliminan de todos los sistemas después de 30 días."
   }
 }

--- a/lib/i18n/dictionaries/es.json
+++ b/lib/i18n/dictionaries/es.json
@@ -253,6 +253,6 @@
     "abortedCloning": "Clonación de voz cancelada"
   },
   "historyPage": {
-    "retentionInfo": "Los archivos de audio generados se eliminan de todos los sistemas después de 30 días."
+    "retentionInfo": "Para cuentas gratis: Los archivos de audio generados se eliminan de todos los sistemas después de 30 días."
   }
 }

--- a/lib/icons.tsx
+++ b/lib/icons.tsx
@@ -10,6 +10,7 @@ export function LogosGoogleIcon(props: SVGProps<SVGSVGElement>) {
       viewBox="0 0 256 262"
       {...props}
     >
+      <title>Google logo</title>
       {/* Icon from SVG Logos by Gil Barbara - https://raw.githubusercontent.com/gilbarbara/logos/master/LICENSE.txt */}
       <path
         fill="#4285F4"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "format": "biome format ./app components hooks lib middleware.ts",
     "analyze": "ANALYZE=true next build",
     "clean": "knip",
-    "check-translations": "node scripts/check-translations.js"
+    "check-translations": "node scripts/check-translations.js",
+    "clean-old-audio": "node scripts/delete-old-audio.js"
   },
   "dependencies": {
     "@ai-sdk/google": "^1.2.19",

--- a/scripts/delete-old-audio.js
+++ b/scripts/delete-old-audio.js
@@ -1,0 +1,54 @@
+import { del } from '@vercel/blob';
+import { Redis } from '@upstash/redis';
+import { createClient } from '@supabase/supabase-js';
+import { config } from 'dotenv';
+
+config({ path: ['.env', '.env.local'] });
+
+const days = Number(process.argv[2]) || 30;
+const cutoff = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!supabaseUrl || !supabaseKey) {
+  throw new Error('Missing Supabase configuration');
+}
+
+const supabase = createClient(supabaseUrl, supabaseKey, {
+  auth: { autoRefreshToken: false, persistSession: false },
+});
+
+const redis = Redis.fromEnv();
+
+async function deleteOldFiles() {
+  console.log(`Deleting audio files older than ${days} days...`);
+
+  const { data: files, error } = await supabase
+    .from('audio_files')
+    .select('id, storage_key, created_at')
+    .lte('created_at', cutoff.toISOString());
+
+  if (error) {
+    console.error('Error fetching audio files:', error);
+    return;
+  }
+
+  for (const file of files) {
+    try {
+      await del(file.storage_key);
+      await redis.del(file.storage_key);
+      await supabase.from('audio_files').delete().eq('id', file.id);
+      console.log(`Deleted ${file.storage_key}`);
+    } catch (err) {
+      console.error(`Failed to delete ${file.storage_key}:`, err);
+    }
+  }
+
+  console.log('Deletion complete.');
+}
+
+deleteOldFiles().catch((err) => {
+  console.error('Error running deletion script:', err);
+  process.exit(1);
+});

--- a/scripts/sync-with-redis.js
+++ b/scripts/sync-with-redis.js
@@ -13,7 +13,7 @@ const redis = Redis.fromEnv();
  * Process all blobs with the prefix 'audio/' and store them in Redis
  */
 async function processAllBlobs() {
-  let cursor = undefined;
+  let cursor;
   let hasMore = true;
   let totalProcessed = 0;
 


### PR DESCRIPTION
## Summary
- document audio cleanup script
- clarify audio file retention in terms and history page
- add translation keys for retention policy
- address linter warnings and type issues

## Testing
- `pnpm run lint:fix`
- `pnpm run format:write`
- `pnpm run type-check`
- `pnpm run check-translations`


------
https://chatgpt.com/codex/tasks/task_e_6869772085c4832cadf6e031a6ad2926