### PR TITLE
Capture client token estimates for Gemini voice generation

### DIFF
--- a/app/api/generate-voice/route.ts
+++ b/app/api/generate-voice/route.ts
@@ -45,6 +45,7 @@ export async function POST(request: Request) {
   let text = '';
   let voice = '';
   let styleVariant = '';
+  let estimatedTokens: number | undefined;
   let user: User | null = null;
   try {
     if (request.body === null) {
@@ -58,6 +59,10 @@ export async function POST(request: Request) {
     text = body.text || '';
     voice = body.voice || '';
     styleVariant = body.styleVariant || '';
+    const estimatedTokensValue = Number(body.estimatedTokens);
+    estimatedTokens = Number.isFinite(estimatedTokensValue)
+      ? estimatedTokensValue
+      : undefined;
 
     if (!(text && voice)) {
       logger.error('Missing required parameters: text or voice', {
@@ -371,6 +376,14 @@ export async function POST(request: Request) {
         );
       }
 
+      const usageMetadata = {
+        ...(usage ?? {}),
+        ...(Number.isFinite(estimatedTokens ?? Number.NaN)
+          ? { clientEstimatedTokenCount: estimatedTokens }
+          : {}),
+        userHasPaid,
+      };
+
       await reduceCredits({ userId: user.id, amount: creditsUsed });
 
       const audioFileDBResult = await saveAudioFile({
@@ -384,10 +397,7 @@ export async function POST(request: Request) {
         voiceId: voiceObj.id,
         duration: '-1',
         credits_used: creditsUsed,
-        usage: {
-          ...usage,
-          userHasPaid,
-        },
+        usage: usageMetadata,
       });
 
       if (audioFileDBResult.error) {

--- a/components/audio-generator.tsx
+++ b/components/audio-generator.tsx
@@ -57,6 +57,7 @@ export function AudioGenerator({
   const [isEnhancingText, setIsEnhancingText] = useState(false);
   const [isEstimating, setIsEstimating] = useState(false);
   const [estimatedCredits, setEstimatedCredits] = useState<number | null>(null);
+  const [estimatedTokens, setEstimatedTokens] = useState<number | null>(null);
 
   const audio = useAudio();
   const isGeminiVoice = selectedVoice?.model === 'gpro';
@@ -91,6 +92,7 @@ export function AudioGenerator({
           text,
           voice: selectedVoice?.name,
           styleVariant,
+          estimatedTokens: isGeminiVoice ? estimatedTokens : undefined,
         }),
         signal: abortController.current.signal,
       });
@@ -230,6 +232,7 @@ export function AudioGenerator({
   // biome-ignore lint/correctness/useExhaustiveDependencies: needed
   useEffect(() => {
     setEstimatedCredits(null);
+    setEstimatedTokens(null);
   }, [selectedVoice, text]);
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: we need text
@@ -266,8 +269,12 @@ export function AudioGenerator({
       }
 
       const estimatedCredits = Number(data.estimatedCredits);
+      const estimatedTokens = Number(data.tokens);
       if (Number.isFinite(estimatedCredits)) {
         setEstimatedCredits(estimatedCredits);
+      }
+      if (Number.isFinite(estimatedTokens)) {
+        setEstimatedTokens(estimatedTokens);
       }
     } catch (error) {
       if (error instanceof APIError) {


### PR DESCRIPTION
## Summary
- capture and store client-estimated token counts for Gemini voice generations in API usage metadata
- send optional estimated tokens from the Generate page when invoking GPRO voice requests
- track token counts when estimating credits so they can be forwarded with the generation request

## Testing
- pnpm run fixall *(fails: biome command not found in PATH and repository has existing lint issues)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945d2ebe084832e9b8aa662319ebd0f)