### PR TITLE
feat: update Deno telegram bot to match daily stats cron job

### DIFF
--- a/supabase/functions/telegram-bot/index.ts
+++ b/supabase/functions/telegram-bot/index.ts
@@ -40,11 +40,27 @@ function formatChange(today: number, yesterday: number): string {
   return diff >= 0 ? `+${diff}` : `${diff}`;
 }
 
+function reduceAmountUsd(acc: number, row: { metadata: any }): number {
+  if (!row.metadata || typeof row.metadata !== 'object') {
+    return acc;
+  }
+  const { dollarAmount } = row.metadata as {
+    priceId: string;
+    dollarAmount: number;
+  };
+  if (typeof dollarAmount === 'number') {
+    return acc + dollarAmount;
+  }
+  return acc;
+}
+
 async function generateLast24HoursStats(): Promise<string> {
   const now = new Date();
-  const previousDay = subtractDays(now, 1);
-  const twoDaysAgo = subtractDays(now, 2);
-  const sevenDaysAgo = subtractDays(now, 7);
+  const today = startOfDay(now);
+  const previousDay = subtractDays(today, 1);
+  const twoDaysAgo = subtractDays(today, 2);
+  const sevenDaysAgo = subtractDays(today, 7);
+  const thirtyDaysAgo = subtractDays(today, 30);
 
   try {
     // Audio files stats
@@ -52,7 +68,7 @@ async function generateLast24HoursStats(): Promise<string> {
       .from('audio_files')
       .select('id', { count: 'exact', head: true })
       .gte('created_at', previousDay.toISOString())
-      .lt('created_at', now.toISOString());
+      .lt('created_at', today.toISOString());
 
     const audioPrev = await supabase
       .from('audio_files')
@@ -64,21 +80,33 @@ async function generateLast24HoursStats(): Promise<string> {
       .from('audio_files')
       .select('id', { count: 'exact', head: true })
       .gte('created_at', sevenDaysAgo.toISOString())
-      .lt('created_at', now.toISOString());
+      .lt('created_at', today.toISOString());
+
+    const audioTotal = await supabase
+      .from('audio_files')
+      .select('id', { count: 'exact', head: true })
+      .lt('created_at', today.toISOString());
 
     const clonePrevDay = await supabase
       .from('audio_files')
       .select('id', { count: 'exact', head: true })
       .eq('model', 'chatterbox-tts')
       .gte('created_at', previousDay.toISOString())
-      .lt('created_at', now.toISOString());
+      .lt('created_at', today.toISOString());
+
+    const cloneWeek = await supabase
+      .from('audio_files')
+      .select('id', { count: 'exact', head: true })
+      .eq('model', 'chatterbox-tts')
+      .gte('created_at', sevenDaysAgo.toISOString())
+      .lt('created_at', today.toISOString());
 
     // Profiles stats
     const profilesPrevDay = await supabase
       .from('profiles')
       .select('id', { count: 'exact', head: true })
       .gte('created_at', previousDay.toISOString())
-      .lt('created_at', now.toISOString());
+      .lt('created_at', today.toISOString());
 
     const profilesPrev = await supabase
       .from('profiles')
@@ -90,7 +118,12 @@ async function generateLast24HoursStats(): Promise<string> {
       .from('profiles')
       .select('id', { count: 'exact', head: true })
       .gte('created_at', sevenDaysAgo.toISOString())
-      .lt('created_at', now.toISOString());
+      .lt('created_at', today.toISOString());
+
+    const profilesTotal = await supabase
+      .from('profiles')
+      .select('id', { count: 'exact', head: true })
+      .lt('created_at', today.toISOString());
 
     // Credit transactions stats
     const creditsPrevDay = await supabase
@@ -98,7 +131,7 @@ async function generateLast24HoursStats(): Promise<string> {
       .select('id', { count: 'exact', head: true })
       .in('type', ['purchase', 'topup'])
       .gte('created_at', previousDay.toISOString())
-      .lt('created_at', now.toISOString());
+      .lt('created_at', today.toISOString());
 
     const creditsPrev = await supabase
       .from('credit_transactions')
@@ -112,36 +145,99 @@ async function generateLast24HoursStats(): Promise<string> {
       .select('id', { count: 'exact', head: true })
       .in('type', ['purchase', 'topup'])
       .gte('created_at', sevenDaysAgo.toISOString())
-      .lt('created_at', now.toISOString());
+      .lt('created_at', today.toISOString());
+
+    const creditsMonth = await supabase
+      .from('credit_transactions')
+      .select('id', { count: 'exact', head: true })
+      .in('type', ['purchase', 'topup'])
+      .gte('created_at', thirtyDaysAgo.toISOString())
+      .lt('created_at', today.toISOString());
+
+    const creditsTotal = await supabase
+      .from('credit_transactions')
+      .select('id', { count: 'exact', head: true })
+      .in('type', ['purchase', 'topup'])
+      .lt('created_at', today.toISOString());
+
+    // Paid users stats
+    const { data: paidUsersData } = await supabase
+      .from('credit_transactions')
+      .select('user_id')
+      .in('type', ['purchase', 'topup'])
+      .lt('created_at', today.toISOString());
+
+    const totalUniquePaidUsers = paidUsersData
+      ? new Set(paidUsersData.map((t) => t.user_id)).size
+      : 0;
+
+    // USD revenue stats
+    const { data: totalAmountUsdData } = await supabase
+      .from('credit_transactions')
+      .select('metadata')
+      .in('type', ['purchase', 'topup'])
+      .lt('created_at', today.toISOString());
+
+    const totalAmountUsd = totalAmountUsdData?.reduce(reduceAmountUsd, 0) ?? 0;
+
+    const { data: totalAmountUsdWeekData } = await supabase
+      .from('credit_transactions')
+      .select('metadata')
+      .in('type', ['purchase', 'topup'])
+      .gte('created_at', sevenDaysAgo.toISOString())
+      .lt('created_at', today.toISOString());
+
+    const totalAmountUsdWeek =
+      totalAmountUsdWeekData?.reduce(reduceAmountUsd, 0) ?? 0;
+
+    const { data: totalAmountUsdMonthData } = await supabase
+      .from('credit_transactions')
+      .select('metadata')
+      .in('type', ['purchase', 'topup'])
+      .gte('created_at', thirtyDaysAgo.toISOString())
+      .lt('created_at', today.toISOString());
+
+    const totalAmountUsdMonth =
+      totalAmountUsdMonthData?.reduce(reduceAmountUsd, 0) ?? 0;
 
     // Calculate counts
     const audioYesterdayCount = audioYesterday.count ?? 0;
     const audioPrevCount = audioPrev.count ?? 0;
     const audioWeekCount = audioWeek.count ?? 0;
-    const cloneCount = clonePrevDay.count ?? 0;
+    const audioTotalCount = audioTotal.count ?? 0;
+    const clonePrevCount = clonePrevDay.count ?? 0;
+    const cloneWeekCount = cloneWeek.count ?? 0;
 
     const profilesTodayCount = profilesPrevDay.count ?? 0;
     const profilesPrevCount = profilesPrev.count ?? 0;
     const profilesWeekCount = profilesWeek.count ?? 0;
+    const profilesTotalCount = profilesTotal.count ?? 0;
 
     const creditsTodayCount = creditsPrevDay.count ?? 0;
     const creditsPrevCount = creditsPrev.count ?? 0;
     const creditsWeekCount = creditsWeek.count ?? 0;
+    const creditsMonthCount = creditsMonth.count ?? 0;
+    const creditsTotalCount = creditsTotal.count ?? 0;
 
     // Format message
     const message = [
-      // e.g. 20/7/25, 16:09:01
-      `📊 24h stats from ${new Intl.DateTimeFormat('es-ES', { dateStyle: 'short', timeStyle: 'long' }).format(previousDay).slice(0, 17)}`,
-      '',
-      `🎵 Audio files: ${audioYesterdayCount} (${formatChange(audioYesterdayCount, audioPrevCount)})`,
-      `  • 7d total: ${audioWeekCount}, avg: ${(audioWeekCount / 7).toFixed(1)}`,
-      `  • Clone voices: ${cloneCount}`,
-      '',
-      `👥 Profiles: ${profilesTodayCount} (${formatChange(profilesTodayCount, profilesPrevCount)})`,
-      `  • 7d total: ${profilesWeekCount}, avg: ${(profilesWeekCount / 7).toFixed(1)}`,
-      '',
-      `💰 Credit Transactions: ${creditsTodayCount} (${formatChange(creditsTodayCount, creditsPrevCount)}) ${creditsTodayCount > 0 ? '🤑' : '😿'}`,
-      `  • 7d total: ${creditsWeekCount}, avg: ${(creditsWeekCount / 7).toFixed(1)}`,
+      `📊 Daily stats for ${previousDay.toISOString().slice(0, 10)}`,
+      `🎵 Audio files: ${audioYesterdayCount} (${formatChange(audioYesterdayCount, audioPrevCount)} from yesterday)`,
+      `  • Cloned voices: ${clonePrevCount}`,
+      `  • 7d cloned: ${cloneWeekCount}, avg ${(cloneWeekCount / 7).toFixed(1)}`,
+      `  • 7d total: ${audioWeekCount}, avg ${(audioWeekCount / 7).toFixed(1)}`,
+      `  • Total: ${audioTotalCount}`,
+      `👥 Profiles: ${profilesTodayCount} (${formatChange(profilesTodayCount, profilesPrevCount)} from yesterday)`,
+      `  • 7d total: ${profilesWeekCount}, avg ${(profilesWeekCount / 7).toFixed(1)}`,
+      `  • Total: ${profilesTotalCount}`,
+      `💰 Credit Transactions: ${creditsTodayCount} (${formatChange(creditsTodayCount, creditsPrevCount)} from yesterday) ${creditsTodayCount > 0 ? '🤑' : '😿'}`,
+      `  • 7d total: ${creditsWeekCount}, avg ${(creditsWeekCount / 7).toFixed(1)}`,
+      `  • 30d total: ${creditsMonthCount}, avg ${(creditsMonthCount / 30).toFixed(1)}`,
+      `  • Total: ${creditsTotalCount}`,
+      `  • Total unique paid users: ${totalUniquePaidUsers}`,
+      `💵 Total USD: $${totalAmountUsd.toFixed(2)}`,
+      `  • 7d total: $${totalAmountUsdWeek.toFixed(2)}, avg $${(totalAmountUsdWeek / 7).toFixed(2)}`,
+      `  • 30d total: $${totalAmountUsdMonth.toFixed(2)}, avg $${(totalAmountUsdMonth / 30).toFixed(2)}`,
     ];
 
     return message.join('\n');


### PR DESCRIPTION
Updates the Deno telegram bot function to return the same comprehensive stats as the daily stats cron job.

## Changes
- Add comprehensive stats including totals, 30-day data, and USD revenue
- Include total unique paid users count
- Improve date calculations using startOfDay function
- Add reduceAmountUsd helper for revenue calculations
- Match format and metrics from app/api/daily-stats/route.ts

Fixes #114

Generated with [Claude Code](https://claude.ai/code)