### PR TITLE
Localize call UI strings and improve gradient background (Firefox fix)

### DIFF
--- a/app/[lang]/(dashboard)/dashboard/call/page.tsx
+++ b/app/[lang]/(dashboard)/dashboard/call/page.tsx
@@ -20,7 +20,7 @@ export default async function Call(props: {
     error,
   } = await supabase.auth.getUser();
   if (!user || error) {
-    return <div>Not logged in</div>;
+    return <div>{dict.profile.notLoggedIn}</div>;
   }
 
   const { data: creditTransactions } = await supabase

--- a/app/globals.css
+++ b/app/globals.css
@@ -146,7 +146,8 @@
 }
 
 .gradient-bg {
-  background: var(--gradient-background);
+  background-color: hsl(var(--gradient-start));
+  background-image: var(--gradient-background);
 }
 
 /* Added incoming call animation */

--- a/components/call/chat.tsx
+++ b/components/call/chat.tsx
@@ -25,7 +25,7 @@ export function Chat() {
   // const { audioTrack, state } = useVoiceAssistant();
   const [isChatRunning, setIsChatRunning] = useState(false);
   const { agent } = useAgent();
-  const { disconnect } = useConnection();
+  const { disconnect, dict } = useConnection();
   // const [isEditingInstructions, setIsEditingInstructions] = useState(false);
   const searchParams = useSearchParams();
 
@@ -48,7 +48,7 @@ export function Chat() {
 
         console.error('Agent Unavailable');
 
-        toast.error('Agent Unavailable');
+        toast.error(dict.agentUnavailable);
       }, 5000);
     }
 
@@ -66,7 +66,7 @@ export function Chat() {
         if (!agent) {
           disconnect();
           setHasSeenAgent(false);
-          toast.info('Disconnected');
+          toast.info(dict.disconnected);
           Sentry.captureMessage('Disconnected');
         }
       }, 5000);

