### PR TITLE
fix: update chooseCharacter translation to 'Who do you want to talk to?'

### DIFF
--- a/lib/i18n/dictionaries/da.json
+++ b/lib/i18n/dictionaries/da.json
@@ -334,7 +334,7 @@
     "configurationUpdateError": "Fejl ved opdatering af konfiguration",
     "agentUnavailable": "Agenten er ikke tilgængelig",
     "disconnected": "Afbrudt",
-    "chooseCharacter": "Vælg din karakter",
+    "chooseCharacter": "Hvem vil du tale med?",
     "presetRemoved": "Preset fjernet",
     "deletePreset": "Slet",
     "deletePresetConfirm": "Dette kan ikke fortrydes.",

--- a/lib/i18n/dictionaries/de.json
+++ b/lib/i18n/dictionaries/de.json
@@ -334,7 +334,7 @@
     "configurationUpdateError": "Fehler beim Aktualisieren der Konfiguration",
     "agentUnavailable": "Agent nicht verfügbar",
     "disconnected": "Getrennt",
-    "chooseCharacter": "Wähle deinen Charakter",
+    "chooseCharacter": "Mit wem möchtest du sprechen?",
     "presetRemoved": "Preset entfernt",
     "deletePreset": "Löschen",
     "deletePresetConfirm": "Dies kann nicht rückgängig gemacht werden.",

--- a/lib/i18n/dictionaries/en.json
+++ b/lib/i18n/dictionaries/en.json
@@ -334,7 +334,7 @@
     "configurationUpdateError": "Error updating configuration",
     "agentUnavailable": "Agent unavailable",
     "disconnected": "Disconnected",
-    "chooseCharacter": "Choose Your Character",
+    "chooseCharacter": "Who do you want to talk to?",
     "presetRemoved": "Preset removed",
     "deletePreset": "Delete",
     "deletePresetConfirm": "This cannot be undone.",

--- a/lib/i18n/dictionaries/es.json
+++ b/lib/i18n/dictionaries/es.json
@@ -334,7 +334,7 @@
     "configurationUpdateError": "Error al actualizar la configuración",
     "agentUnavailable": "Agente no disponible",
     "disconnected": "Desconectado",
-    "chooseCharacter": "Elige tu personaje",
+    "chooseCharacter": "¿Con quién quieres hablar?",
     "presetRemoved": "Preset eliminado",
     "deletePreset": "Eliminar",
     "deletePresetConfirm": "Esto no se puede deshacer.",

--- a/lib/i18n/dictionaries/fr.json
+++ b/lib/i18n/dictionaries/fr.json
@@ -334,7 +334,7 @@
     "configurationUpdateError": "Erreur lors de la mise à jour de la configuration",
     "agentUnavailable": "Agent indisponible",
     "disconnected": "Déconnecté",
-    "chooseCharacter": "Choisissez votre personnage",
+    "chooseCharacter": "À qui voulez-vous parler ?",
     "presetRemoved": "Preset supprimé",
     "deletePreset": "Supprimer",
     "deletePresetConfirm": "Cette action est irréversible.",

--- a/lib/i18n/dictionaries/it.json
+++ b/lib/i18n/dictionaries/it.json
@@ -334,7 +334,7 @@
     "configurationUpdateError": "Errore durante l'aggiornamento della configurazione",
     "agentUnavailable": "Agente non disponibile",
     "disconnected": "Disconnesso",
-    "chooseCharacter": "Scegli il tuo personaggio",
+    "chooseCharacter": "Con chi vuoi parlare?",
     "presetRemoved": "Preset rimosso",
     "deletePreset": "Elimina",
     "deletePresetConfirm": "Questa azione non può essere annullata.",


### PR DESCRIPTION
Update the call page chooseCharacter key across all 6 supported languages:
- en: Who do you want to talk to?
- es: ¿Con quién quieres hablar?
- fr: À qui voulez-vous parler ?
- de: Mit wem möchtest du sprechen?
- da: Hvem vil du tale med?
- it: Con chi vuoi parlare?

Closes #260