### PR TITLE
Show promo bonus notice on pricing and credits pages (localized)

### DIFF
--- a/app/[lang]/(dashboard)/dashboard/credits/credit-topup.tsx
+++ b/app/[lang]/(dashboard)/dashboard/credits/credit-topup.tsx
@@ -84,19 +84,23 @@ export function CreditTopup({ dict, lang }: CreditTopupProps) {
   ];
 
   return (
-    <div
-      className="grid gap-6 md:grid-cols-1 lg:grid-cols-3"
-      data-promo-theme={promoTheme}
-    >
-      {plans.map((plan) => (
-        <PlanCard
-          bannerTranslations={bannerTranslations}
-          dict={dict.credits}
-          isPromoEnabled={isPromoEnabled}
-          key={plan.id}
-          plan={plan}
-        />
-      ))}
+    <div className="space-y-3" data-promo-theme={promoTheme}>
+      {isPromoEnabled && (
+        <p className="text-center text-muted-foreground text-sm">
+          {dict.credits.promoNotice}
+        </p>
+      )}
+      <div className="grid gap-6 md:grid-cols-1 lg:grid-cols-3">
+        {plans.map((plan) => (
+          <PlanCard
+            bannerTranslations={bannerTranslations}
+            dict={dict.credits}
+            isPromoEnabled={isPromoEnabled}
+            key={plan.id}
+            plan={plan}
+          />
+        ))}
+      </div>
     </div>
   );
 }

--- a/components/pricing-table.tsx
+++ b/components/pricing-table.tsx
@@ -76,9 +76,14 @@ async function PricingTable({ lang }: { lang: Locale }) {
       className="flex flex-col gap-6 py-16 xl:px-28"
       data-promo-theme={promoTheme}
     >
-      <h2 className="mx-auto mb-4 font-semibold text-2xl">
+      <h2 className="mx-auto font-semibold text-2xl">
         {credits.pricingPlan}
       </h2>
+      {isPromoEnabled && (
+        <p className="mx-auto max-w-2xl text-center text-muted-foreground text-sm">
+          {credits.promoNotice}
+        </p>
+      )}
       <div className="grid gap-6 md:grid-cols-1 lg:grid-cols-3">
         {plans.map((plan) => (
           <Card

--- a/lib/i18n/dictionaries/da.json
+++ b/lib/i18n/dictionaries/da.json
@@ -191,6 +191,7 @@
     "pricingPlan": "Priser",
     "title": "Køb kreditter til skabere og virksomheder i alle størrelser",
     "description": "Vælg den mængde kreditter, der passer bedst til dine behov",
+    "promoNotice": "Bonuscredits anvendes, mens kampagnen er aktiv.",
     "historyEmpty": "Din kreditforbrugshistorik vises her",
     "billing": {
       "forever": "(for evigt)"

--- a/lib/i18n/dictionaries/de.json
+++ b/lib/i18n/dictionaries/de.json
@@ -191,6 +191,7 @@
     "pricingPlan": "Preispläne",
     "title": "Credits für Kreative und Unternehmen jeder Größe kaufen",
     "description": "Wählen Sie die Anzahl an Credits, die am besten zu Ihren Bedürfnissen passt",
+    "promoNotice": "Bonusguthaben werden angewendet, solange die Aktion aktiv ist.",
     "historyEmpty": "Ihre Credit-Nutzungshistorie wird hier angezeigt",
     "billing": {
       "forever": "(für immer)"

--- a/lib/i18n/dictionaries/en.json
+++ b/lib/i18n/dictionaries/en.json
@@ -191,6 +191,7 @@
     "pricingPlan": "Pricing",
     "title": "Purchase credits for creators and businesses of all sizes",
     "description": "Choose the amount of credits that best fits your needs",
+    "promoNotice": "Bonus credits applied while promotion is active.",
     "historyEmpty": "Your credit usage history will appear here",
     "billing": {
       "forever": "(forever)"

--- a/lib/i18n/dictionaries/es.json
+++ b/lib/i18n/dictionaries/es.json
@@ -191,6 +191,7 @@
     "pricingPlan": "Tarifas",
     "title": "Compra créditos para creadores y empresas de todos los tamaños",
     "description": "Elige la cantidad de créditos que mejor se adapte a tus necesidades",
+    "promoNotice": "Los créditos de bonificación se aplican mientras la promoción esté activa.",
     "historyEmpty": "Tu historial de uso de créditos aparecerá aquí",
     "billing": {
       "forever": "(para siempre)"

--- a/lib/i18n/dictionaries/fr.json
+++ b/lib/i18n/dictionaries/fr.json
@@ -191,6 +191,7 @@
     "pricingPlan": "Tarifs",
     "title": "Achetez des crédits pour les créateurs et entreprises de toutes tailles",
     "description": "Choisissez la quantité de crédits qui correspond le mieux à vos besoins",
+    "promoNotice": "Les crédits bonus s'appliquent tant que la promotion est active.",
     "historyEmpty": "Votre historique d'utilisation des crédits apparaîtra ici",
     "billing": {
       "forever": "(pour toujours)"

--- a/lib/i18n/dictionaries/it.json
+++ b/lib/i18n/dictionaries/it.json
@@ -191,6 +191,7 @@
     "pricingPlan": "Prezzi",
     "title": "Acquista crediti per creatori e aziende di tutte le dimensioni",
     "description": "Scegli la quantità di crediti più adatta alle tue esigenze",
+    "promoNotice": "I crediti bonus si applicano mentre la promozione è attiva.",
     "historyEmpty": "La cronologia del tuo utilizzo crediti apparirà qui",
     "billing": {
       "forever": "(per sempre)"


### PR DESCRIPTION
### Motivation
- Surface a clear promotional notice when the promo feature is enabled so users see that bonus credits are applied to purchases.
- Keep the message localized for all supported site languages so translations appear consistently across pricing UI.

### Description
- Add a centered promo notice below the landing page pricing heading in `components/pricing-table.tsx` that renders when `NEXT_PUBLIC_PROMO_ENABLED === 'true'`.
- Add the same centered promo notice above the credit top-up plan grid in `app/[lang]/(dashboard)/dashboard/credits/credit-topup.tsx` when the promo is enabled.
- Add `promoNotice` translation strings to the i18n dictionaries for supported locales: `lib/i18n/dictionaries/{en,es,de,fr,da,it}.json`.
- Preserve existing promo banner behavior (banner badge and per-plan bonus text) and only surface the new explanatory line when the env flag is set.

### Testing
- Ran `pnpm run fixall` which attempted lint/format/type fixes but failed due to existing lint diagnostics in the repository unrelated to this change. (failed)
- Ran `pnpm typecheck` which failed due to missing `contentlayer/generated` types in the environment. (failed)
- Launched a local dev server with `NEXT_PUBLIC_PROMO_ENABLED=true pnpm dev` and attempted an automated Playwright capture to verify the UI, but the render attempt failed due to the missing Contentlayer module and Playwright/Chromium runtime errors. (failed)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967106a8c98832eb2c3f00b8ba99002)