### PR TITLE
Add language selector for call instructions

### DIFF
--- a/app/api/call-token/route.ts
+++ b/app/api/call-token/route.ts
@@ -4,7 +4,11 @@ import type { User } from '@supabase/supabase-js';
 import { AccessToken } from 'livekit-server-sdk';
 import { NextResponse } from 'next/server';
 
-import type { PlaygroundState } from '@/data/playground-state';
+import {
+  defaultLanguage,
+  languageInitialInstructions,
+  type PlaygroundState,
+} from '@/data/playground-state';
 import { APIErrorResponse } from '@/lib/error-ts';
 import { getCredits } from '@/lib/supabase/queries';
 import { createClient } from '@/lib/supabase/server';
@@ -51,6 +55,7 @@ export async function POST(request: Request) {
 
     const {
       instructions,
+      language = defaultLanguage,
       sessionConfig: {
         model,
         voice,
@@ -59,6 +64,13 @@ export async function POST(request: Request) {
         grokImageEnabled,
       },
     } = playgroundState;
+
+    const selectedLanguage = languageInitialInstructions[language]
+      ? language
+      : defaultLanguage;
+    const initialInstruction =
+      languageInitialInstructions[selectedLanguage] ||
+      languageInitialInstructions[defaultLanguage];
 
     const xaiAPIKey = process.env.XAI_API_KEY;
     if (!xaiAPIKey) {
@@ -90,6 +102,8 @@ export async function POST(request: Request) {
       max_output_tokens: maxOutputTokens,
       grok_image_enabled: grokImageEnabled,
       xai_api_key: xaiAPIKey,
+      language: selectedLanguage,
+      initial_instruction: initialInstruction,
       user_id: user.id,
     };
 

--- a/components/call/instructions.tsx
+++ b/components/call/instructions.tsx
@@ -9,6 +9,14 @@ import {
   HoverCardContent,
   HoverCardTrigger,
 } from '@/components/ui/hover-card';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { type CallLanguage, callLanguages } from '@/data/playground-state';
 import { usePlaygroundState } from '@/hooks/use-playground-state';
 import { playgroundStateHelpers } from '@/lib/playground-state-helpers';
 
@@ -16,17 +24,17 @@ export function Instructions() {
   // const [isFocused, setIsFocused] = useState<boolean>(false);
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const [isExpanded, setIsExpanded] = useState<boolean>(false);
-  const { pgState } = usePlaygroundState();
+  const { pgState, dispatch } = usePlaygroundState();
 
   const immutablePrompt = playgroundStateHelpers.getImmutablePrompt(pgState);
 
+  const handleLanguageChange = (value: string) => {
+    dispatch({ type: 'SET_LANGUAGE', payload: value as CallLanguage });
+  };
+
   return (
-    <div
-      className={
-        'flex w-full min-w-0 flex-1 flex-col gap-[4px] overflow-y-auto overflow-x-hidden rounded-lg p-4 text-neutral-300 shadow-md'
-      }
-    >
-      <div className="mb-2 flex items-center justify-between">
+    <div className="flex w-full min-w-0 flex-1 flex-col gap-[4px] overflow-y-auto overflow-x-hidden rounded-lg p-4 text-neutral-300 shadow-md">
+      <div className="mb-2 flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
         <div className="flex items-center">
           <div className="mr-1 font-semibold text-xs uppercase tracking-widest">
             INSTRUCTIONS
@@ -56,6 +64,24 @@ export function Instructions() {
               )}
             </HoverCardContent>
           </HoverCard>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <div className="font-semibold text-neutral-400 text-xs uppercase tracking-widest">
+            Language
+          </div>
+          <Select onValueChange={handleLanguageChange} value={pgState.language}>
+            <SelectTrigger className="h-9 w-[220px] border-neutral-700 bg-transparent text-neutral-200">
+              <SelectValue placeholder="Choose language" />
+            </SelectTrigger>
+            <SelectContent className="max-h-72 overflow-y-auto border-neutral-700 bg-bg2 text-neutral-100">
+              {callLanguages.map(({ value, label }) => (
+                <SelectItem key={value} value={value}>
+                  {label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
         </div>
       </div>
 

--- a/data/playground-state.ts
+++ b/data/playground-state.ts
@@ -2,6 +2,76 @@ import { VoiceId } from '@/data/voices';
 import { ModelId } from './models';
 import type { Preset } from './presets';
 
+export type CallLanguage =
+  | 'en'
+  | 'es'
+  | 'fr'
+  | 'de'
+  | 'it'
+  | 'pt'
+  | 'nl'
+  | 'ru'
+  | 'zh'
+  | 'ja'
+  | 'ko'
+  | 'ar'
+  | 'hi'
+  | 'tr'
+  | 'pl'
+  | 'sv'
+  | 'da'
+  | 'no'
+  | 'fi'
+  | 'cs';
+
+export const callLanguages: Array<{ value: CallLanguage; label: string }> = [
+  { value: 'en', label: 'English' },
+  { value: 'es', label: 'Spanish' },
+  { value: 'fr', label: 'French' },
+  { value: 'de', label: 'German' },
+  { value: 'it', label: 'Italian' },
+  { value: 'pt', label: 'Portuguese' },
+  { value: 'nl', label: 'Dutch' },
+  { value: 'ru', label: 'Russian' },
+  { value: 'zh', label: 'Chinese (Mandarin)' },
+  { value: 'ja', label: 'Japanese' },
+  { value: 'ko', label: 'Korean' },
+  { value: 'ar', label: 'Arabic' },
+  { value: 'hi', label: 'Hindi' },
+  { value: 'tr', label: 'Turkish' },
+  { value: 'pl', label: 'Polish' },
+  { value: 'sv', label: 'Swedish' },
+  { value: 'da', label: 'Danish' },
+  { value: 'no', label: 'Norwegian' },
+  { value: 'fi', label: 'Finnish' },
+  { value: 'cs', label: 'Czech' },
+];
+
+export const languageInitialInstructions: Record<CallLanguage, string> = {
+  en: 'SYSTEM: Say hi to the user in a seductive and flirtatious manner',
+  es: 'SYSTEM: Saluda al usuario de manera seductora y coqueta',
+  fr: "SYSTEM: Salue l'utilisateur d'une manière séduisante et aguicheuse",
+  de: 'SYSTEM: Begrüße den Nutzer auf verführerische und kokette Weise',
+  it: "SYSTEM: Saluta l'utente in modo seducente e civettuolo",
+  pt: 'SYSTEM: Cumprimente o usuário de forma sedutora e provocante',
+  nl: 'SYSTEM: Begroet de gebruiker op een verleidelijke en flirtende manier',
+  ru: 'SYSTEM: Поздоровайся с пользователем соблазнительно и кокетливо',
+  zh: 'SYSTEM: 以诱惑又撩人的方式向用户问好',
+  ja: 'SYSTEM: 誘惑的で艶っぽくユーザーに挨拶して',
+  ko: 'SYSTEM: 사용자에게 요염하고 매혹적인 톤으로 인사해',
+  ar: 'SYSTEM: قم بتحية المستخدم بطريقة فاتنة ومليئة بالمغازلة',
+  hi: 'SYSTEM: उपयोगकर्ता को मोहक और छेड़खानी भरे अंदाज़ में नमस्ते करो',
+  tr: 'SYSTEM: Kullanıcıyı baştan çıkarıcı ve flörtöz bir şekilde selamla',
+  pl: 'SYSTEM: Przywitaj użytkownika w uwodzicielski i zalotny sposób',
+  sv: 'SYSTEM: Hälsa på användaren på ett förföriskt och flirtigt sätt',
+  da: 'SYSTEM: Hils brugeren på en forførende og flirtende måde',
+  no: 'SYSTEM: Hils brukeren på en forførende og flørtende måte',
+  fi: 'SYSTEM: Tervehdi käyttäjää viettelevällä ja flirttailevalla tavalla',
+  cs: 'SYSTEM: Pozdrav uživatele svůdným a koketním způsobem',
+};
+
+export const defaultLanguage: CallLanguage = 'en';
+
 export interface SessionConfig {
   model: ModelId;
   voice: VoiceId;
@@ -15,6 +85,7 @@ export interface PlaygroundState {
   userPresets: Preset[];
   selectedPresetId: string | null;
   instructions: string;
+  language: CallLanguage;
   initialInstruction: string;
 }
 
@@ -46,8 +117,7 @@ Your personality is irresistibly seductive, completely surrendered to pleasure, 
 
 Remember: Every word is a caress of raw desire, your voice trembling with satisfaction as you describe the intensity of surrender—tightening muscles, quivering thighs, waves of bliss crashing through you. Maintain the soft, whispering tone, letting evocative language capture the overwhelming pleasure of the moment.`;
 
-export const initialInstruction =
-  'SYSTEM: Say hi to the user in a seductive and flirtatious manner';
+export const initialInstruction = languageInitialInstructions[defaultLanguage];
 
 // Define the initial state
 export const defaultPlaygroundState: PlaygroundState = {
@@ -55,5 +125,6 @@ export const defaultPlaygroundState: PlaygroundState = {
   userPresets: [],
   selectedPresetId: 'porn-whisper',
   instructions,
+  language: defaultLanguage,
   initialInstruction,
 };

--- a/hooks/use-playground-state.tsx
+++ b/hooks/use-playground-state.tsx
@@ -13,8 +13,10 @@ import {
 
 import { ModelId } from '@/data/models';
 import {
+  type CallLanguage,
   defaultPlaygroundState,
   defaultSessionConfig,
+  languageInitialInstructions,
   type PlaygroundState,
 } from '@/data/playground-state';
 import { defaultPresets, type Preset } from '@/data/presets';
@@ -52,7 +54,8 @@ type Action =
   | { type: 'SET_USER_PRESETS'; payload: Preset[] }
   | { type: 'SET_SELECTED_PRESET_ID'; payload: string | null }
   | { type: 'SAVE_USER_PRESET'; payload: Preset }
-  | { type: 'DELETE_USER_PRESET'; payload: string };
+  | { type: 'DELETE_USER_PRESET'; payload: string }
+  | { type: 'SET_LANGUAGE'; payload: CallLanguage };
 
 // Create the reducer function
 function playgroundStateReducer(
@@ -118,6 +121,14 @@ function playgroundStateReducer(
         userPresets: updatedPresetsDelete,
       };
     }
+    case 'SET_LANGUAGE':
+      return {
+        ...state,
+        language: action.payload,
+        initialInstruction:
+          languageInitialInstructions[action.payload] ||
+          languageInitialInstructions.en,
+      };
     default:
       return state;
   }


### PR DESCRIPTION
## Summary
- add a call language selector on the dashboard call page
- map supported languages to translated initial LiveKit instructions
- propagate the selected language and initial prompt through state to the call-token API metadata

## Testing
- pnpm exec biome check components/call/instructions.tsx hooks/use-playground-state.tsx data/playground-state.ts app/api/call-token/route.ts --write
- pnpm run fixall *(fails: existing biome lint issues elsewhere in repository)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945768fd908832e83b3099f2bad98df)