### PR TITLE
daily-stats: Fix MTD calculation including previous month data

### DIFF
--- a/app/api/daily-stats/route.ts
+++ b/app/api/daily-stats/route.ts
@@ -59,13 +59,15 @@ export async function GET(request: NextRequest) {
   const twoDaysAgo = subtractDays(today, 2);
   const sevenDaysAgo = subtractDays(today, 7);
   const thirtyDaysAgo = subtractDays(today, 30);
-  const monthStart = startOfMonth(untilNow);
-  const previousMonthStart = startOfPreviousMonth(untilNow);
+  // Use previousDay for MTD calculations since we're reporting on that day's month
+  const monthStart = startOfMonth(previousDay);
+  const previousMonthStart = startOfPreviousMonth(previousDay);
 
   // Calculate previous month period end for comparison
+  // Cap at monthStart to avoid bleeding into the current month when prev month has fewer days
   const duration = today.getTime() - monthStart.getTime();
   const previousMonthPeriodEnd = new Date(
-    previousMonthStart.getTime() + duration,
+    Math.min(previousMonthStart.getTime() + duration, monthStart.getTime()),
   );
 
   // Fetch data in parallel - combine related queries and filter in memory


### PR DESCRIPTION
When running the daily stats cron on the 1st of a month, the MTD calculation was using the execution date (e.g., Jan 1st) instead of the reporting date (e.g., Dec 31st). This resulted in $0.00 MTD because monthStart and today were both Jan 1st.

Also caps previousMonthPeriodEnd at monthStart to prevent including days from the current month when the previous month has fewer days.