### PR TITLE
Add call sessions analytics to daily stats endpoint

### DIFF
--- a/app/api/daily-stats/route.ts
+++ b/app/api/daily-stats/route.ts
@@ -188,7 +188,9 @@ export async function GET(request: NextRequest) {
 
   // Call sessions data processing
   const callSessionsWeekData = (callSessionsWeekResult.data ?? []).filter(
-    (item): item is {
+    (
+      item,
+    ): item is {
       id: string;
       started_at: string;
       duration_seconds: number;
@@ -199,21 +201,22 @@ export async function GET(request: NextRequest) {
   const callSessionsTotalCount = callSessionsTotalCountResult.count ?? 0;
 
   // Filter call sessions by date ranges (using started_at as the date field)
-  const callSessionsYesterdayData = callSessionsWeekData.filter((item) => {
-    const itemTime = new Date(item.started_at).getTime();
-    return itemTime >= previousDay.getTime() && itemTime < today.getTime();
-  });
+  const callSessionsYesterdayData = filterByDateRange(
+    callSessionsWeekData,
+    previousDay,
+    today,
+    'started_at',
+  );
   const callsYesterdayCount = callSessionsYesterdayData.length;
   const callsWeekCount = callSessionsWeekData.length;
-  const callsWeekAvg = callsWeekCount / 7;
 
   // Calculate total duration for yesterday and week
   const callsDurationYesterday = callSessionsYesterdayData.reduce(
-    (sum, call) => sum + (call.duration_seconds || 0),
+    (sum, call) => sum + call.duration_seconds,
     0,
   );
   const callsDurationWeek = callSessionsWeekData.reduce(
-    (sum, call) => sum + (call.duration_seconds || 0),
+    (sum, call) => sum + call.duration_seconds,
     0,
   );
 
@@ -482,8 +485,8 @@ export async function GET(request: NextRequest) {
     `  - All-time: ${audioTotalCount.toLocaleString()}`,
     `  - Top voices: ${topVoiceList}`,
     '',
-    `📞 Calls: ${callsYesterdayCount} (${formatChange(callsYesterdayCount, callsWeekAvg)})`,
-    `  - 7d: ${callsWeekCount} (avg ${callsWeekAvg.toFixed(1)})`,
+    `📞 Calls: ${callsYesterdayCount} (${formatChange(callsYesterdayCount, callsWeekCount / 7)})`,
+    `  - 7d: ${callsWeekCount} (avg ${(callsWeekCount / 7).toFixed(1)})`,
     `  - Duration: ${formatDuration(callsDurationYesterday)} | 7d: ${formatDuration(callsDurationWeek)} (avg ${formatDuration(Math.round(callsDurationWeek / 7))})`,
     `  - All-time: ${callSessionsTotalCount.toLocaleString()}`,
     '',

--- a/app/api/daily-stats/utils.ts
+++ b/app/api/daily-stats/utils.ts
@@ -62,15 +62,25 @@ export function maskUsername(username?: string): string | undefined {
   return maskedUsername;
 }
 
-export const filterByDateRange = <T extends { created_at: string }>(
+export function filterByDateRange<T extends { created_at: string }>(
   items: T[],
   start: Date,
   end: Date,
-) => {
+): T[];
+export function filterByDateRange<
+  K extends string,
+  T extends Record<K, string>,
+>(items: T[], start: Date, end: Date, dateKey: K): T[];
+export function filterByDateRange<T extends Record<string, unknown>>(
+  items: T[],
+  start: Date,
+  end: Date,
+  dateKey = 'created_at',
+): T[] {
   const startTime = start.getTime();
   const endTime = end.getTime();
   return items.filter((item) => {
-    const itemTime = new Date(item.created_at).getTime();
+    const itemTime = new Date(item[dateKey] as string).getTime();
     return itemTime >= startTime && itemTime < endTime;
   });
-};
+}


### PR DESCRIPTION
Add call session metrics to the daily stats report:
- Number of calls made yesterday with diff vs 7-day average
- 7-day total and average
- Duration stats (yesterday, 7-day total, 7-day average)
- All-time call count