### PR TITLE
Add Edge Config integration for call instructions

### DIFF
--- a/app/[lang]/(dashboard)/dashboard/call/layout.tsx
+++ b/app/[lang]/(dashboard)/dashboard/call/layout.tsx
@@ -5,6 +5,11 @@ import { ConfigurationForm } from '@/components/call/configuration-form';
 // import { ThemeToggle } from "@/components/custom/theme-toggle";
 import { RoomWrapper } from '@/components/call/room-wrapper';
 import { TooltipProvider } from '@/components/ui/tooltip';
+import { defaultPresets as baseDefaultPresets } from '@/data/presets';
+import {
+  applyPresetInstructionOverrides,
+  getCallInstructionConfig,
+} from '@/lib/edge-config/call-instructions';
 import { ConnectionProvider } from '@/hooks/use-connection';
 import { PlaygroundStateProvider } from '@/hooks/use-playground-state';
 
@@ -15,14 +20,28 @@ export const metadata: Metadata = {
 
 import '@livekit/components-styles';
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const { defaultInstructions, initialInstruction, presetInstructions } =
+    await getCallInstructionConfig();
+
+  const defaultPresets = applyPresetInstructionOverrides(
+    baseDefaultPresets,
+    presetInstructions,
+  );
+
   return (
     // <PHProvider>
-    <PlaygroundStateProvider>
+    <PlaygroundStateProvider
+      defaultPresets={defaultPresets}
+      initialState={{
+        instructions: defaultInstructions,
+        initialInstruction,
+      }}
+    >
       <ConnectionProvider>
         <TooltipProvider>
           <RoomWrapper>

--- a/components/call/instructions.tsx
+++ b/components/call/instructions.tsx
@@ -10,15 +10,14 @@ import {
   HoverCardTrigger,
 } from '@/components/ui/hover-card';
 import { usePlaygroundState } from '@/hooks/use-playground-state';
-import { playgroundStateHelpers } from '@/lib/playground-state-helpers';
 
 export function Instructions() {
   // const [isFocused, setIsFocused] = useState<boolean>(false);
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const [isExpanded, setIsExpanded] = useState<boolean>(false);
-  const { pgState } = usePlaygroundState();
+  const { pgState, helpers } = usePlaygroundState();
 
-  const immutablePrompt = playgroundStateHelpers.getImmutablePrompt(pgState);
+  const immutablePrompt = helpers.getImmutablePrompt(pgState);
 
   return (
     <div

--- a/data/playground-state.ts
+++ b/data/playground-state.ts
@@ -1,6 +1,7 @@
 import { VoiceId } from '@/data/voices';
 import { ModelId } from './models';
 import type { Preset } from './presets';
+import { defaultPresets } from './presets';
 
 export interface SessionConfig {
   model: ModelId;
@@ -16,6 +17,7 @@ export interface PlaygroundState {
   selectedPresetId: string | null;
   instructions: string;
   initialInstruction: string;
+  defaultPresets: Preset[];
 }
 
 export const defaultSessionConfig: SessionConfig = {
@@ -56,4 +58,5 @@ export const defaultPlaygroundState: PlaygroundState = {
   selectedPresetId: 'porn-whisper',
   instructions,
   initialInstruction,
+  defaultPresets,
 };

--- a/hooks/use-connection.tsx
+++ b/hooks/use-connection.tsx
@@ -5,7 +5,6 @@ import { createContext, useCallback, useContext, useState } from 'react';
 
 import type { PlaygroundState } from '@/data/playground-state';
 import { VoiceId } from '@/data/voices';
-import { playgroundStateHelpers } from '@/lib/playground-state-helpers';
 import { usePlaygroundState } from './use-playground-state';
 
 export type ConnectFn = () => Promise<void>;
@@ -36,7 +35,7 @@ export const ConnectionProvider = ({
     voice: VoiceId;
   }>({ wsUrl: '', token: '', shouldConnect: false, voice: VoiceId.ARA });
 
-  const { pgState } = usePlaygroundState();
+  const { pgState, helpers } = usePlaygroundState();
 
   const connect = async () => {
     console.log('connect');
@@ -46,9 +45,7 @@ export const ConnectionProvider = ({
       headers: {
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify(
-        playgroundStateHelpers.getStateWithFullInstructions(pgState),
-      ),
+      body: JSON.stringify(helpers.getStateWithFullInstructions(pgState)),
     });
 
     if (!response.ok) {

--- a/lib/edge-config/call-instructions.ts
+++ b/lib/edge-config/call-instructions.ts
@@ -1,0 +1,58 @@
+import { captureException } from '@sentry/nextjs';
+import { get } from '@vercel/edge-config';
+
+import {
+  initialInstruction as fallbackInitialInstruction,
+  instructions as fallbackInstructions,
+} from '@/data/playground-state';
+import type { Preset } from '@/data/presets';
+
+type CallInstructionConfig = {
+  defaultInstructions: string;
+  initialInstruction: string;
+  presetInstructions?: Record<string, string>;
+};
+
+const FALLBACK_CONFIG: CallInstructionConfig = {
+  defaultInstructions: fallbackInstructions,
+  initialInstruction: fallbackInitialInstruction,
+};
+
+export async function getCallInstructionConfig(): Promise<CallInstructionConfig> {
+  try {
+    const config =
+      await get<Partial<CallInstructionConfig>>('call-instructions');
+
+    return {
+      defaultInstructions:
+        config?.defaultInstructions ??
+        config?.instructions ??
+        fallbackInstructions,
+      initialInstruction:
+        config?.initialInstruction ?? fallbackInitialInstruction,
+      presetInstructions: config?.presetInstructions,
+    };
+  } catch (error) {
+    captureException(error, {
+      data: {
+        message: 'Failed to load call instructions from Edge Config',
+      },
+    });
+
+    return FALLBACK_CONFIG;
+  }
+}
+
+export function applyPresetInstructionOverrides(
+  presets: Preset[],
+  presetInstructions?: Record<string, string>,
+): Preset[] {
+  if (!presetInstructions) {
+    return presets;
+  }
+
+  return presets.map((preset) => ({
+    ...preset,
+    instructions: presetInstructions[preset.id] ?? preset.instructions,
+  }));
+}

--- a/lib/playground-state-helpers.ts
+++ b/lib/playground-state-helpers.ts
@@ -2,142 +2,149 @@ import {
   type PlaygroundState,
   type SessionConfig,
   defaultSessionConfig,
-} from "@/data/playground-state";
-import { type Preset, defaultPresets } from "@/data/presets";
-import { IMMUTABLE_GROK_IMAGE_GENERATION_PROMPT } from "@/data/immutable-prompt";
+} from '@/data/playground-state';
+import { type Preset, defaultPresets as baseDefaultPresets } from '@/data/presets';
+import { IMMUTABLE_GROK_IMAGE_GENERATION_PROMPT } from '@/data/immutable-prompt';
 
-export const playgroundStateHelpers = {
-  getSelectedPreset: (state: PlaygroundState) => [...defaultPresets, ...state.userPresets].find(
-      (preset) => preset.id === state.selectedPresetId
-    ),
-  getDefaultPresets: () => defaultPresets,
-  getAllPresets: (state: PlaygroundState) => [
-    ...defaultPresets,
-    ...state.userPresets,
-  ],
+export const createPlaygroundStateHelpers = (
+  defaultPresets: Preset[] = baseDefaultPresets,
+) => {
+  const helpers = {
+    getSelectedPreset: (state: PlaygroundState) =>
+      [...defaultPresets, ...state.userPresets].find(
+        (preset) => preset.id === state.selectedPresetId,
+      ),
+    getDefaultPresets: () => defaultPresets,
+    getAllPresets: (state: PlaygroundState) => [
+      ...defaultPresets,
+      ...state.userPresets,
+    ],
 
-  encodeToUrlParams: (state: PlaygroundState): string => {
-    const params = new URLSearchParams();
+    encodeToUrlParams: (state: PlaygroundState): string => {
+      const params = new URLSearchParams();
 
-    let isDefaultPreset = false;
-    const selectedPreset = playgroundStateHelpers.getSelectedPreset(state);
-    if (selectedPreset) {
-      params.set("preset", selectedPreset.id);
-      isDefaultPreset = !!selectedPreset.defaultGroup;
-    }
-
-    if (!isDefaultPreset) {
-      if (state.instructions) {
-        params.set("instructions", state.instructions);
+      let isDefaultPreset = false;
+      const selectedPreset = helpers.getSelectedPreset(state);
+      if (selectedPreset) {
+        params.set('preset', selectedPreset.id);
+        isDefaultPreset = !!selectedPreset.defaultGroup;
       }
 
-      if (selectedPreset) {
-        params.set("presetName", selectedPreset.name);
-        if (selectedPreset.description) {
-          params.set("presetDescription", selectedPreset.description);
+      if (!isDefaultPreset) {
+        if (state.instructions) {
+          params.set('instructions', state.instructions);
+        }
+
+        if (selectedPreset) {
+          params.set('presetName', selectedPreset.name);
+          if (selectedPreset.description) {
+            params.set('presetDescription', selectedPreset.description);
+          }
+        }
+
+        if (state.sessionConfig) {
+          Object.entries(state.sessionConfig).forEach(([key, value]) => {
+            if (value !== defaultSessionConfig[key as keyof SessionConfig]) {
+              params.set(`sessionConfig.${key}`, String(value));
+            }
+          });
         }
       }
+      return params.toString();
+    },
 
-      if (state.sessionConfig) {
-        Object.entries(state.sessionConfig).forEach(([key, value]) => {
-          if (value !== defaultSessionConfig[key as keyof SessionConfig]) {
-            params.set(`sessionConfig.${key}`, String(value));
-          }
-        });
+    decodeFromURLParams: (
+      urlParams: string,
+    ): { state: Partial<PlaygroundState>; preset?: Partial<Preset> } => {
+      const params = new URLSearchParams(urlParams);
+      const returnValue: {
+        state: Partial<PlaygroundState>;
+        preset?: Partial<Preset>;
+      } = { state: {} };
+
+      const instructions = params.get('instructions');
+      if (instructions) {
+        returnValue.state.instructions = instructions;
       }
-    }
-    return params.toString();
-  },
 
-  decodeFromURLParams: (
-    urlParams: string
-  ): { state: Partial<PlaygroundState>; preset?: Partial<Preset> } => {
-    const params = new URLSearchParams(urlParams);
-    const returnValue: {
-      state: Partial<PlaygroundState>;
-      preset?: Partial<Preset>;
-    } = { state: {} };
+      const sessionConfig: Partial<PlaygroundState['sessionConfig']> = {};
+      params.forEach((value, key) => {
+        if (key.startsWith('sessionConfig.')) {
+          const configKey = key.split('.')[1] as keyof PlaygroundState['sessionConfig'];
+          sessionConfig[configKey] = value as any;
+        }
+      });
 
-    const instructions = params.get("instructions");
-    if (instructions) {
-      returnValue.state.instructions = instructions;
-    }
-
-    const sessionConfig: Partial<PlaygroundState["sessionConfig"]> = {};
-    params.forEach((value, key) => {
-      if (key.startsWith("sessionConfig.")) {
-        const configKey = key.split(
-          "."
-        )[1] as keyof PlaygroundState["sessionConfig"];
-        sessionConfig[configKey] = value as any;
+      if (Object.keys(sessionConfig).length > 0) {
+        returnValue.state.sessionConfig = sessionConfig as SessionConfig;
       }
-    });
 
-    if (Object.keys(sessionConfig).length > 0) {
-      returnValue.state.sessionConfig = sessionConfig as SessionConfig;
-    }
+      const presetId = params.get('preset');
+      if (presetId) {
+        returnValue.preset = {
+          id: presetId,
+          name: params.get('presetName') || undefined,
+          description: params.get('presetDescription') || undefined,
+        };
+        returnValue.state.selectedPresetId = presetId;
+      }
 
-    const presetId = params.get("preset");
-    if (presetId) {
-      returnValue.preset = {
-        id: presetId,
-        name: params.get("presetName") || undefined,
-        description: params.get("presetDescription") || undefined,
+      return returnValue;
+    },
+
+    updateBrowserUrl: (state: PlaygroundState) => {
+      if (typeof window !== 'undefined') {
+        const params = helpers.encodeToUrlParams(state);
+        const newUrl = `${window.location.origin}${window.location.pathname}${params ? `?${params}` : ''}`;
+        window.history.replaceState({}, '', newUrl);
+      }
+    },
+
+    /**
+     * Checks if the immutable Grok Imagine prompt should be used
+     * Returns true if Grok Imagine is enabled AND the current preset is NOT the creative-artist preset
+     */
+    shouldUseImmutablePrompt: (state: PlaygroundState): boolean => {
+      const { sessionConfig, selectedPresetId } = state;
+      return (
+        sessionConfig.grokImageEnabled && selectedPresetId !== 'creative-artist'
+      );
+    },
+
+    /**
+     * Gets the full instructions with immutable prompt prepended if needed
+     */
+    getFullInstructions: (state: PlaygroundState): string => {
+      const shouldUseImmutable = helpers.shouldUseImmutablePrompt(state);
+
+      if (shouldUseImmutable) {
+        return `${IMMUTABLE_GROK_IMAGE_GENERATION_PROMPT}\n\n${state.instructions}`;
+      }
+
+      return state.instructions;
+    },
+
+    /**
+     * Gets just the immutable prompt if it should be used
+     */
+    getImmutablePrompt: (state: PlaygroundState): string | null =>
+      helpers.shouldUseImmutablePrompt(state)
+        ? IMMUTABLE_GROK_IMAGE_GENERATION_PROMPT
+        : null,
+
+    /**
+     * Returns a new state object with full instructions (including additional prompt if needed)
+     */
+    getStateWithFullInstructions: (state: PlaygroundState): PlaygroundState => {
+      const fullInstructions = helpers.getFullInstructions(state);
+      return {
+        ...state,
+        instructions: fullInstructions,
       };
-      returnValue.state.selectedPresetId = presetId;
-    }
+    },
+  };
 
-    return returnValue;
-  },
-
-  updateBrowserUrl: (state: PlaygroundState) => {
-    if (typeof window !== "undefined") {
-      const params = playgroundStateHelpers.encodeToUrlParams(state);
-      const newUrl = `${window.location.origin}${window.location.pathname}${params ? `?${params}` : ""}`;
-      window.history.replaceState({}, "", newUrl);
-    }
-  },
-
-  /**
-   * Checks if the immutable Grok Imagine prompt should be used
-   * Returns true if Grok Imagine is enabled AND the current preset is NOT the creative-artist preset
-   */
-  shouldUseImmutablePrompt: (state: PlaygroundState): boolean => {
-    const { sessionConfig, selectedPresetId } = state;
-    return (
-      sessionConfig.grokImageEnabled && selectedPresetId !== "creative-artist"
-    );
-  },
-
-  /**
-   * Gets the full instructions with immutable prompt prepended if needed
-   */
-  getFullInstructions: (state: PlaygroundState): string => {
-    const shouldUseImmutable =
-      playgroundStateHelpers.shouldUseImmutablePrompt(state);
-
-    if (shouldUseImmutable) {
-      return `${IMMUTABLE_GROK_IMAGE_GENERATION_PROMPT}\n\n${state.instructions}`;
-    }
-
-    return state.instructions;
-  },
-
-  /**
-   * Gets just the immutable prompt if it should be used
-   */
-  getImmutablePrompt: (state: PlaygroundState): string | null => playgroundStateHelpers.shouldUseImmutablePrompt(state)
-      ? IMMUTABLE_GROK_IMAGE_GENERATION_PROMPT
-      : null,
-
-  /**
-   * Returns a new state object with full instructions (including additional prompt if needed)
-   */
-  getStateWithFullInstructions: (state: PlaygroundState): PlaygroundState => {
-    const fullInstructions = playgroundStateHelpers.getFullInstructions(state);
-    return {
-      ...state,
-      instructions: fullInstructions,
-    };
-  },
+  return helpers;
 };
+
+export const playgroundStateHelpers = createPlaygroundStateHelpers();

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "@upstash/redis": "^1.35.7",
     "@vercel/analytics": "^1.6.1",
     "@vercel/blob": "^1.0.0",
+    "@vercel/edge-config": "^1.4.3",
     "@vercel/speed-insights": "^1.3.1",
     "@wasm-audio-decoders/ogg-vorbis": "^0.1.20",
     "ai": "^4.3.16",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -133,6 +133,9 @@ importers:
       '@vercel/blob':
         specifier: ^1.0.0
         version: 1.1.1
+      '@vercel/edge-config':
+        specifier: ^1.4.3
+        version: 1.4.3(@opentelemetry/api@1.9.0)(next@15.5.9(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.53.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.86.3))
       '@vercel/speed-insights':
         specifier: ^1.3.1
         version: 1.3.1(next@15.5.9(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.53.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.86.3))(react@19.2.3)
@@ -3655,6 +3658,21 @@ packages:
   '@vercel/blob@1.1.1':
     resolution: {integrity: sha512-heiJGj2qt5qTv6yiShH9f6KRAoZGj+lz61GQ+lBRL4lhvUmKI9A51KYlQTnsUd9ymdFlKHBlvmPeG+yGz2Qsbg==}
     engines: {node: '>=16.14'}
+
+  '@vercel/edge-config-fs@0.1.0':
+    resolution: {integrity: sha512-NRIBwfcS0bUoUbRWlNGetqjvLSwgYH/BqKqDN7vK1g32p7dN96k0712COgaz6VFizAm9b0g6IG6hR6+hc0KCPg==}
+
+  '@vercel/edge-config@1.4.3':
+    resolution: {integrity: sha512-8vTDATodRrH49wMzKEjZ8/5H2qs1aPkD0uRK585f/Fx4YN2wfHfY/3td9OFrh+gdnCq07z8A5f0hoY6xhBcPkg==}
+    engines: {node: '>=14.6'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.7.0
+      next: '>=1'
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      next:
+        optional: true
 
   '@vercel/speed-insights@1.3.1':
     resolution: {integrity: sha512-PbEr7FrMkUrGYvlcLHGkXdCkxnylCWePx7lPxxq36DNdfo9mcUjLOmqOyPDHAOgnfqgGGdmE3XI9L/4+5fr+vQ==}
@@ -10641,6 +10659,15 @@ snapshots:
       is-node-process: 1.2.0
       throttleit: 2.1.0
       undici: 7.10.0
+
+  '@vercel/edge-config-fs@0.1.0': {}
+
+  '@vercel/edge-config@1.4.3(@opentelemetry/api@1.9.0)(next@15.5.9(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.53.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.86.3))':
+    dependencies:
+      '@vercel/edge-config-fs': 0.1.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+      next: 15.5.9(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.53.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.86.3)
 
   '@vercel/speed-insights@1.3.1(next@15.5.9(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.53.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.86.3))(react@19.2.3)':
     optionalDependencies:


### PR DESCRIPTION
## Summary
- load call instructions and preset overrides from Vercel Edge Config
- allow playground state to accept injected presets/instructions and use helper factory
- initialize the call dashboard layout with Edge Config-driven defaults

## Testing
- pnpm run fixall *(fails due to pre-existing lint issues outside modified files)*
- pnpm run format --write


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694587d2a018832eac337b608dc2d971)