### PR TITLE
[codex] chore(release): prepare 2026.4.10

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,24 @@
 
 Completed releases are documented here in reverse chronological order.
 
+## [2026.4.10] - 2026-04-10
+
+### Added
+
+#### Internal
+
+- Added a `/cli/login` exchange flow so SexyVoice CLI can open a browser,
+  let you choose or rotate an API key, and redeem the new key without
+  manual copy/paste. [#337](https://github.com/gianpaj/sexyvoice/pull/337)
+
+### Changed
+
+#### Internal
+
+- Refreshed the shared Generate button with a shimmer loading state and
+  keyboard shortcut hint across dashboard voice generation and cloning
+  flows. [#340](https://github.com/gianpaj/sexyvoice/pull/340)
+
 ## [2026.4.7] - 2026-04-07
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "version": "2026.4.7",
+  "version": "2026.4.10",
   "scripts": {
     "dev": "next dev",
     "prebuild": "pnpm run check-translations && pnpm run build:content",

--- a/scripts/create-release.sh
+++ b/scripts/create-release.sh
@@ -2,8 +2,8 @@
 
 set -euo pipefail
 
-VERSION=2026.4.7
-TAG=2026-04-07
+VERSION=2026.4.10
+TAG=2026-04-10
 
 test "$(node -p "require('./package.json').version")" = "$VERSION"
 


### PR DESCRIPTION
## Summary
- add the 2026.4.10 changelog entry using changes merged after the 2026-04-07 release tag
- bump `package.json` to `2026.4.10`
- align `scripts/create-release.sh` with the new version and tag

## Validation
- `node -p "require('./package.json').version"`
- `bash -n scripts/create-release.sh`
- `git diff --check`
