### PR TITLE
Fix sidebar mobile hide on footer links

### DIFF
--- a/app/[lang]/(dashboard)/dashboard.ui.tsx
+++ b/app/[lang]/(dashboard)/dashboard.ui.tsx
@@ -37,6 +37,7 @@ import {
   SidebarMenuItem,
   SidebarProvider,
   SidebarTrigger,
+  useSidebar,
 } from '@/components/ui/sidebar';
 import { createClient } from '@/lib/supabase/client';
 import type { Locale } from '@/lib/i18n/i18n-config';
@@ -56,6 +57,7 @@ export default function DashboardUI({
   const pathname = usePathname();
   const supabase = createClient();
   const router = useRouter();
+  const { isMobile, toggleSidebar } = useSidebar();
   const [credit_transactions, setCreditTransactions] = useState<
     CreditTransaction[] | null
   >([]);
@@ -221,7 +223,16 @@ export default function DashboardUI({
                       className="w-[--radix-popper-anchor-width]"
                     >
                       <DropdownMenuItem asChild>
-                        <Link href={`/${lang}/dashboard/profile`}>Profile</Link>
+                        <Link 
+                          href={`/${lang}/dashboard/profile`}
+                          onClick={() => {
+                            if (isMobile) {
+                              toggleSidebar();
+                            }
+                          }}
+                        >
+                          Profile
+                        </Link>
                       </DropdownMenuItem>
                       <DropdownMenuItem onClick={handleSignOut}>
                         <span>Sign out</span>

--- a/components/credits-section.tsx
+++ b/components/credits-section.tsx
@@ -4,6 +4,7 @@ import type langDict from '@/lib/i18n/dictionaries/en.json';
 import type { Locale } from '@/lib/i18n/i18n-config';
 import { Button } from './ui/button';
 import { ProgressCircle } from './ui/circular-progress';
+import { useSidebar } from './ui/sidebar';
 import { Skeleton } from './ui/skeleton';
 
 function CreditsSection({
@@ -17,6 +18,7 @@ function CreditsSection({
   credits: number;
   credit_transactions: CreditTransaction[];
 }) {
+  const { isMobile, toggleSidebar } = useSidebar();
   const total_credits =
     credit_transactions?.reduce(
       (acc, transaction) => acc + transaction.amount,
@@ -39,7 +41,16 @@ function CreditsSection({
           asChild
           className="pr-0 hover:no-underline bg-gradient-to-r from-blue-400 to-purple-500 bg-clip-text text-transparent"
         >
-          <Link href={`/${lang}/dashboard/credits`}>{dict.topupButton}</Link>
+          <Link 
+            href={`/${lang}/dashboard/credits`}
+            onClick={() => {
+              if (isMobile) {
+                toggleSidebar();
+              }
+            }}
+          >
+            {dict.topupButton}
+          </Link>
         </Button>
       </div>
       <div className="flex items-center gap-4">


### PR DESCRIPTION
Fixes #122

Adds toggleSidebar() functionality to sidebar footer links:
- Profile dropdown link in dashboard.ui.tsx
- Top-up link in CreditsSection component

Both links now properly hide the sidebar when clicked on mobile devices, improving the mobile user experience.

🤖 Generated with [Claude Code](https://claude.ai/code)