### PR TITLE
feat: add winter sale banner

### DIFF
--- a/app/[lang]/(dashboard)/dashboard.ui.tsx
+++ b/app/[lang]/(dashboard)/dashboard.ui.tsx
@@ -132,7 +132,7 @@ export default function DashboardUI({
         </Sidebar>
 
         <PromoBanner
-          arialLabelDismiss={blackFridayDict.arialLabelDismiss}
+          ariaLabelDismiss={blackFridayDict.ariaLabelDismiss}
           countdown={
             process.env.NEXT_PUBLIC_PROMO_COUNTDOWN_END_DATE
               ? {

--- a/app/[lang]/blog/[slug]/page.tsx
+++ b/app/[lang]/blog/[slug]/page.tsx
@@ -187,7 +187,7 @@ const PostLayout = async (props: {
       </Script>
 
       <PromoBanner
-        arialLabelDismiss={blackFridayDict.arialLabelDismiss}
+        ariaLabelDismiss={blackFridayDict.ariaLabelDismiss}
         countdown={
           process.env.NEXT_PUBLIC_PROMO_COUNTDOWN_END_DATE
             ? {

--- a/app/[lang]/page.tsx
+++ b/app/[lang]/page.tsx
@@ -74,7 +74,7 @@ export default async function LandingPage(props: {
       <Script type="application/ld+json">{JSON.stringify(jsonLd)}</Script>
 
       <PromoBanner
-        arialLabelDismiss={blackFridayDict.arialLabelDismiss}
+        ariaLabelDismiss={blackFridayDict.ariaLabelDismiss}
         countdown={
           process.env.NEXT_PUBLIC_PROMO_COUNTDOWN_END_DATE
             ? {

--- a/components/promo-banner.tsx
+++ b/components/promo-banner.tsx
@@ -14,7 +14,7 @@ interface PromoBannerProps {
   text: string;
   ctaLink: string;
   ctaText: string;
-  arialLabelDismiss: string;
+  ariaLabelDismiss: string;
   isEnabled?: boolean;
   countdown?: {
     enabled: boolean;
@@ -67,7 +67,7 @@ export function PromoBanner({
   text,
   ctaLink,
   ctaText,
-  arialLabelDismiss,
+  ariaLabelDismiss,
   isEnabled = false,
   countdown,
 }: PromoBannerProps) {
@@ -207,7 +207,7 @@ export function PromoBanner({
           </Button>
 
           <Button
-            aria-label={arialLabelDismiss}
+            aria-label={ariaLabelDismiss}
             className="absolute right-0 md:relative"
             onClick={handleDismissBanner}
             size="sm"

--- a/lib/i18n/dictionaries/de.json
+++ b/lib/i18n/dictionaries/de.json
@@ -421,7 +421,7 @@
       "text": "🎃 Halloween Special – Erhalten Sie bis zu 35% Extra-Credits bei einem Kauf 👻\nZeitlich begrenztes Angebot 🦇",
       "ctaLoggedIn": "Credits Erhalten",
       "ctaLoggedOut": "Jetzt Registrieren",
-      "arialLabelDismiss": "Halloween-Banner schließen",
+      "ariaLabelDismiss": "Halloween-Banner schließen",
       "pricing": {
         "bannerText": "🎃 Halloween-Special"
       }
@@ -430,7 +430,7 @@
       "text": "🛍️ Black Friday Sale – Erhalten Sie bis zu 50% Extra-Credits bei jedem Kauf!\nZeitlich begrenztes Angebot 🔥",
       "ctaLoggedIn": "Angebot Sichern",
       "ctaLoggedOut": "Jetzt Registrieren",
-      "arialLabelDismiss": "Black Friday-Banner schließen",
+      "ariaLabelDismiss": "Black Friday-Banner schließen",
       "countdown": {
         "prefix": "Angebot endet in:",
         "days": "Tage",
@@ -446,7 +446,7 @@
       "text": "❄️ Winterschlussverkauf – Erhalten Sie bis zu 35% Extra-Credits bei einem Kauf ☃️\nZeitlich begrenztes Angebot 🎿",
       "ctaLoggedIn": "Angebot Sichern ❄️",
       "ctaLoggedOut": "Jetzt Registrieren ❄️",
-      "arialLabelDismiss": "Winterschlussverkauf-Banner schließen",
+      "ariaLabelDismiss": "Winterschlussverkauf-Banner schließen",
       "pricing": {
         "bannerText": "❄️ Winterschlussverkauf"
       }

--- a/lib/i18n/dictionaries/en.json
+++ b/lib/i18n/dictionaries/en.json
@@ -421,7 +421,7 @@
       "text": "🎃 Halloween Special – Get up to 35% extra credits with a purchase 👻\nLimited time offer 🦇",
       "ctaLoggedIn": "Claim Offer 🎃",
       "ctaLoggedOut": "Sign Up Now 🎃",
-      "arialLabelDismiss": "Dismiss Halloween banner",
+      "ariaLabelDismiss": "Dismiss Halloween banner",
       "pricing": {
         "bannerText": "🎃 Halloween Special"
       }
@@ -430,7 +430,7 @@
       "text": "🛍️ Black Friday Sale – Get up to 35% extra credits!",
       "ctaLoggedIn": "Claim Offer",
       "ctaLoggedOut": "Claim Offer",
-      "arialLabelDismiss": "Dismiss Black Friday banner",
+      "ariaLabelDismiss": "Dismiss Black Friday banner",
       "countdown": {
         "prefix": "Deal ends in:",
         "days": "Days",
@@ -446,7 +446,7 @@
       "text": "❄️ Winter Sale – Get up to 35% extra credits with a purchase ☃️\nLimited time offer 🎿",
       "ctaLoggedIn": "Claim Offer ❄️",
       "ctaLoggedOut": "Sign Up Now ❄️",
-      "arialLabelDismiss": "Dismiss Winter Sale banner",
+      "ariaLabelDismiss": "Dismiss Winter Sale banner",
       "pricing": {
         "bannerText": "❄️ Winter Sale"
       }

--- a/lib/i18n/dictionaries/es.json
+++ b/lib/i18n/dictionaries/es.json
@@ -421,7 +421,7 @@
       "text": "🎃 Especial Halloween – Consigue hasta un 35% de créditos extra con tu compra 👻\nOferta por tiempo limitado 🦇",
       "ctaLoggedIn": "Obtener Créditos",
       "ctaLoggedOut": "Regístrate Ahora",
-      "arialLabelDismiss": "Descartar banner de Halloween",
+      "ariaLabelDismiss": "Descartar banner de Halloween",
       "pricing": {
         "bannerText": "🎃 Especial Halloween"
       }
@@ -430,7 +430,7 @@
       "text": "🛍️ Oferta Black Friday – ¡Consigue hasta un 50% de créditos extra con cualquier compra!\nOferta por tiempo limitado 🔥",
       "ctaLoggedIn": "Obtener Oferta",
       "ctaLoggedOut": "Regístrate Ahora",
-      "arialLabelDismiss": "Descartar banner de Black Friday",
+      "ariaLabelDismiss": "Descartar banner de Black Friday",
       "countdown": {
         "prefix": "La oferta termina en:",
         "days": "Días",
@@ -446,7 +446,7 @@
       "text": "❄️ Oferta de Invierno – Consigue hasta un 35% de créditos extra con tu compra ☃️\nOferta por tiempo limitado 🎿",
       "ctaLoggedIn": "Obtener Oferta ❄️",
       "ctaLoggedOut": "Regístrate Ahora ❄️",
-      "arialLabelDismiss": "Descartar banner de Oferta de Invierno",
+      "ariaLabelDismiss": "Descartar banner de Oferta de Invierno",
       "pricing": {
         "bannerText": "❄️ Oferta de Invierno"
       }


### PR DESCRIPTION
Add winterSaleBanner translations for EN, ES, and DE locales. Structure follows existing promo banners without countdown.