--- a/components/call/configuration-form.tsx
+++ b/components/call/configuration-form.tsx
@@ -53,7 +53,7 @@ export interface ConfigurationFormFieldProps {
 
 export function ConfigurationForm() {
   const { pgState, dispatch, helpers } = usePlaygroundState();
-  const { connect, disconnect } = useConnection();
+  const { connect, disconnect, dict } = useConnection();
   const connectionState = useConnectionState();
   const { localParticipant } = useLocalParticipant();
   const form = useForm<z.infer<typeof ConfigurationFormSchema>>({
@@ -146,9 +146,9 @@ export function ConfigurationForm() {
         // Wait a bit longer for the connection to stabilize and attributes to sync
         await new Promise((resolve) => setTimeout(resolve, 500));
 
-        toast.success('Reconnected');
+        toast.success(dict.reconnected);
       } catch {
-        toast.error('Reconnection failed');
+        toast.error(dict.reconnectionFailed);
       } finally {
         // Always reset the reconnecting flag
         isReconnectingRef.current = false;
@@ -167,10 +167,10 @@ export function ConfigurationForm() {
       console.debug('pg.updateConfig', response);
       const responseObj = JSON.parse(response);
       if (responseObj.changed) {
-        toast('Configuration updated');
+        toast(dict.configurationUpdated);
       }
     } catch {
-      toast('Error Updating Configuration');
+      toast(dict.configurationUpdateError);
     }
   }, [
     pgState.sessionConfig,
@@ -181,6 +181,7 @@ export function ConfigurationForm() {
     connect,
     disconnect,
     helpers,
+    dict,
   ]);
 
   // Function to debounce updates when user stops interacting
@@ -246,7 +247,7 @@ export function ConfigurationForm() {
       <Form {...form}>
         <div className="w-full border-separator1 border-b px-4 pt-0 pb-4 md:px-1 md:py-4">
           <div className="font-bold text-fg0 text-xs uppercase tracking-widest">
-            Configuration
+            {dict.configurationTitle}
           </div>
         </div>
         <div className="flex w-full flex-col justify-between gap-2 border-separator1 border-b px-4 py-4 md:h-16 md:flex-row md:px-1">
@@ -258,7 +259,7 @@ export function ConfigurationForm() {
           {displayLanguage && (
             <div className="flex w-full items-center justify-between">
               <div className="font-semibold text-neutral-400 text-xs uppercase tracking-widest">
-                Language
+                {dict.languageLabel}
               </div>
               <Select
                 disabled={connectionState === ConnectionState.Connected}
@@ -266,7 +267,7 @@ export function ConfigurationForm() {
                 value={pgState.language}
               >
                 <SelectTrigger className="h-9 w-fit text-neutral-200">
-                  <SelectValue placeholder="Choose language" />
+                  <SelectValue placeholder={dict.languagePlaceholder} />
                 </SelectTrigger>
                 <SelectContent className="max-h-72 overflow-y-auto text-neutral-100">
                   {callLanguages.map(({ value, label }) => (

--- a/components/call/connect-button.tsx
+++ b/components/call/connect-button.tsx
@@ -7,7 +7,7 @@ import { Button } from '@/components/ui/button';
 import { useConnection } from '@/hooks/use-connection';
 
 export function ConnectButton() {
-  const { connect, disconnect, shouldConnect } = useConnection();
+  const { connect, disconnect, shouldConnect, dict } = useConnection();
   const [connecting, setConnecting] = useState<boolean>(false);
   const [initiateConnectionFlag, setInitiateConnectionFlag] = useState(false);
 
@@ -53,7 +53,7 @@ export function ConnectButton() {
         onClick={handleConnectionToggle}
         size="lg"
       >
-        {connecting || shouldConnect ? 'Connecting' : 'Start a call'}
+        {connecting || shouldConnect ? dict.connecting : dict.startCall}
       </Button>
     </div>
   );

--- a/hooks/use-connection.tsx
+++ b/hooks/use-connection.tsx
@@ -20,6 +20,7 @@ interface TokenGeneratorData {
   token: string;
   pgState: PlaygroundState;
   voice: VoiceId;
+  dict: (typeof langDict)['call'];
   disconnect: () => Promise<void>;
   connect: ConnectFn;
 }
@@ -95,6 +96,7 @@ export const ConnectionProvider = ({
         shouldConnect: connectionDetails.shouldConnect,
         voice: connectionDetails.voice,
         pgState,
+        dict,
         connect,
         disconnect,
       }}

--- a/lib/i18n/dictionaries/da.json
+++ b/lib/i18n/dictionaries/da.json
@@ -317,7 +317,18 @@
   "call": {
     "notice1": "Udforsk dine dybeste ønsker i total privatliv.",
     "notice2": "End-to-end krypterede, fordomsfrie samtaler.",
-    "notEnoughCredits": "Du har ikke nok kreditter. Minimum påkrævet er __COUNT__"
+    "notEnoughCredits": "Du har ikke nok kreditter. Minimum påkrævet er __COUNT__",
+    "configurationTitle": "Konfiguration",
+    "languageLabel": "Sprog",
+    "languagePlaceholder": "Vælg sprog",
+    "startCall": "Start et opkald",
+    "connecting": "Forbinder",
+    "reconnected": "Forbundet igen",
+    "reconnectionFailed": "Genforbindelse mislykkedes",
+    "configurationUpdated": "Konfiguration opdateret",
+    "configurationUpdateError": "Fejl ved opdatering af konfiguration",
+    "agentUnavailable": "Agenten er ikke tilgængelig",
+    "disconnected": "Afbrudt"
   },
   "clone": {
     "audioFileLabel": "Lydfil",

--- a/lib/i18n/dictionaries/de.json
+++ b/lib/i18n/dictionaries/de.json
@@ -317,7 +317,18 @@
   "call": {
     "notice1": "Erkunden Sie Ihre tiefsten Wünsche in völliger Privatsphäre.",
     "notice2": "Ende-zu-Ende verschlüsselt, urteilsfreie Gespräche",
-    "notEnoughCredits": "Sie haben nicht genügend Credits. Das Minimum beträgt __COUNT__"
+    "notEnoughCredits": "Sie haben nicht genügend Credits. Das Minimum beträgt __COUNT__",
+    "configurationTitle": "Konfiguration",
+    "languageLabel": "Sprache",
+    "languagePlaceholder": "Sprache wählen",
+    "startCall": "Anruf starten",
+    "connecting": "Verbinden",
+    "reconnected": "Wiederverbunden",
+    "reconnectionFailed": "Wiederverbindung fehlgeschlagen",
+    "configurationUpdated": "Konfiguration aktualisiert",
+    "configurationUpdateError": "Fehler beim Aktualisieren der Konfiguration",
+    "agentUnavailable": "Agent nicht verfügbar",
+    "disconnected": "Getrennt"
   },
   "clone": {
     "audioFileLabel": "Audiodatei",

--- a/lib/i18n/dictionaries/en.json
+++ b/lib/i18n/dictionaries/en.json
@@ -317,7 +317,18 @@
   "call": {
     "notice1": "Explore your deepest desires in total privacy.",
     "notice2": "End-to-end encrypted, judgment-free conversations.",
-    "notEnoughCredits": "You don't have enough credits. The minimum required is __COUNT__"
+    "notEnoughCredits": "You don't have enough credits. The minimum required is __COUNT__",
+    "configurationTitle": "Configuration",
+    "languageLabel": "Language",
+    "languagePlaceholder": "Choose language",
+    "startCall": "Start a call",
+    "connecting": "Connecting",
+    "reconnected": "Reconnected",
+    "reconnectionFailed": "Reconnection failed",
+    "configurationUpdated": "Configuration updated",
+    "configurationUpdateError": "Error updating configuration",
+    "agentUnavailable": "Agent unavailable",
+    "disconnected": "Disconnected"
   },
   "clone": {
     "audioFileLabel": "Audio File",

--- a/lib/i18n/dictionaries/es.json
+++ b/lib/i18n/dictionaries/es.json
@@ -317,7 +317,18 @@
   "call": {
     "notice1": "Explora tus deseos más profundos en total privacidad.",
     "notice2": "Conversaciones cifradas de extremo a extremo, sin juzgar.",
-    "notEnoughCredits": "No tienes suficientes créditos. El mínimo requerido es __COUNT__"
+    "notEnoughCredits": "No tienes suficientes créditos. El mínimo requerido es __COUNT__",
+    "configurationTitle": "Configuración",
+    "languageLabel": "Idioma",
+    "languagePlaceholder": "Elige un idioma",
+    "startCall": "Iniciar una llamada",
+    "connecting": "Conectando",
+    "reconnected": "Reconectado",
+    "reconnectionFailed": "Falló la reconexión",
+    "configurationUpdated": "Configuración actualizada",
+    "configurationUpdateError": "Error al actualizar la configuración",
+    "agentUnavailable": "Agente no disponible",
+    "disconnected": "Desconectado"
   },
   "clone": {
     "audioFileLabel": "Archivo de Audio",

--- a/lib/i18n/dictionaries/fr.json
+++ b/lib/i18n/dictionaries/fr.json
@@ -317,7 +317,18 @@
   "call": {
     "notice1": "Explorez vos désirs les plus profonds en toute intimité.",
     "notice2": "Conversations chiffrées de bout en bout, sans jugement.",
-    "notEnoughCredits": "Vous n'avez pas assez de crédits. Le minimum requis est __COUNT__"
+    "notEnoughCredits": "Vous n'avez pas assez de crédits. Le minimum requis est __COUNT__",
+    "configurationTitle": "Configuration",
+    "languageLabel": "Langue",
+    "languagePlaceholder": "Choisir une langue",
+    "startCall": "Démarrer un appel",
+    "connecting": "Connexion en cours",
+    "reconnected": "Reconnecté",
+    "reconnectionFailed": "Échec de la reconnexion",
+    "configurationUpdated": "Configuration mise à jour",
+    "configurationUpdateError": "Erreur lors de la mise à jour de la configuration",
+    "agentUnavailable": "Agent indisponible",
+    "disconnected": "Déconnecté"
   },
   "clone": {
     "audioFileLabel": "Fichier audio",

--- a/lib/i18n/dictionaries/it.json
+++ b/lib/i18n/dictionaries/it.json
@@ -317,7 +317,18 @@
   "call": {
     "notice1": "Esplora i tuoi desideri più profondi in totale privacy.",
     "notice2": "Conversazioni crittografate end-to-end, senza giudizi.",
-    "notEnoughCredits": "Non hai crediti sufficienti. Il minimo richiesto è __COUNT__"
+    "notEnoughCredits": "Non hai crediti sufficienti. Il minimo richiesto è __COUNT__",
+    "configurationTitle": "Configurazione",
+    "languageLabel": "Lingua",
+    "languagePlaceholder": "Scegli la lingua",
+    "startCall": "Avvia una chiamata",
+    "connecting": "Connessione in corso",
+    "reconnected": "Riconnesso",
+    "reconnectionFailed": "Riconnessione non riuscita",
+    "configurationUpdated": "Configurazione aggiornata",
+    "configurationUpdateError": "Errore durante l'aggiornamento della configurazione",
+    "agentUnavailable": "Agente non disponibile",
+    "disconnected": "Disconnesso"
   },
   "clone": {
     "audioFileLabel": "File audio",


### PR DESCRIPTION
### Motivation
- Fix missing translations in the call UI and ensure the call action button gradient renders correctly in Firefox.

### Description
- Thread the call dictionary through `ConnectionProvider` / `useConnection` and replace hard-coded call strings with localized keys in `connect-button`, `chat`, `configuration-form`, and the call page.
- Add new `call.*` translation keys to multiple locale dictionaries (`en`, `es`, `de`, `da`, `it`, `fr`) and use `dict.profile.notLoggedIn` on the call page.
- Update `.gradient-bg` in `app/globals.css` to provide a `background-color` fallback and set `background-image: var(--gradient-background)` to improve rendering in Firefox.

### Testing
- Ran `pnpm run fixall` which failed due to existing Biome lint errors in unrelated files (reported, no change to those files in this PR).
- Ran `pnpm typecheck` which failed because `contentlayer/generated` types are not present in the environment.
- Attempted a Playwright screenshot of the call page which timed out / crashed due to a browser instability in the container.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697922589350832e8098bcb24fd87697)