### PR TITLE
fix(daily-stats): paginate audio_files and call_sessions all-time duration queries

### DIFF
--- a/.github/workflows/deploy-telegram-bot.yml
+++ b/.github/workflows/deploy-telegram-bot.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.2.2
 
       - name: Setup Deno
-        uses: denoland/setup-deno@v1
+        uses: denoland/setup-deno@d3305a5580004f63d8dba6c60b2ac8d0960efc45 # v1
 
       - name: Install deployctl
         run: deno install -gArf jsr:@deno/deployctl

--- a/.github/workflows/deploy-telegram-bot.yml
+++ b/.github/workflows/deploy-telegram-bot.yml
@@ -26,6 +26,7 @@ jobs:
 
       - name: Deploy to Deno Deploy
         working-directory: apps/web/supabase/functions/telegram-bot
-        run: deployctl deploy --project=sv-telegram-bot --entrypoint=./index.ts --prod --token=$DENO_TOKEN
+        run: deployctl deploy --project=sv-telegram-bot --entrypoint=./index.ts --prod
+          --token=$DENO_TOKEN
         env:
           DENO_TOKEN: ${{ secrets.DENO_TOKEN }}

--- a/.github/workflows/deploy-telegram-bot.yml
+++ b/.github/workflows/deploy-telegram-bot.yml
@@ -1,0 +1,31 @@
+name: Deploy Telegram Bot
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'apps/web/supabase/functions/telegram-bot/**'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Deno
+        uses: denoland/setup-deno@v1
+
+      - name: Install deployctl
+        run: deno install -gArf jsr:@deno/deployctl
+
+      - name: Deploy to Deno Deploy
+        working-directory: apps/web/supabase/functions/telegram-bot
+        run: deployctl deploy --project=sv-telegram-bot --entrypoint=./index.ts --prod --token=$DENO_TOKEN
+        env:
+          DENO_TOKEN: ${{ secrets.DENO_TOKEN }}

--- a/apps/web/app/[lang]/(dashboard)/dashboard/credits/page.tsx
+++ b/apps/web/app/[lang]/(dashboard)/dashboard/credits/page.tsx
@@ -1,24 +1,24 @@
-import { captureException } from "@sentry/nextjs";
-import { ExternalLink, Sparkles } from "lucide-react";
-import Link from "next/link";
-import Script from "next/script";
-import { getMessages } from "next-intl/server";
-import type Stripe from "stripe";
+import { captureException } from '@sentry/nextjs';
+import { ExternalLink, Sparkles } from 'lucide-react';
+import Link from 'next/link';
+import Script from 'next/script';
+import { getMessages } from 'next-intl/server';
+import type Stripe from 'stripe';
 
-import { Button } from "@/components/ui/button";
-import type { Locale } from "@/lib/i18n/i18n-config";
-import { getCustomerData } from "@/lib/redis/queries";
-import { SUBSCRIPTION_BONUS_MULTIPLIER } from "@/lib/stripe/pricing";
+import { Button } from '@/components/ui/button';
+import type { Locale } from '@/lib/i18n/i18n-config';
+import { getCustomerData } from '@/lib/redis/queries';
+import { SUBSCRIPTION_BONUS_MULTIPLIER } from '@/lib/stripe/pricing';
 import {
   createCustomerSession,
   createOrRetrieveCustomer,
   refreshCustomerSubscriptionData,
-} from "@/lib/stripe/stripe-admin";
-import { getUserById } from "@/lib/supabase/queries";
-import { createClient } from "@/lib/supabase/server";
-import { CreditHistory } from "./credit-history";
-import { CreditTopup } from "./credit-topup";
-import { TopupStatus } from "./topup-status";
+} from '@/lib/stripe/stripe-admin';
+import { getUserById } from '@/lib/supabase/queries';
+import { createClient } from '@/lib/supabase/server';
+import { CreditHistory } from './credit-history';
+import { CreditTopup } from './credit-topup';
+import { TopupStatus } from './topup-status';
 
 export default async function CreditsPage(props: {
   params: Promise<{ lang: Locale }>;
@@ -31,7 +31,7 @@ export default async function CreditsPage(props: {
 
   const userData = user && (await getUserById(user.id));
   if (!(user && userData)) {
-    throw new Error("User not found");
+    throw new Error('User not found');
   }
 
   const stripeId = await createOrRetrieveCustomer(
@@ -41,10 +41,10 @@ export default async function CreditsPage(props: {
   );
 
   if (!stripeId) {
-    const error = new Error("Failed to create or retrieve Stripe customer.");
+    const error = new Error('Failed to create or retrieve Stripe customer.');
     console.error(error.message);
     captureException(error, {
-      level: "error",
+      level: 'error',
       user: { id: user.id, email: user.email },
     });
     throw error;
@@ -54,15 +54,15 @@ export default async function CreditsPage(props: {
 
   let customerData = await getCustomerData(stripeId);
   let shouldShowPricingTable =
-    !customerData || customerData.status !== "active";
+    !customerData || customerData.status !== 'active';
   let clientSecret: Stripe.Response<Stripe.CustomerSession> | null = null;
 
   if (shouldShowPricingTable) {
     try {
       customerData = await refreshCustomerSubscriptionData(stripeId);
-      shouldShowPricingTable = customerData.status !== "active";
+      shouldShowPricingTable = customerData.status !== 'active';
     } catch (error) {
-      console.error("Failed to refresh Stripe subscription data", error);
+      console.error('Failed to refresh Stripe subscription data', error);
       shouldShowPricingTable = false;
     }
   }
@@ -72,10 +72,10 @@ export default async function CreditsPage(props: {
   }
 
   const { data: existingTransactions } = await supabase
-    .from("credit_transactions")
-    .select("id, created_at, description, type, amount")
-    .eq("user_id", user.id)
-    .order("created_at", { ascending: false })
+    .from('credit_transactions')
+    .select('id, created_at, description, type, amount')
+    .eq('user_id', user.id)
+    .order('created_at', { ascending: false })
     .limit(100);
 
   return (
@@ -120,7 +120,7 @@ export default async function CreditsPage(props: {
           <Sparkles className="size-5 shrink-0 text-yellow-500" />
           <span>
             {dict.sidebar.subscriptionDiscount.replace(
-              "{discount}",
+              '{discount}',
               String(Math.round((SUBSCRIPTION_BONUS_MULTIPLIER - 1) * 100)),
             )}
           </span>

--- a/apps/web/app/[lang]/(dashboard)/dashboard/generate/generateui.client.test.tsx
+++ b/apps/web/app/[lang]/(dashboard)/dashboard/generate/generateui.client.test.tsx
@@ -1,17 +1,17 @@
 // @vitest-environment jsdom
-import "@testing-library/jest-dom/vitest";
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import '@testing-library/jest-dom/vitest';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
 
-import { GenerateUI } from "./generateui.client";
+import { GenerateUI } from './generateui.client';
 
 const mockVoiceSelector = vi.fn();
 const mockAudioGenerator = vi.fn();
 
-vi.mock("@/components/voice-selector", () => ({
+vi.mock('@/components/voice-selector', () => ({
   VoiceSelector: (
     props: React.ComponentProps<
-      typeof import("@/components/voice-selector").VoiceSelector
+      typeof import('@/components/voice-selector').VoiceSelector
     >,
   ) => {
     mockVoiceSelector(props);
@@ -19,10 +19,10 @@ vi.mock("@/components/voice-selector", () => ({
   },
 }));
 
-vi.mock("@/components/audio-generator", () => ({
+vi.mock('@/components/audio-generator', () => ({
   AudioGenerator: (
     props: React.ComponentProps<
-      typeof import("@/components/audio-generator").AudioGenerator
+      typeof import('@/components/audio-generator').AudioGenerator
     >,
   ) => {
     mockAudioGenerator(props);
@@ -30,85 +30,85 @@ vi.mock("@/components/audio-generator", () => ({
   },
 }));
 
-vi.mock("../clone/audio-provider", () => ({
+vi.mock('../clone/audio-provider', () => ({
   AudioProvider: ({ children }: { children: React.ReactNode }) => (
     <>{children}</>
   ),
 }));
 
 const baseDict = {
-  title: "Generate audio",
-  textAreaPlaceholder: "Enter text",
-  estimateCreditsButton: "Estimate credits",
-  ctaButton: "Generate",
-  generating: "Generating",
-  cancel: "Cancel",
-  playAudio: "Play audio",
-  resetPlayer: "Reset player",
-  downloadAudio: "Download audio",
-  notEnoughCredits: "Not enough credits",
-  success: "Success",
-  error: "Something went wrong",
-  errorEstimating: "Failed to estimate credits",
-  dailyLimitError: "Daily limit reached (__COUNT__)",
+  title: 'Generate audio',
+  textAreaPlaceholder: 'Enter text',
+  estimateCreditsButton: 'Estimate credits',
+  ctaButton: 'Generate',
+  generating: 'Generating',
+  cancel: 'Cancel',
+  playAudio: 'Play audio',
+  resetPlayer: 'Reset player',
+  downloadAudio: 'Download audio',
+  notEnoughCredits: 'Not enough credits',
+  success: 'Success',
+  error: 'Something went wrong',
+  errorEstimating: 'Failed to estimate credits',
+  dailyLimitError: 'Daily limit reached (__COUNT__)',
   voiceSelector: {
-    title: "Choose voice",
-    description: "Pick a voice for generation",
-    geminiInfo: "Gemini voice info",
-    grokInfo: "Grok voice info",
-    toolTipEmotionTags: "Emotion tags",
-    selectStyleTextareaPlaceholder: "Describe the speaking style",
+    title: 'Choose voice',
+    description: 'Pick a voice for generation',
+    geminiInfo: 'Gemini voice info',
+    grokInfo: 'Grok voice info',
+    toolTipEmotionTags: 'Emotion tags',
+    selectStyleTextareaPlaceholder: 'Describe the speaking style',
   },
   grok: {
-    helperText: "Use Grok tags to control delivery.",
-    inlineEffectPlaceholder: "Insert tags",
-    wrappingEffectPlaceholder: "Wrap selected text",
-    formatPlaceholder: "Select format",
+    helperText: 'Use Grok tags to control delivery.',
+    inlineEffectPlaceholder: 'Insert tags',
+    wrappingEffectPlaceholder: 'Wrap selected text',
+    formatPlaceholder: 'Select format',
     effects: {
-      pause: "Pause",
-      longPause: "Long pause",
-      humTune: "Hum tune",
-      laugh: "Laugh",
-      chuckle: "Chuckle",
-      giggle: "Giggle",
-      cry: "Cry",
-      tsk: "Tsk",
-      tongueClick: "Tongue click",
-      lipSmack: "Lip smack",
-      breath: "Breath",
-      inhale: "Inhale",
-      exhale: "Exhale",
-      sigh: "Sigh",
+      pause: 'Pause',
+      longPause: 'Long pause',
+      humTune: 'Hum tune',
+      laugh: 'Laugh',
+      chuckle: 'Chuckle',
+      giggle: 'Giggle',
+      cry: 'Cry',
+      tsk: 'Tsk',
+      tongueClick: 'Tongue click',
+      lipSmack: 'Lip smack',
+      breath: 'Breath',
+      inhale: 'Inhale',
+      exhale: 'Exhale',
+      sigh: 'Sigh',
     },
   },
 } as const;
 
 function createVoice(
-  overrides: Partial<Tables<"voices">> = {},
-): Tables<"voices"> {
+  overrides: Partial<Tables<'voices'>> = {},
+): Tables<'voices'> {
   return {
-    id: "voice-id",
-    name: "tara",
-    language: "en",
+    id: 'voice-id',
+    name: 'tara',
+    language: 'en',
     model:
-      "lucataco/orpheus-3b-0.1-ft:79f2a473e6a9720716a473d9b2f2951437dbf91dc02ccb7079fb3d89b881207f",
+      'lucataco/orpheus-3b-0.1-ft:79f2a473e6a9720716a473d9b2f2951437dbf91dc02ccb7079fb3d89b881207f',
     description: null,
     type: null,
     sort_order: 0,
-    feature: "tts",
+    feature: 'tts',
     sample_url: null,
     sample_prompt: null,
     user_id: null,
     created_at: null,
     ...overrides,
-  } as Tables<"voices">;
+  } as Tables<'voices'>;
 }
 
-function renderGenerateUI(publicVoices: Tables<"voices">[]) {
+function renderGenerateUI(publicVoices: Tables<'voices'>[]) {
   return render(
     <GenerateUI
       dict={
-        baseDict as unknown as (typeof import("@/messages/en.json"))["generate"]
+        baseDict as unknown as typeof import('@/messages/en.json')['generate']
       }
       hasEnoughCredits
       isPaidUser
@@ -117,18 +117,18 @@ function renderGenerateUI(publicVoices: Tables<"voices">[]) {
   );
 }
 
-describe("GenerateUI", () => {
-  it("passes Gemini style state to both child components for Gemini voices", () => {
+describe('GenerateUI', () => {
+  it('passes Gemini style state to both child components for Gemini voices', () => {
     const geminiVoice = createVoice({
-      id: "voice-gemini",
-      name: "kore",
-      model: "gpro",
+      id: 'voice-gemini',
+      name: 'kore',
+      model: 'gpro',
     });
 
     renderGenerateUI([geminiVoice]);
 
-    expect(screen.getByTestId("voice-selector")).toBeInTheDocument();
-    expect(screen.getByTestId("audio-generator")).toBeInTheDocument();
+    expect(screen.getByTestId('voice-selector')).toBeInTheDocument();
+    expect(screen.getByTestId('audio-generator')).toBeInTheDocument();
 
     expect(mockVoiceSelector).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -145,11 +145,11 @@ describe("GenerateUI", () => {
     );
   });
 
-  it("omits Gemini style and passes Grok codec only to audio generator for Grok voices", () => {
+  it('omits Gemini style and passes Grok codec only to audio generator for Grok voices', () => {
     const grokVoice = createVoice({
-      id: "voice-grok",
-      name: "eve",
-      model: "grok",
+      id: 'voice-grok',
+      name: 'eve',
+      model: 'grok',
     });
 
     renderGenerateUI([grokVoice]);
@@ -169,12 +169,12 @@ describe("GenerateUI", () => {
     );
   });
 
-  it("omits Gemini style and Grok codec for Replicate voices", () => {
+  it('omits Gemini style and Grok codec for Replicate voices', () => {
     const replicateVoice = createVoice({
-      id: "voice-replicate",
-      name: "tara",
+      id: 'voice-replicate',
+      name: 'tara',
       model:
-        "lucataco/orpheus-3b-0.1-ft:79f2a473e6a9720716a473d9b2f2951437dbf91dc02ccb7079fb3d89b881207f",
+        'lucataco/orpheus-3b-0.1-ft:79f2a473e6a9720716a473d9b2f2951437dbf91dc02ccb7079fb3d89b881207f',
     });
 
     renderGenerateUI([replicateVoice]);
@@ -194,22 +194,22 @@ describe("GenerateUI", () => {
     );
   });
 
-  it("uses the featured voice as the initial selected voice when present", () => {
+  it('uses the featured voice as the initial selected voice when present', () => {
     const firstVoice = createVoice({
-      id: "voice-first",
-      name: "tara",
+      id: 'voice-first',
+      name: 'tara',
       model:
-        "lucataco/orpheus-3b-0.1-ft:79f2a473e6a9720716a473d9b2f2951437dbf91dc02ccb7079fb3d89b881207f",
+        'lucataco/orpheus-3b-0.1-ft:79f2a473e6a9720716a473d9b2f2951437dbf91dc02ccb7079fb3d89b881207f',
     });
     const featuredVoice = createVoice({
-      id: "voice-featured",
-      name: "eve",
-      model: "grok",
+      id: 'voice-featured',
+      name: 'eve',
+      model: 'grok',
     });
     const thirdVoice = createVoice({
-      id: "voice-third",
-      name: "kore",
-      model: "gpro",
+      id: 'voice-third',
+      name: 'kore',
+      model: 'gpro',
     });
 
     renderGenerateUI([firstVoice, featuredVoice, thirdVoice]);
@@ -227,17 +227,17 @@ describe("GenerateUI", () => {
     );
   });
 
-  it("uses the first public voice as the initial selected voice when no featured voice is present", () => {
+  it('uses the first public voice as the initial selected voice when no featured voice is present', () => {
     const firstVoice = createVoice({
-      id: "voice-first",
-      name: "tara",
+      id: 'voice-first',
+      name: 'tara',
       model:
-        "lucataco/orpheus-3b-0.1-ft:79f2a473e6a9720716a473d9b2f2951437dbf91dc02ccb7079fb3d89b881207f",
+        'lucataco/orpheus-3b-0.1-ft:79f2a473e6a9720716a473d9b2f2951437dbf91dc02ccb7079fb3d89b881207f',
     });
     const secondVoice = createVoice({
-      id: "voice-second",
-      name: "kore",
-      model: "gpro",
+      id: 'voice-second',
+      name: 'kore',
+      model: 'gpro',
     });
 
     renderGenerateUI([firstVoice, secondVoice]);
@@ -255,7 +255,7 @@ describe("GenerateUI", () => {
     );
   });
 
-  it("falls back to no selected voice when the list is empty", () => {
+  it('falls back to no selected voice when the list is empty', () => {
     renderGenerateUI([]);
 
     expect(mockVoiceSelector).toHaveBeenCalledWith(

--- a/apps/web/app/api/daily-stats/queries.ts
+++ b/apps/web/app/api/daily-stats/queries.ts
@@ -1,0 +1,200 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+import type { DailyStatsProfileRelation } from './types';
+import { fetchAllPages, PAGE_SIZE } from './utils';
+
+export const VOICE_CLONING_MODELS = [
+  'resemble-ai/chatterbox-multilingual',
+  'resemble-ai/chatterbox',
+  'voxtral-mini-tts-2603',
+] as const;
+
+export interface DailyStatsCreditTransaction {
+  created_at: string;
+  description: string | null;
+  id: string;
+  metadata: Json;
+  profiles: DailyStatsProfileRelation;
+  type: 'purchase' | 'freemium' | 'topup' | 'refund';
+  user_id: string;
+}
+
+export interface DailyStatsUsageEvent {
+  credits_used: number;
+  id: string;
+  occurred_at: string;
+  profiles: DailyStatsProfileRelation;
+  source_type: string;
+  user_id: string;
+}
+
+export interface DailyStatsAudioFile {
+  created_at: string | null;
+  id: string;
+  model: string | null;
+}
+
+export interface DailyStatsProfile {
+  created_at: string | null;
+  id: string;
+  username: string | null;
+}
+
+export interface DailyStatsCallSessionDuration {
+  duration_seconds: number;
+}
+
+type DailyStatsSupabaseClient = SupabaseClient;
+
+export function getUsageEventsInRange(
+  supabase: DailyStatsSupabaseClient,
+  start: Date,
+  end: Date,
+): Promise<DailyStatsUsageEvent[]> {
+  return fetchAllPages<DailyStatsUsageEvent>((offset) =>
+    supabase
+      .from('usage_events')
+      .select(
+        'id, user_id, source_type, credits_used, occurred_at, profiles(username)',
+      )
+      .gte('occurred_at', start.toISOString())
+      .lt('occurred_at', end.toISOString())
+      .order('occurred_at', { ascending: true })
+      .range(offset, offset + PAGE_SIZE - 1)
+      .then(({ data, error }) => ({
+        data: (data as DailyStatsUsageEvent[] | null) ?? null,
+        error,
+      })),
+  );
+}
+
+export function getAudioFilesInRange(
+  supabase: DailyStatsSupabaseClient,
+  start: Date,
+  end: Date,
+): Promise<DailyStatsAudioFile[]> {
+  return fetchAllPages<DailyStatsAudioFile>((offset) =>
+    supabase
+      .from('audio_files')
+      .select('id, created_at, model')
+      .gte('created_at', start.toISOString())
+      .lt('created_at', end.toISOString())
+      .order('created_at', { ascending: true })
+      .order('id', { ascending: true })
+      .range(offset, offset + PAGE_SIZE - 1)
+      .then(({ data, error }) => ({
+        data: (data as DailyStatsAudioFile[] | null) ?? null,
+        error,
+      })),
+  );
+}
+
+export function getClonedAudioFilesInRange(
+  supabase: DailyStatsSupabaseClient,
+  start: Date,
+  end: Date,
+): Promise<Array<{ created_at: string | null; id: string }>> {
+  return fetchAllPages<{ created_at: string | null; id: string }>((offset) =>
+    supabase
+      .from('audio_files')
+      .select('id, created_at')
+      .in('model', [...VOICE_CLONING_MODELS])
+      .gte('created_at', start.toISOString())
+      .lt('created_at', end.toISOString())
+      .order('created_at', { ascending: true })
+      .order('id', { ascending: true })
+      .range(offset, offset + PAGE_SIZE - 1)
+      .then(({ data, error }) => ({
+        data:
+          (data as Array<{ created_at: string | null; id: string }> | null) ??
+          null,
+        error,
+      })),
+  );
+}
+
+export function getProfilesInRange(
+  supabase: DailyStatsSupabaseClient,
+  start: Date,
+  end: Date,
+): Promise<DailyStatsProfile[]> {
+  return fetchAllPages<DailyStatsProfile>((offset) =>
+    supabase
+      .from('profiles')
+      .select('id, created_at, username')
+      .gte('created_at', start.toISOString())
+      .lt('created_at', end.toISOString())
+      .order('created_at', { ascending: true })
+      .range(offset, offset + PAGE_SIZE - 1)
+      .then(({ data, error }) => ({
+        data: (data as DailyStatsProfile[] | null) ?? null,
+        error,
+      })),
+  );
+}
+
+export function getCreditTransactionsInRange(
+  supabase: DailyStatsSupabaseClient,
+  start: Date,
+  end: Date,
+): Promise<DailyStatsCreditTransaction[]> {
+  return fetchAllPages<DailyStatsCreditTransaction>((offset) =>
+    supabase
+      .from('credit_transactions')
+      .select(
+        'id, user_id, created_at, type, description, amount, metadata, profiles(username)',
+      )
+      .in('type', ['purchase', 'topup', 'refund'])
+      .not('description', 'ilike', '%manual%')
+      .gte('created_at', start.toISOString())
+      .lt('created_at', end.toISOString())
+      .order('created_at', { ascending: true })
+      .range(offset, offset + PAGE_SIZE - 1)
+      .then(({ data, error }) => ({
+        data: (data as DailyStatsCreditTransaction[] | null) ?? null,
+        error,
+      })),
+  );
+}
+
+export function getPurchaseTransactionsBefore(
+  supabase: DailyStatsSupabaseClient,
+  end: Date,
+): Promise<DailyStatsCreditTransaction[]> {
+  return fetchAllPages<DailyStatsCreditTransaction>((offset) =>
+    supabase
+      .from('credit_transactions')
+      .select(
+        'id, user_id, created_at, type, description, amount, metadata, profiles(username)',
+      )
+      .in('type', ['purchase', 'topup'])
+      .not('description', 'ilike', '%manual%')
+      .lt('created_at', end.toISOString())
+      .order('created_at', { ascending: true })
+      .order('id', { ascending: true })
+      .range(offset, offset + PAGE_SIZE - 1)
+      .then(({ data, error }) => ({
+        data: (data as DailyStatsCreditTransaction[] | null) ?? null,
+        error,
+      })),
+  );
+}
+
+export function getCallSessionDurationsBefore(
+  supabase: DailyStatsSupabaseClient,
+  end: Date,
+): Promise<DailyStatsCallSessionDuration[]> {
+  return fetchAllPages<DailyStatsCallSessionDuration>((offset) =>
+    supabase
+      .from('call_sessions')
+      .select('duration_seconds')
+      .lt('started_at', end.toISOString())
+      .order('started_at', { ascending: true })
+      .order('id', { ascending: true })
+      .range(offset, offset + PAGE_SIZE - 1)
+      .then(({ data, error }) => ({
+        data: (data as DailyStatsCallSessionDuration[] | null) ?? null,
+        error,
+      })),
+  );
+}

--- a/apps/web/app/api/daily-stats/queries.ts
+++ b/apps/web/app/api/daily-stats/queries.ts
@@ -60,6 +60,7 @@ export function getUsageEventsInRange(
       .gte('occurred_at', start.toISOString())
       .lt('occurred_at', end.toISOString())
       .order('occurred_at', { ascending: true })
+      .order('id', { ascending: true })
       .range(offset, offset + PAGE_SIZE - 1)
       .then(({ data, error }) => ({
         data: (data as DailyStatsUsageEvent[] | null) ?? null,
@@ -125,6 +126,7 @@ export function getProfilesInRange(
       .gte('created_at', start.toISOString())
       .lt('created_at', end.toISOString())
       .order('created_at', { ascending: true })
+      .order('id', { ascending: true })
       .range(offset, offset + PAGE_SIZE - 1)
       .then(({ data, error }) => ({
         data: (data as DailyStatsProfile[] | null) ?? null,
@@ -149,6 +151,7 @@ export function getCreditTransactionsInRange(
       .gte('created_at', start.toISOString())
       .lt('created_at', end.toISOString())
       .order('created_at', { ascending: true })
+      .order('id', { ascending: true })
       .range(offset, offset + PAGE_SIZE - 1)
       .then(({ data, error }) => ({
         data: (data as DailyStatsCreditTransaction[] | null) ?? null,

--- a/apps/web/app/api/daily-stats/queries.ts
+++ b/apps/web/app/api/daily-stats/queries.ts
@@ -10,6 +10,7 @@ export const VOICE_CLONING_MODELS = [
 ] as const;
 
 export interface DailyStatsCreditTransaction {
+  amount: number;
   created_at: string;
   description: string | null;
   id: string;

--- a/apps/web/app/api/daily-stats/route.ts
+++ b/apps/web/app/api/daily-stats/route.ts
@@ -242,16 +242,9 @@ export async function GET(request: NextRequest) {
       callSessionsTotalCountResult,
       callSessionsAllTimeDurationResult,
     ] = await Promise.all([
-      // (audioYesterdayResult) Audio files yesterday with voice information
-      _timed(
-        `audio_files:yesterday ${previousDay.toISOString().slice(0, 10)}..${today.toISOString().slice(0, 10)}`,
-        supabase
-          .from('audio_files')
-          .select('id, created_at, model, voice_id, voices(name)')
-          .gte('created_at', previousDay.toISOString())
-          .lt('created_at', today.toISOString())
-          .then((result) => result),
-      ),
+      // (audioYesterdayResult) Placeholder; fetched below with pagination because
+      // Supabase caps result sets at 1000 rows per request
+      Promise.resolve({ data: null, error: null }),
 
       // (audioWeekResult) Audio files last 7 days
       _timed(
@@ -320,11 +313,9 @@ export async function GET(request: NextRequest) {
         .select('id', { count: 'exact', head: true })
         .lt('started_at', today.toISOString()),
 
-      // (callSessionsAllTimeDurationResult) All-time call sessions durations
-      supabase
-        .from('call_sessions')
-        .select('duration_seconds')
-        .lt('started_at', today.toISOString()),
+      // (callSessionsAllTimeDurationResult) Placeholder; fetched below with
+      // pagination because all-time sessions exceed 1000 rows
+      Promise.resolve({ data: null, error: null }),
     ]);
 
     // Fetch all usage events with pagination (Supabase limits to 1000 per request)
@@ -370,6 +361,82 @@ export async function GET(request: NextRequest) {
       data: await fetchAllUsageEvents(),
       error: null,
     };
+
+    // Fetch audio files yesterday with pagination (Supabase limits to 1000 per request)
+    const fetchAllAudioFilesYesterday = async () => {
+      const allAudio: {
+        id: string;
+        created_at: string;
+        model: string | null;
+        voice_id: string | null;
+        voices: { name: string } | null;
+      }[] = [];
+      const pageSize = 1000;
+      let offset = 0;
+      let hasMore = true;
+
+      while (hasMore) {
+        const { data, error } = await supabase
+          .from('audio_files')
+          .select('id, created_at, model, voice_id, voices(name)')
+          .gte('created_at', previousDay.toISOString())
+          .lt('created_at', today.toISOString())
+          .order('created_at', { ascending: true })
+          .range(offset, offset + pageSize - 1);
+
+        if (error) throw error;
+
+        if (data && data.length > 0) {
+          allAudio.push(...data);
+          offset += pageSize;
+          hasMore = data.length === pageSize;
+        } else {
+          hasMore = false;
+        }
+      }
+
+      return allAudio;
+    };
+
+    // Fetch all-time call session durations with pagination (Supabase limits to 1000 per request)
+    const fetchAllCallSessionDurationsAllTime = async () => {
+      const allDurations: { duration_seconds: number }[] = [];
+      const pageSize = 1000;
+      let offset = 0;
+      let hasMore = true;
+
+      while (hasMore) {
+        const { data, error } = await supabase
+          .from('call_sessions')
+          .select('duration_seconds')
+          .lt('started_at', today.toISOString())
+          .order('started_at', { ascending: true })
+          .range(offset, offset + pageSize - 1);
+
+        if (error) throw error;
+
+        if (data && data.length > 0) {
+          allDurations.push(...data);
+          offset += pageSize;
+          hasMore = data.length === pageSize;
+        } else {
+          hasMore = false;
+        }
+      }
+
+      return allDurations;
+    };
+
+    [audioYesterdayResult, callSessionsAllTimeDurationResult] = await Promise.all([
+      _timed(
+        `audio_files:yesterday paginated ${previousDay.toISOString().slice(0, 10)}..${today.toISOString().slice(0, 10)}`,
+        fetchAllAudioFilesYesterday().then((data) => ({ data, error: null })),
+      ),
+      _timed(
+        `call_sessions:all_time_durations paginated < ${today.toISOString().slice(0, 10)}`,
+        fetchAllCallSessionDurationsAllTime().then((data) => ({ data, error: null })),
+      ),
+    ]);
 
     // Fetch all credit transactions with pagination (Supabase limits to 1000 per request)
     const fetchAllProfilesInRange = async (

--- a/apps/web/app/api/daily-stats/route.ts
+++ b/apps/web/app/api/daily-stats/route.ts
@@ -227,11 +227,9 @@ export async function GET(request: NextRequest) {
     // Fetch data in parallel - combine related queries and filter in memory
     [
       // Audio files - fetch for last specific ranges
-      audioYesterdayResult,
       audioWeekResult,
       audioTotalCountResult,
       clonesResult,
-      profilesRecentResult,
       profilesTotalCountResult,
       apiKeysYesterdayResult,
 
@@ -240,12 +238,7 @@ export async function GET(request: NextRequest) {
       // Call sessions - fetch for last 7 days (includes yesterday)
       callSessionsWeekResult,
       callSessionsTotalCountResult,
-      callSessionsAllTimeDurationResult,
     ] = await Promise.all([
-      // (audioYesterdayResult) Placeholder; fetched below with pagination because
-      // Supabase caps result sets at 1000 rows per request
-      Promise.resolve({ data: null, error: null }),
-
       // (audioWeekResult) Audio files last 7 days
       _timed(
         `audio_files:week_count ${sevenDaysAgo.toISOString().slice(0, 10)}..${today.toISOString().slice(0, 10)}`,
@@ -279,10 +272,6 @@ export async function GET(request: NextRequest) {
           .then((result) => result),
       ),
 
-      // (profilesRecentResult) Placeholder; fetched below with pagination because
-      // Supabase caps result sets at 1000 rows per request
-      Promise.resolve({ data: null, error: null }),
-
       // (profilesTotalCountResult) Total profiles count
       supabase
         .from('profiles')
@@ -313,9 +302,6 @@ export async function GET(request: NextRequest) {
         .select('id', { count: 'exact', head: true })
         .lt('started_at', today.toISOString()),
 
-      // (callSessionsAllTimeDurationResult) Placeholder; fetched below with
-      // pagination because all-time sessions exceed 1000 rows
-      Promise.resolve({ data: null, error: null }),
     ]);
 
     // Fetch all usage events with pagination (Supabase limits to 1000 per request)
@@ -427,18 +413,6 @@ export async function GET(request: NextRequest) {
       return allDurations;
     };
 
-    [audioYesterdayResult, callSessionsAllTimeDurationResult] = await Promise.all([
-      _timed(
-        `audio_files:yesterday paginated ${previousDay.toISOString().slice(0, 10)}..${today.toISOString().slice(0, 10)}`,
-        fetchAllAudioFilesYesterday().then((data) => ({ data, error: null })),
-      ),
-      _timed(
-        `call_sessions:all_time_durations paginated < ${today.toISOString().slice(0, 10)}`,
-        fetchAllCallSessionDurationsAllTime().then((data) => ({ data, error: null })),
-      ),
-    ]);
-
-    // Fetch all credit transactions with pagination (Supabase limits to 1000 per request)
     const fetchAllProfilesInRange = async (
       start: Date,
       end: Date,
@@ -481,10 +455,17 @@ export async function GET(request: NextRequest) {
       return allProfiles;
     };
 
-    profilesRecentResult = {
-      data: await fetchAllProfilesInRange(sevenDaysAgo, today),
-      error: null,
-    };
+    [audioYesterdayResult, callSessionsAllTimeDurationResult, profilesRecentResult] = await Promise.all([
+      _timed(
+        `audio_files:yesterday paginated ${previousDay.toISOString().slice(0, 10)}..${today.toISOString().slice(0, 10)}`,
+        fetchAllAudioFilesYesterday().then((data) => ({ data, error: null })),
+      ),
+      _timed(
+        `call_sessions:all_time_durations paginated < ${today.toISOString().slice(0, 10)}`,
+        fetchAllCallSessionDurationsAllTime().then((data) => ({ data, error: null })),
+      ),
+      fetchAllProfilesInRange(sevenDaysAgo, today).then((data) => ({ data, error: null })),
+    ]);
 
     const fetchCreditTransactionsInRange = async (
       start: Date,

--- a/apps/web/app/api/daily-stats/route.ts
+++ b/apps/web/app/api/daily-stats/route.ts
@@ -198,7 +198,7 @@ export async function GET(request: NextRequest) {
       callSessionsWeekResult = cached.callSessionsWeekResult;
       callSessionsTotalCountResult = cached.callSessionsTotalCountResult;
       callSessionsAllTimeDurationResult =
-        cached.callSessionsAllTimeDurationResult;
+        cached.callSessionsAllTimeDurationResult ?? { data: [], error: null };
       usageEventsWeekResult = cached.usageEventsWeekResult;
       loadedFromValidCache = true;
     } else {
@@ -210,8 +210,9 @@ export async function GET(request: NextRequest) {
     }
   }
 
+  const supabase = createAdminClient();
+
   if (!loadedFromValidCache) {
-    const supabase = createAdminClient();
 
     // Fetch data in parallel - combine related queries and filter in memory
     [
@@ -654,7 +655,7 @@ export async function GET(request: NextRequest) {
 
   const nextPayingSubscriberUserId = nextSubscriptionDueForPayment
     ? (
-        await createAdminClient()
+        await supabase
           .from('profiles')
           .select('id')
           .eq('stripe_id', nextSubscriptionDueForPayment.customerId)

--- a/apps/web/app/api/daily-stats/route.ts
+++ b/apps/web/app/api/daily-stats/route.ts
@@ -650,10 +650,20 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ ok: true });
   }
 
+  const nextPayingSubscriberUserId = nextSubscriptionDueForPayment
+    ? (
+        await createAdminClient()
+          .from('profiles')
+          .select('id')
+          .eq('stripe_id', nextSubscriptionDueForPayment.customerId)
+          .single()
+      ).data?.id
+    : null;
+
   const nextPayingSubscriber =
-    nextSubscriptionDueForPayment &&
+    nextPayingSubscriberUserId &&
     allTimePurchaseTransactions.find(
-      (t) => t.user_id === nextSubscriptionDueForPayment?.customerId,
+      (t) => t.user_id === nextPayingSubscriberUserId,
     );
 
   const cloneModelLabels = new Set(['Chatterbox', 'Voxtral Clone']);
@@ -1315,7 +1325,7 @@ export async function GET(request: NextRequest) {
     `💰 Revenue: $${totalAmountUsdToday.toFixed(2)} yesterday (${totalAmountUsdToday >= avg7dRevenue ? '↑' : '↓'}$${Math.abs(totalAmountUsdToday - avg7dRevenue).toFixed(2)} vs 7d avg)`,
     `  - 7d: $${total7dRevenue.toFixed(2)} (avg $${avg7dRevenue.toFixed(2)}/day) | All-time: $${totalAmountUsd.toFixed(0)}`,
     `  - 3mo avg MTD: $${avgPrevMtdRevenue.toFixed(0)} vs MTD: $${mtdRevenue.toFixed(0)} (${formatCurrencyChange(mtdRevenue, avgPrevMtdRevenue)})`,
-    `  - Subscribers: ${activeSubscribersCount} active | New subs: ${newSubscribersTodayCount} yesterday, ${newSubscribersWeekCount} in 7d | Next renewal: ${maskUsername(nextPayingSubscriber?.username)} on ${nextSubscriptionDueForPayment?.dueDate.slice(0, 10)}`,
+    `  - Subscribers: ${activeSubscribersCount} active | New subs: ${newSubscribersTodayCount} yesterday, ${newSubscribersWeekCount} in 7d | Next renewal: ${maskUsername(nextPayingSubscriber?.profiles?.username)} on ${nextSubscriptionDueForPayment?.dueDate.slice(0, 10)}`,
   ];
 
   const message = [

--- a/apps/web/app/api/daily-stats/route.ts
+++ b/apps/web/app/api/daily-stats/route.ts
@@ -484,6 +484,8 @@ export async function GET(request: NextRequest) {
   if (callSessionsWeekResult?.error) throw callSessionsWeekResult.error;
   if (callSessionsTotalCountResult?.error)
     throw callSessionsTotalCountResult.error;
+  if (callSessionsAllTimeDurationResult?.error)
+    throw callSessionsAllTimeDurationResult.error;
   if (!usageEventsWeekResult) {
     throw new Error(
       'usageEventsWeekResult was not loaded after cache validation/fetch',

--- a/apps/web/app/api/daily-stats/route.ts
+++ b/apps/web/app/api/daily-stats/route.ts
@@ -302,6 +302,7 @@ export async function GET(request: NextRequest) {
           .gte('occurred_at', sevenDaysAgo.toISOString())
           .lt('occurred_at', today.toISOString())
           .order('occurred_at', { ascending: true })
+          .order('id', { ascending: true })
           .range(offset, offset + PAGE_SIZE - 1),
       );
 
@@ -353,6 +354,7 @@ export async function GET(request: NextRequest) {
           .gte('created_at', start.toISOString())
           .lt('created_at', end.toISOString())
           .order('created_at', { ascending: true })
+          .order('id', { ascending: true })
           .range(offset, offset + PAGE_SIZE - 1),
       );
 
@@ -395,6 +397,7 @@ export async function GET(request: NextRequest) {
           .gte('created_at', start.toISOString())
           .lt('created_at', end.toISOString())
           .order('created_at', { ascending: true })
+          .order('id', { ascending: true })
           .range(offset, offset + PAGE_SIZE - 1),
       );
 

--- a/apps/web/app/api/daily-stats/route.ts
+++ b/apps/web/app/api/daily-stats/route.ts
@@ -13,14 +13,22 @@ import {
   findNextSubscriptionDueForPayment,
 } from '@/lib/redis/queries';
 import { createAdminClient } from '@/lib/supabase/admin';
-import { getUserByStripeCustomerId } from '@/lib/supabase/queries';
 import type { UsageSourceType } from '@/lib/supabase/usage-queries';
 import {
+  _timed,
+  calculateUsageBreakdown,
+  countByDateRange,
+  fetchAllPages,
   filterByDateRange,
   formatChange,
   formatCompactNumber,
   formatCurrencyChange,
+  formatDuration,
+  formatDurationChange,
+  getFeatureHealthStatus,
   maskUsername,
+  normalizeModelName,
+  PAGE_SIZE,
   reduceAmountUsd,
   startOfDay,
   startOfMonth,
@@ -73,7 +81,6 @@ export async function GET(request: NextRequest) {
     dateParam = searchParams.get('date');
   }
 
-  const supabase = createAdminClient();
   const untilNow = dateParam ? new Date(dateParam) : new Date();
   const today = startOfDay(untilNow);
   const cacheReportDate = today.toISOString().slice(0, 10);
@@ -147,6 +154,7 @@ export async function GET(request: NextRequest) {
   // biome-ignore lint/suspicious/noExplicitAny: Cache data is dynamically typed
   let apiKeysYesterdayResult: any;
   let allCreditTransactions: CreditTransaction[] = [];
+  let allTimePurchaseTransactions: CreditTransaction[] = [];
   // biome-ignore lint/suspicious/noExplicitAny: Cache data is dynamically typed
   let activeSubscribersCount: any;
   // biome-ignore lint/suspicious/noExplicitAny: Cache data is dynamically typed
@@ -184,6 +192,7 @@ export async function GET(request: NextRequest) {
       profilesTotalCountResult = cached.profilesTotalCountResult;
       apiKeysYesterdayResult = cached.apiKeysYesterdayResult;
       allCreditTransactions = cached.allCreditTransactions;
+      allTimePurchaseTransactions = cached.allTimePurchaseTransactions ?? [];
       activeSubscribersCount = cached.activeSubscribersCount;
       nextSubscriptionDueForPayment = cached.nextSubscriptionDueForPayment;
       callSessionsWeekResult = cached.callSessionsWeekResult;
@@ -202,27 +211,7 @@ export async function GET(request: NextRequest) {
   }
 
   if (!loadedFromValidCache) {
-    // Helper to time individual queries
-    const _timed = async <T>(
-      label: string,
-      promise: PromiseLike<T>,
-    ): Promise<T> => {
-      const start = Date.now();
-      console.log(`⏱  [daily-stats] START  ${label}`);
-      try {
-        const result = await promise;
-        console.log(
-          `✅ [daily-stats] DONE   ${label} — ${Date.now() - start}ms`,
-        );
-        return result;
-      } catch (err) {
-        console.log(
-          `❌ [daily-stats] ERROR  ${label} — ${Date.now() - start}ms`,
-          err,
-        );
-        throw err;
-      }
-    };
+    const supabase = createAdminClient();
 
     // Fetch data in parallel - combine related queries and filter in memory
     [
@@ -301,25 +290,11 @@ export async function GET(request: NextRequest) {
         .from('call_sessions')
         .select('id', { count: 'exact', head: true })
         .lt('started_at', today.toISOString()),
-
     ]);
 
-    // Fetch all usage events with pagination (Supabase limits to 1000 per request)
-    const fetchAllUsageEvents = async () => {
-      const allEvents: {
-        id: string;
-        user_id: string;
-        source_type: string;
-        credits_used: number;
-        occurred_at: string;
-        profiles: { username: string } | null;
-      }[] = [];
-      const pageSize = 1000;
-      let offset = 0;
-      let hasMore = true;
-
-      while (hasMore) {
-        const { data, error } = await supabase
+    const fetchAllUsageEvents = async () =>
+      fetchAllPages<UsageEvent>((offset) =>
+        supabase
           .from('usage_events')
           .select(
             'id, user_id, source_type, credits_used, occurred_at, profiles(username)',
@@ -327,86 +302,35 @@ export async function GET(request: NextRequest) {
           .gte('occurred_at', sevenDaysAgo.toISOString())
           .lt('occurred_at', today.toISOString())
           .order('occurred_at', { ascending: true })
-          .range(offset, offset + pageSize - 1);
+          .range(offset, offset + PAGE_SIZE - 1),
+      );
 
-        if (error) throw error;
-
-        if (data && data.length > 0) {
-          allEvents.push(...data);
-          offset += pageSize;
-          hasMore = data.length === pageSize;
-        } else {
-          hasMore = false;
-        }
-      }
-
-      return allEvents;
-    };
-
-    // Fetch audio files yesterday with pagination (Supabase limits to 1000 per request)
-    const fetchAllAudioFilesYesterday = async () => {
-      const allAudio: {
+    const fetchAllAudioFilesYesterday = async () =>
+      fetchAllPages<{
         id: string;
         created_at: string | null;
         model: string | null;
-      }[] = [];
-      const pageSize = 1000;
-      let offset = 0;
-      let hasMore = true;
-
-      while (hasMore) {
-        const { data, error } = await supabase
+      }>((offset) =>
+        supabase
           .from('audio_files')
           .select('id, created_at, model')
           .gte('created_at', previousDay.toISOString())
           .lt('created_at', today.toISOString())
           .order('created_at', { ascending: true })
           .order('id', { ascending: true })
-          .range(offset, offset + pageSize - 1);
+          .range(offset, offset + PAGE_SIZE - 1),
+      );
 
-        if (error) throw error;
-
-        if (data && data.length > 0) {
-          allAudio.push(...data);
-          offset += pageSize;
-          hasMore = data.length === pageSize;
-        } else {
-          hasMore = false;
-        }
-      }
-
-      return allAudio;
-    };
-
-    // Fetch all-time call session durations with pagination (Supabase limits to 1000 per request)
-    const fetchAllCallSessionDurationsAllTime = async () => {
-      const allDurations: { duration_seconds: number }[] = [];
-      const pageSize = 1000;
-      let offset = 0;
-      let hasMore = true;
-
-      while (hasMore) {
-        const { data, error } = await supabase
+    const fetchAllCallSessionDurationsAllTime = async () =>
+      fetchAllPages<{ duration_seconds: number }>((offset) =>
+        supabase
           .from('call_sessions')
           .select('duration_seconds')
           .lt('started_at', today.toISOString())
           .order('started_at', { ascending: true })
           .order('id', { ascending: true })
-          .range(offset, offset + pageSize - 1);
-
-        if (error) throw error;
-
-        if (data && data.length > 0) {
-          allDurations.push(...data);
-          offset += pageSize;
-          hasMore = data.length === pageSize;
-        } else {
-          hasMore = false;
-        }
-      }
-
-      return allDurations;
-    };
+          .range(offset, offset + PAGE_SIZE - 1),
+      );
 
     const fetchAllProfilesInRange = async (
       start: Date,
@@ -417,40 +341,27 @@ export async function GET(request: NextRequest) {
         created_at: string | null;
         username: string | null;
       }[]
-    > => {
-      const allProfiles: {
+    > =>
+      fetchAllPages<{
         id: string;
         created_at: string | null;
         username: string | null;
-      }[] = [];
-      const pageSize = 1000;
-      let offset = 0;
-      let hasMore = true;
-
-      while (hasMore) {
-        const { data, error } = await supabase
+      }>((offset) =>
+        supabase
           .from('profiles')
           .select('id, created_at, username')
           .gte('created_at', start.toISOString())
           .lt('created_at', end.toISOString())
           .order('created_at', { ascending: true })
-          .range(offset, offset + pageSize - 1);
+          .range(offset, offset + PAGE_SIZE - 1),
+      );
 
-        if (error) throw error;
-
-        if (data && data.length > 0) {
-          allProfiles.push(...data);
-          offset += pageSize;
-          hasMore = data.length === pageSize;
-        } else {
-          hasMore = false;
-        }
-      }
-
-      return allProfiles;
-    };
-
-    [usageEventsWeekResult, audioYesterdayResult, callSessionsAllTimeDurationResult, profilesRecentResult] = await Promise.all([
+    [
+      usageEventsWeekResult,
+      audioYesterdayResult,
+      callSessionsAllTimeDurationResult,
+      profilesRecentResult,
+    ] = await Promise.all([
       fetchAllUsageEvents().then((data) => ({ data, error: null })),
       _timed(
         `audio_files:yesterday paginated ${previousDay.toISOString().slice(0, 10)}..${today.toISOString().slice(0, 10)}`,
@@ -458,22 +369,23 @@ export async function GET(request: NextRequest) {
       ),
       _timed(
         `call_sessions:all_time_durations paginated < ${today.toISOString().slice(0, 10)}`,
-        fetchAllCallSessionDurationsAllTime().then((data) => ({ data, error: null })),
+        fetchAllCallSessionDurationsAllTime().then((data) => ({
+          data,
+          error: null,
+        })),
       ),
-      fetchAllProfilesInRange(sevenDaysAgo, today).then((data) => ({ data, error: null })),
+      fetchAllProfilesInRange(sevenDaysAgo, today).then((data) => ({
+        data,
+        error: null,
+      })),
     ]);
 
     const fetchCreditTransactionsInRange = async (
       start: Date,
       end: Date,
-    ): Promise<CreditTransaction[]> => {
-      const allTransactions: CreditTransaction[] = [];
-      const pageSize = 1000;
-      let offset = 0;
-      let hasMore = true;
-
-      while (hasMore) {
-        const { data, error } = await supabase
+    ): Promise<CreditTransaction[]> =>
+      fetchAllPages<CreditTransaction>((offset) =>
+        supabase
           .from('credit_transactions')
           .select(
             'id, user_id, created_at, type, description, amount, metadata, profiles(username)',
@@ -483,21 +395,25 @@ export async function GET(request: NextRequest) {
           .gte('created_at', start.toISOString())
           .lt('created_at', end.toISOString())
           .order('created_at', { ascending: true })
-          .range(offset, offset + pageSize - 1);
+          .range(offset, offset + PAGE_SIZE - 1),
+      );
 
-        if (error) throw error;
-
-        if (data && data.length > 0) {
-          allTransactions.push(...data);
-          offset += pageSize;
-          hasMore = data.length === pageSize;
-        } else {
-          hasMore = false;
-        }
-      }
-
-      return allTransactions;
-    };
+    const fetchAllTimePurchaseTransactions = async (): Promise<
+      CreditTransaction[]
+    > =>
+      fetchAllPages<CreditTransaction>((offset) =>
+        supabase
+          .from('credit_transactions')
+          .select(
+            'id, user_id, created_at, type, description, amount, metadata, profiles(username)',
+          )
+          .in('type', ['purchase', 'topup'])
+          .not('description', 'ilike', '%manual%')
+          .lt('created_at', today.toISOString())
+          .order('created_at', { ascending: true })
+          .order('id', { ascending: true })
+          .range(offset, offset + PAGE_SIZE - 1),
+      );
 
     const [
       yesterdayCreditTransactions,
@@ -507,7 +423,8 @@ export async function GET(request: NextRequest) {
       previousMonthToDateCreditTransactions,
       twoMonthsAgoToDateCreditTransactions,
       threeMonthsAgoToDateCreditTransactions,
-      allTimeRefundTransactions,
+      allTimeCreditTransactions,
+      allTimePurchaseTransactionsResult,
     ] = await Promise.all([
       fetchCreditTransactionsInRange(previousDay, today),
       fetchCreditTransactionsInRange(sevenDaysAgo, today),
@@ -526,12 +443,13 @@ export async function GET(request: NextRequest) {
         new Date('1970-01-01T00:00:00.000Z'),
         today,
       ),
+      fetchAllTimePurchaseTransactions(),
     ]);
 
     allCreditTransactions = [
       ...new Map(
         [
-          ...allTimeRefundTransactions,
+          ...allTimeCreditTransactions,
           ...yesterdayCreditTransactions,
           ...sevenDayCreditTransactions,
           ...thirtyDayCreditTransactions,
@@ -542,6 +460,11 @@ export async function GET(request: NextRequest) {
         ].map((transaction) => [transaction.id, transaction]),
       ).values(),
     ].sort(
+      (a, b) =>
+        new Date(a.created_at).getTime() - new Date(b.created_at).getTime(),
+    );
+
+    allTimePurchaseTransactions = allTimePurchaseTransactionsResult.sort(
       (a, b) =>
         new Date(a.created_at).getTime() - new Date(b.created_at).getTime(),
     );
@@ -567,7 +490,7 @@ export async function GET(request: NextRequest) {
 
   // Cache results for faster debugging (non-prod only) — written after error
   // checks so we never persist a partial/failed response to disk
-  if (!isProd) {
+  if (!(isProd || loadedFromValidCache)) {
     const cacheData = {
       reportDate: cacheReportDate,
       audioYesterdayResult,
@@ -578,6 +501,7 @@ export async function GET(request: NextRequest) {
       profilesTotalCountResult,
       apiKeysYesterdayResult,
       allCreditTransactions,
+      allTimePurchaseTransactions,
       activeSubscribersCount,
       nextSubscriptionDueForPayment,
       callSessionsWeekResult,
@@ -681,22 +605,6 @@ export async function GET(request: NextRequest) {
         : 0,
     ) || 0;
 
-  // Format duration in minutes
-  const formatDuration = (seconds: number): string => {
-    const mins = Math.floor(seconds / 60);
-    const secs = seconds % 60;
-    return mins > 0 ? `${mins}m ${secs}s` : `${secs}s`;
-  };
-
-  const formatDurationChange = (
-    currentSeconds: number,
-    baselineSeconds: number,
-  ): string => {
-    const diffSeconds = Math.round(currentSeconds - baselineSeconds);
-    const sign = diffSeconds >= 0 ? '+' : '-';
-    return `${sign}${formatDuration(Math.abs(diffSeconds))}`;
-  };
-
   // Separate refunds from purchases/top-ups
   const refundTransactions = creditTransactions.filter(
     (t) => t.type === 'refund',
@@ -706,20 +614,15 @@ export async function GET(request: NextRequest) {
   );
 
   // Filter clones by date ranges
-  const clonePrevCount = filterByDateRange(
-    clonesData,
-    previousDay,
-    today,
-  ).length;
+  const clonePrevCount = countByDateRange(clonesData, previousDay, today);
   const cloneWeekCount = clonesData.length;
 
   // Filter profiles by date ranges
-  const profilesYesterdayData = filterByDateRange(
+  const profilesTodayCount = countByDateRange(
     profilesRecentData,
     previousDay,
     today,
   );
-  const profilesTodayCount = profilesYesterdayData.length;
   const profilesWeekCount = profilesRecentData.length;
 
   // Early exit if no audio files yesterday
@@ -746,34 +649,9 @@ export async function GET(request: NextRequest) {
 
   const nextPayingSubscriber =
     nextSubscriptionDueForPayment &&
-    (await getUserByStripeCustomerId(
-      nextSubscriptionDueForPayment?.customerId,
-    ));
-
-  // Top models calculation
-  const normalizeModelName = (modelName: string | null | undefined) => {
-    const trimmedModelName = modelName?.trim();
-    if (!trimmedModelName) return 'Unknown';
-
-    const modelWithoutVersion =
-      trimmedModelName.split(':')[0] ?? trimmedModelName;
-    const modelWithoutOwner =
-      modelWithoutVersion.split('/').pop() ?? modelWithoutVersion;
-    const normalizedModelName = modelWithoutOwner
-      .replace('-preview-tts', '')
-      .replace('-multilingual', '');
-
-    const friendlyModelLabels: Record<string, string> = {
-      chatterbox: 'Chatterbox',
-      'gemini-2.5-flash': 'Gemini Flash',
-      'gemini-2.5-pro': 'Gemini Pro',
-      grok: 'Grok',
-      'orpheus-3b-0.1-ft': 'Orpheus',
-      'voxtral-mini-tts-2603': 'Voxtral Clone',
-    };
-
-    return friendlyModelLabels[normalizedModelName] ?? normalizedModelName;
-  };
+    allTimePurchaseTransactions.find(
+      (t) => t.user_id === nextSubscriptionDueForPayment?.customerId,
+    );
 
   const cloneModelLabels = new Set(['Chatterbox', 'Voxtral Clone']);
   const modelCounts = new Map<string, number>();
@@ -849,7 +727,7 @@ export async function GET(request: NextRequest) {
   }).length;
   const creditsWeekCount = purchaseWeekData.length;
   const creditsMonthCount = purchaseThirtyDayData.length;
-  const creditsTotalCount = purchaseTransactions.length;
+  const creditsTotalCount = allTimePurchaseTransactions.length;
 
   // Filter refund transactions by date ranges
   const refundsPrevDayData = refundTransactions.filter(
@@ -961,7 +839,7 @@ export async function GET(request: NextRequest) {
   const topCustomerProfilesCount = topCustomerIds.length || '';
 
   const totalUniquePaidUsers = new Set(
-    purchaseTransactions.map((t) => t.user_id),
+    allTimePurchaseTransactions.map((t) => t.user_id),
   ).size;
   // Revenue calculations (incl. refund)
   const totalAmountUsd = creditTransactions.reduce(reduceAmountUsd, 0);
@@ -1044,7 +922,7 @@ export async function GET(request: NextRequest) {
   );
 
   // DEBUG: Log paid user usage analysis
-  if (!isProd) {
+  if (!isProd && process.env.DEBUG) {
     // Get unique user IDs from yesterday's usage events
     const yesterdayUserIds = new Set(
       filterByDateRange(
@@ -1126,17 +1004,6 @@ export async function GET(request: NextRequest) {
 
   const getSourceTypeLabel = (sourceType: string): string =>
     sourceTypeLabels[sourceType as UsageSourceType] ?? sourceType;
-
-  const calculateUsageBreakdown = (
-    events: typeof paidUserUsageEvents,
-  ): Map<string, number> => {
-    const breakdown = new Map<string, number>();
-    for (const event of events) {
-      const current = breakdown.get(event.source_type) ?? 0;
-      breakdown.set(event.source_type, current + event.credits_used);
-    }
-    return breakdown;
-  };
 
   const formatUsageBreakdown = (breakdown: Map<string, number>): string => {
     const total = [...breakdown.values()].reduce((sum, v) => sum + v, 0);
@@ -1220,7 +1087,7 @@ export async function GET(request: NextRequest) {
   }
 
   // DEBUG: Credit calculation verification
-  if (!isProd) {
+  if (!isProd && process.env.DEBUG) {
     console.log('\n💰 DEBUG: Credit Calculation Verification');
     console.log(
       '  - Paid user usage events (yesterday):',
@@ -1280,7 +1147,7 @@ export async function GET(request: NextRequest) {
   }
 
   // DEBUG: Top users verification
-  if (!isProd) {
+  if (!isProd && process.env.DEBUG) {
     console.log('\n👤 DEBUG: Top Users Verification');
     console.log('  - Total unique users with credits:', userCreditUsage.size);
     console.log('  - Top 3 raw data:');
@@ -1382,15 +1249,6 @@ export async function GET(request: NextRequest) {
     totalActiveUsersYesterday > 0
       ? ((creditsTodayCount / totalActiveUsersYesterday) * 100).toFixed(1)
       : null;
-
-  const getFeatureHealthStatus = (
-    current: number,
-    baseline: number,
-  ): '🟢 active' | '🟡 below trend' | '🔴 no usage' => {
-    if (current === 0) return '🔴 no usage';
-    if (baseline > 0 && current < baseline) return '🟡 below trend';
-    return '🟢 active';
-  };
 
   const featureHealthItems = [
     {

--- a/apps/web/app/api/daily-stats/route.ts
+++ b/apps/web/app/api/daily-stats/route.ts
@@ -13,6 +13,7 @@ import {
   findNextSubscriptionDueForPayment,
 } from '@/lib/redis/queries';
 import { createAdminClient } from '@/lib/supabase/admin';
+import { getUserIdByStripeCustomerId } from '@/lib/supabase/queries';
 import type { UsageSourceType } from '@/lib/supabase/usage-queries';
 import {
   _timed,
@@ -26,6 +27,7 @@ import {
   formatDuration,
   formatDurationChange,
   getFeatureHealthStatus,
+  getProfileUsername,
   maskUsername,
   normalizeModelName,
   PAGE_SIZE,
@@ -213,7 +215,6 @@ export async function GET(request: NextRequest) {
   const supabase = createAdminClient();
 
   if (!loadedFromValidCache) {
-
     // Fetch data in parallel - combine related queries and filter in memory
     [
       // Audio files - fetch for last specific ranges
@@ -654,20 +655,16 @@ export async function GET(request: NextRequest) {
   }
 
   const nextPayingSubscriberUserId = nextSubscriptionDueForPayment
-    ? (
-        await supabase
-          .from('profiles')
-          .select('id')
-          .eq('stripe_id', nextSubscriptionDueForPayment.customerId)
-          .single()
-      ).data?.id
+    ? await getUserIdByStripeCustomerId(
+        nextSubscriptionDueForPayment.customerId,
+      )
     : null;
 
-  const nextPayingSubscriber =
-    nextPayingSubscriberUserId &&
-    allTimePurchaseTransactions.find(
-      (t) => t.user_id === nextPayingSubscriberUserId,
-    );
+  const nextPayingSubscriber = nextPayingSubscriberUserId
+    ? allTimePurchaseTransactions.find(
+        (t) => t.user_id === nextPayingSubscriberUserId,
+      )
+    : undefined;
 
   const cloneModelLabels = new Set(['Chatterbox', 'Voxtral Clone']);
   const modelCounts = new Map<string, number>();
@@ -1328,7 +1325,7 @@ export async function GET(request: NextRequest) {
     `💰 Revenue: $${totalAmountUsdToday.toFixed(2)} yesterday (${totalAmountUsdToday >= avg7dRevenue ? '↑' : '↓'}$${Math.abs(totalAmountUsdToday - avg7dRevenue).toFixed(2)} vs 7d avg)`,
     `  - 7d: $${total7dRevenue.toFixed(2)} (avg $${avg7dRevenue.toFixed(2)}/day) | All-time: $${totalAmountUsd.toFixed(0)}`,
     `  - 3mo avg MTD: $${avgPrevMtdRevenue.toFixed(0)} vs MTD: $${mtdRevenue.toFixed(0)} (${formatCurrencyChange(mtdRevenue, avgPrevMtdRevenue)})`,
-    `  - Subscribers: ${activeSubscribersCount} active | New subs: ${newSubscribersTodayCount} yesterday, ${newSubscribersWeekCount} in 7d | Next renewal: ${maskUsername(nextPayingSubscriber?.profiles?.username)} on ${nextSubscriptionDueForPayment?.dueDate.slice(0, 10)}`,
+    `  - Subscribers: ${activeSubscribersCount} active | New subs: ${newSubscribersTodayCount} yesterday, ${newSubscribersWeekCount} in 7d | Next renewal: ${maskUsername(getProfileUsername(nextPayingSubscriber?.profiles ?? null))} on ${nextSubscriptionDueForPayment?.dueDate.slice(0, 10)}`,
   ];
 
   const message = [

--- a/apps/web/app/api/daily-stats/route.ts
+++ b/apps/web/app/api/daily-stats/route.ts
@@ -16,10 +16,17 @@ import { createAdminClient } from '@/lib/supabase/admin';
 import { getUserIdByStripeCustomerId } from '@/lib/supabase/queries';
 import type { UsageSourceType } from '@/lib/supabase/usage-queries';
 import {
+  getAudioFilesInRange,
+  getCallSessionDurationsBefore,
+  getCreditTransactionsInRange,
+  getProfilesInRange,
+  getUsageEventsInRange,
+  VOICE_CLONING_MODELS,
+} from './queries';
+import {
   _timed,
   calculateUsageBreakdown,
   countByDateRange,
-  fetchAllPages,
   filterByDateRange,
   formatChange,
   formatCompactNumber,
@@ -30,7 +37,6 @@ import {
   getProfileUsername,
   maskUsername,
   normalizeModelName,
-  PAGE_SIZE,
   reduceAmountUsd,
   startOfDay,
   startOfMonth,
@@ -43,12 +49,6 @@ import {
 // which drops the PostgREST connection and surfaces as a PostgreSQL 57014
 // (query_canceled) error rather than a Vercel timeout.
 export const maxDuration = 300;
-
-const VOICE_CLONING_MODELS = [
-  'resemble-ai/chatterbox-multilingual',
-  'resemble-ai/chatterbox',
-  'voxtral-mini-tts-2603',
-];
 
 // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: it's fine
 export async function GET(request: NextRequest) {
@@ -120,26 +120,6 @@ export async function GET(request: NextRequest) {
     ),
   );
 
-  // Partial credit_transactions type matching the selected columns
-  interface CreditTransaction {
-    created_at: string;
-    description: string | null;
-    id: string;
-    metadata: Json;
-    profiles: { username: string } | null;
-    type: 'purchase' | 'freemium' | 'topup' | 'refund';
-    user_id: string;
-  }
-
-  interface UsageEvent {
-    credits_used: number;
-    id: string;
-    occurred_at: string;
-    profiles: { username: string } | null;
-    source_type: string;
-    user_id: string;
-  }
-
   // Load from cache if available (non-prod only)
   // biome-ignore lint/suspicious/noExplicitAny: Cache data is dynamically typed
   let audioYesterdayResult: any;
@@ -155,8 +135,12 @@ export async function GET(request: NextRequest) {
   let profilesTotalCountResult: any;
   // biome-ignore lint/suspicious/noExplicitAny: Cache data is dynamically typed
   let apiKeysYesterdayResult: any;
-  let allCreditTransactions: CreditTransaction[] = [];
-  let allTimePurchaseTransactions: CreditTransaction[] = [];
+  let allCreditTransactions: Awaited<
+    ReturnType<typeof getCreditTransactionsInRange>
+  > = [];
+  let allTimePurchaseTransactions: Awaited<
+    ReturnType<typeof getCreditTransactionsInRange>
+  > = [];
   // biome-ignore lint/suspicious/noExplicitAny: Cache data is dynamically typed
   let activeSubscribersCount: any;
   // biome-ignore lint/suspicious/noExplicitAny: Cache data is dynamically typed
@@ -168,7 +152,10 @@ export async function GET(request: NextRequest) {
   // biome-ignore lint/suspicious/noExplicitAny: Cache data is dynamically typed
   let callSessionsAllTimeDurationResult: any;
   let usageEventsWeekResult:
-    | { data: UsageEvent[] | null; error: unknown }
+    | {
+        data: Awaited<ReturnType<typeof getUsageEventsInRange>> | null;
+        error: unknown;
+      }
     | undefined;
   let loadedFromValidCache = false;
 
@@ -294,131 +281,35 @@ export async function GET(request: NextRequest) {
         .lt('started_at', today.toISOString()),
     ]);
 
-    const fetchAllUsageEvents = async () =>
-      fetchAllPages<UsageEvent>((offset) =>
-        supabase
-          .from('usage_events')
-          .select(
-            'id, user_id, source_type, credits_used, occurred_at, profiles(username)',
-          )
-          .gte('occurred_at', sevenDaysAgo.toISOString())
-          .lt('occurred_at', today.toISOString())
-          .order('occurred_at', { ascending: true })
-          .order('id', { ascending: true })
-          .range(offset, offset + PAGE_SIZE - 1),
-      );
-
-    const fetchAllAudioFilesYesterday = async () =>
-      fetchAllPages<{
-        id: string;
-        created_at: string | null;
-        model: string | null;
-      }>((offset) =>
-        supabase
-          .from('audio_files')
-          .select('id, created_at, model')
-          .gte('created_at', previousDay.toISOString())
-          .lt('created_at', today.toISOString())
-          .order('created_at', { ascending: true })
-          .order('id', { ascending: true })
-          .range(offset, offset + PAGE_SIZE - 1),
-      );
-
-    const fetchAllCallSessionDurationsAllTime = async () =>
-      fetchAllPages<{ duration_seconds: number }>((offset) =>
-        supabase
-          .from('call_sessions')
-          .select('duration_seconds')
-          .lt('started_at', today.toISOString())
-          .order('started_at', { ascending: true })
-          .order('id', { ascending: true })
-          .range(offset, offset + PAGE_SIZE - 1),
-      );
-
-    const fetchAllProfilesInRange = async (
-      start: Date,
-      end: Date,
-    ): Promise<
-      {
-        id: string;
-        created_at: string | null;
-        username: string | null;
-      }[]
-    > =>
-      fetchAllPages<{
-        id: string;
-        created_at: string | null;
-        username: string | null;
-      }>((offset) =>
-        supabase
-          .from('profiles')
-          .select('id, created_at, username')
-          .gte('created_at', start.toISOString())
-          .lt('created_at', end.toISOString())
-          .order('created_at', { ascending: true })
-          .order('id', { ascending: true })
-          .range(offset, offset + PAGE_SIZE - 1),
-      );
-
     [
       usageEventsWeekResult,
       audioYesterdayResult,
       callSessionsAllTimeDurationResult,
       profilesRecentResult,
     ] = await Promise.all([
-      fetchAllUsageEvents().then((data) => ({ data, error: null })),
+      getUsageEventsInRange(supabase, sevenDaysAgo, today).then((data) => ({
+        data,
+        error: null,
+      })),
       _timed(
         `audio_files:yesterday paginated ${previousDay.toISOString().slice(0, 10)}..${today.toISOString().slice(0, 10)}`,
-        fetchAllAudioFilesYesterday().then((data) => ({ data, error: null })),
-      ),
-      _timed(
-        `call_sessions:all_time_durations paginated < ${today.toISOString().slice(0, 10)}`,
-        fetchAllCallSessionDurationsAllTime().then((data) => ({
+        getAudioFilesInRange(supabase, previousDay, today).then((data) => ({
           data,
           error: null,
         })),
       ),
-      fetchAllProfilesInRange(sevenDaysAgo, today).then((data) => ({
+      _timed(
+        `call_sessions:all_time_durations paginated < ${today.toISOString().slice(0, 10)}`,
+        getCallSessionDurationsBefore(supabase, today).then((data) => ({
+          data,
+          error: null,
+        })),
+      ),
+      getProfilesInRange(supabase, sevenDaysAgo, today).then((data) => ({
         data,
         error: null,
       })),
     ]);
-
-    const fetchCreditTransactionsInRange = async (
-      start: Date,
-      end: Date,
-    ): Promise<CreditTransaction[]> =>
-      fetchAllPages<CreditTransaction>((offset) =>
-        supabase
-          .from('credit_transactions')
-          .select(
-            'id, user_id, created_at, type, description, amount, metadata, profiles(username)',
-          )
-          .in('type', ['purchase', 'topup', 'refund'])
-          .not('description', 'ilike', '%manual%')
-          .gte('created_at', start.toISOString())
-          .lt('created_at', end.toISOString())
-          .order('created_at', { ascending: true })
-          .order('id', { ascending: true })
-          .range(offset, offset + PAGE_SIZE - 1),
-      );
-
-    const fetchAllTimePurchaseTransactions = async (): Promise<
-      CreditTransaction[]
-    > =>
-      fetchAllPages<CreditTransaction>((offset) =>
-        supabase
-          .from('credit_transactions')
-          .select(
-            'id, user_id, created_at, type, description, amount, metadata, profiles(username)',
-          )
-          .in('type', ['purchase', 'topup'])
-          .not('description', 'ilike', '%manual%')
-          .lt('created_at', today.toISOString())
-          .order('created_at', { ascending: true })
-          .order('id', { ascending: true })
-          .range(offset, offset + PAGE_SIZE - 1),
-      );
 
     const [
       yesterdayCreditTransactions,
@@ -429,26 +320,31 @@ export async function GET(request: NextRequest) {
       twoMonthsAgoToDateCreditTransactions,
       threeMonthsAgoToDateCreditTransactions,
       allTimeCreditTransactions,
-      allTimePurchaseTransactionsResult,
     ] = await Promise.all([
-      fetchCreditTransactionsInRange(previousDay, today),
-      fetchCreditTransactionsInRange(sevenDaysAgo, today),
-      fetchCreditTransactionsInRange(thirtyDaysAgo, today),
-      fetchCreditTransactionsInRange(monthStart, today),
-      fetchCreditTransactionsInRange(
+      getCreditTransactionsInRange(supabase, previousDay, today),
+      getCreditTransactionsInRange(supabase, sevenDaysAgo, today),
+      getCreditTransactionsInRange(supabase, thirtyDaysAgo, today),
+      getCreditTransactionsInRange(supabase, monthStart, today),
+      getCreditTransactionsInRange(
+        supabase,
         previousMonthStart,
         previousMonthPeriodEnd,
       ),
-      fetchCreditTransactionsInRange(twoMonthsAgoStart, twoMonthsAgoPeriodEnd),
-      fetchCreditTransactionsInRange(
+      getCreditTransactionsInRange(
+        supabase,
+        twoMonthsAgoStart,
+        twoMonthsAgoPeriodEnd,
+      ),
+      getCreditTransactionsInRange(
+        supabase,
         threeMonthsAgoStart,
         threeMonthsAgoPeriodEnd,
       ),
-      fetchCreditTransactionsInRange(
+      getCreditTransactionsInRange(
+        supabase,
         new Date('1970-01-01T00:00:00.000Z'),
         today,
       ),
-      fetchAllTimePurchaseTransactions(),
     ]);
 
     allCreditTransactions = [
@@ -469,10 +365,12 @@ export async function GET(request: NextRequest) {
         new Date(a.created_at).getTime() - new Date(b.created_at).getTime(),
     );
 
-    allTimePurchaseTransactions = allTimePurchaseTransactionsResult.sort(
-      (a, b) =>
-        new Date(a.created_at).getTime() - new Date(b.created_at).getTime(),
-    );
+    allTimePurchaseTransactions = allTimeCreditTransactions
+      .filter((transaction) => transaction.type !== 'refund')
+      .sort(
+        (a, b) =>
+          new Date(a.created_at).getTime() - new Date(b.created_at).getTime(),
+      );
   } // end of else (not using cache)
 
   if (audioYesterdayResult?.error) throw audioYesterdayResult.error;
@@ -556,7 +454,7 @@ export async function GET(request: NextRequest) {
     (key) => key.last_used_at !== null,
   ).length;
 
-  const creditTransactions: CreditTransaction[] = allCreditTransactions;
+  const creditTransactions = allCreditTransactions;
 
   const callSessionsWeekData = (
     (callSessionsWeekResult.data ?? []) as (Tables<'call_sessions'> & {
@@ -568,7 +466,7 @@ export async function GET(request: NextRequest) {
     (callSessionsAllTimeDurationResult.data ?? []) as {
       duration_seconds: number;
     }[];
-  const usageEventsWeekData: UsageEvent[] = usageEventsWeekResult.data ?? [];
+  const usageEventsWeekData = usageEventsWeekResult.data ?? [];
 
   // Calculate API TTS credits used yesterday
   const apiTtsCreditsYesterday = filterByDateRange(
@@ -794,7 +692,7 @@ export async function GET(request: NextRequest) {
     existing.push({
       amount: dollarAmount,
       type: purchaseTypeLabel,
-      username: transaction.profiles?.username || 'Unknown',
+      username: getProfileUsername(transaction.profiles) || 'Unknown',
     });
     customerTransactions.set(transaction.user_id, existing);
   }
@@ -1154,8 +1052,9 @@ export async function GET(request: NextRequest) {
   // Get usernames for top usage users from usage events
   const userIdToUsername = new Map<string, string>();
   for (const event of usageEventsWeekData) {
-    if (event.profiles?.username && !userIdToUsername.has(event.user_id)) {
-      userIdToUsername.set(event.user_id, event.profiles.username);
+    const username = getProfileUsername(event.profiles);
+    if (username && !userIdToUsername.has(event.user_id)) {
+      userIdToUsername.set(event.user_id, username);
     }
   }
 

--- a/apps/web/app/api/daily-stats/route.ts
+++ b/apps/web/app/api/daily-stats/route.ts
@@ -343,19 +343,12 @@ export async function GET(request: NextRequest) {
       return allEvents;
     };
 
-    usageEventsWeekResult = {
-      data: await fetchAllUsageEvents(),
-      error: null,
-    };
-
     // Fetch audio files yesterday with pagination (Supabase limits to 1000 per request)
     const fetchAllAudioFilesYesterday = async () => {
       const allAudio: {
         id: string;
         created_at: string | null;
         model: string | null;
-        voice_id: string | null;
-        voices: { name: string } | null;
       }[] = [];
       const pageSize = 1000;
       let offset = 0;
@@ -364,7 +357,7 @@ export async function GET(request: NextRequest) {
       while (hasMore) {
         const { data, error } = await supabase
           .from('audio_files')
-          .select('id, created_at, model, voice_id, voices(name)')
+          .select('id, created_at, model')
           .gte('created_at', previousDay.toISOString())
           .lt('created_at', today.toISOString())
           .order('created_at', { ascending: true })
@@ -457,7 +450,8 @@ export async function GET(request: NextRequest) {
       return allProfiles;
     };
 
-    [audioYesterdayResult, callSessionsAllTimeDurationResult, profilesRecentResult] = await Promise.all([
+    [usageEventsWeekResult, audioYesterdayResult, callSessionsAllTimeDurationResult, profilesRecentResult] = await Promise.all([
+      fetchAllUsageEvents().then((data) => ({ data, error: null })),
       _timed(
         `audio_files:yesterday paginated ${previousDay.toISOString().slice(0, 10)}..${today.toISOString().slice(0, 10)}`,
         fetchAllAudioFilesYesterday().then((data) => ({ data, error: null })),

--- a/apps/web/app/api/daily-stats/route.ts
+++ b/apps/web/app/api/daily-stats/route.ts
@@ -368,6 +368,7 @@ export async function GET(request: NextRequest) {
           .gte('created_at', previousDay.toISOString())
           .lt('created_at', today.toISOString())
           .order('created_at', { ascending: true })
+          .order('id', { ascending: true })
           .range(offset, offset + pageSize - 1);
 
         if (error) throw error;
@@ -397,6 +398,7 @@ export async function GET(request: NextRequest) {
           .select('duration_seconds')
           .lt('started_at', today.toISOString())
           .order('started_at', { ascending: true })
+          .order('id', { ascending: true })
           .range(offset, offset + pageSize - 1);
 
         if (error) throw error;

--- a/apps/web/app/api/daily-stats/route.ts
+++ b/apps/web/app/api/daily-stats/route.ts
@@ -366,7 +366,7 @@ export async function GET(request: NextRequest) {
     const fetchAllAudioFilesYesterday = async () => {
       const allAudio: {
         id: string;
-        created_at: string;
+        created_at: string | null;
         model: string | null;
         voice_id: string | null;
         voices: { name: string } | null;

--- a/apps/web/app/api/daily-stats/types.ts
+++ b/apps/web/app/api/daily-stats/types.ts
@@ -1,0 +1,4 @@
+export type DailyStatsProfileRelation =
+  | { username: string }
+  | { username: string }[]
+  | null;

--- a/apps/web/app/api/daily-stats/utils.ts
+++ b/apps/web/app/api/daily-stats/utils.ts
@@ -1,3 +1,35 @@
+import type { DailyStatsProfileRelation } from './types';
+
+interface UsageBreakdownEvent {
+  credits_used: number;
+  source_type: string;
+}
+
+type DateRangeItem<K extends string = string> = Record<K, string>;
+interface MetadataWithDollarAmount {
+  dollarAmount?: number;
+}
+
+// Helper to time individual queries
+export const _timed = async <T>(
+  label: string,
+  promise: PromiseLike<T>,
+): Promise<T> => {
+  const start = Date.now();
+  console.log(`⏱  [daily-stats] START  ${label}`);
+  try {
+    const result = await promise;
+    console.log(`✅ [daily-stats] DONE   ${label} — ${Date.now() - start}ms`);
+    return result;
+  } catch (err) {
+    console.log(
+      `❌ [daily-stats] ERROR  ${label} — ${Date.now() - start}ms`,
+      err,
+    );
+    throw err;
+  }
+};
+
 export function formatCompactNumber(num: number): string {
   if (num >= 1_000_000) {
     return `${(num / 1_000_000).toFixed(1)}M`;
@@ -17,6 +49,11 @@ export function startOfDay(date: Date): Date {
 export function subtractDays(date: Date, days: number): Date {
   // 86_400_000 milliseconds in 24 hours
   return new Date(date.getTime() - days * 86_400_000);
+}
+
+export function isInDateRange(value: string, start: Date, end: Date): boolean {
+  const itemTime = new Date(value).getTime();
+  return itemTime >= start.getTime() && itemTime < end.getTime();
 }
 
 export function startOfMonth(date: Date): Date {
@@ -49,18 +86,44 @@ export function formatCurrencyChange(
   return `${arrow}$${Math.abs(diff).toFixed(2)} (${arrow}${Math.abs(pct).toFixed(0)}%)`;
 }
 
+// Format duration in minutes
+export const formatDuration = (seconds: number): string => {
+  const mins = Math.floor(seconds / 60);
+  const secs = seconds % 60;
+  return mins > 0 ? `${mins}m ${secs}s` : `${secs}s`;
+};
+
+export const formatDurationChange = (
+  currentSeconds: number,
+  baselineSeconds: number,
+): string => {
+  const diffSeconds = Math.round(currentSeconds - baselineSeconds);
+  const sign = diffSeconds >= 0 ? '+' : '-';
+  return `${sign}${formatDuration(Math.abs(diffSeconds))}`;
+};
+
 export function reduceAmountUsd(acc: number, row: { metadata: Json }): number {
   if (!row.metadata || typeof row.metadata !== 'object') {
     console.log('Invalid metadata in row:', row);
     return acc;
   }
-  const { dollarAmount } = row.metadata as {
-    dollarAmount: number;
-  };
-  if (typeof dollarAmount === 'number') {
-    return acc + dollarAmount;
+
+  const { dollarAmount } = row.metadata as MetadataWithDollarAmount;
+  return typeof dollarAmount === 'number' ? acc + dollarAmount : acc;
+}
+
+export function getProfileUsername(
+  profileRelation: DailyStatsProfileRelation,
+): string | undefined {
+  if (!profileRelation) {
+    return undefined;
   }
-  return acc;
+
+  if (Array.isArray(profileRelation)) {
+    return profileRelation[0]?.username;
+  }
+
+  return profileRelation.username;
 }
 
 export function maskUsername(username?: string): string | undefined {
@@ -86,20 +149,148 @@ export function filterByDateRange<T extends { created_at: string }>(
   start: Date,
   end: Date,
 ): T[];
-export function filterByDateRange<
-  K extends string,
-  T extends Record<K, string>,
->(items: T[], start: Date, end: Date, dateKey: K): T[];
+export function filterByDateRange<K extends string, T extends DateRangeItem<K>>(
+  items: T[],
+  start: Date,
+  end: Date,
+  dateKey: K,
+): T[];
 export function filterByDateRange<T extends Record<string, unknown>>(
   items: T[],
   start: Date,
   end: Date,
   dateKey = 'created_at',
 ): T[] {
-  const startTime = start.getTime();
-  const endTime = end.getTime();
-  return items.filter((item) => {
-    const itemTime = new Date(item[dateKey] as string).getTime();
-    return itemTime >= startTime && itemTime < endTime;
-  });
+  return items.filter((item) =>
+    isInDateRange(item[dateKey] as string, start, end),
+  );
+}
+
+export function countByDateRange<T extends { created_at: string }>(
+  items: T[],
+  start: Date,
+  end: Date,
+): number;
+export function countByDateRange<K extends string, T extends DateRangeItem<K>>(
+  items: T[],
+  start: Date,
+  end: Date,
+  dateKey: K,
+): number;
+export function countByDateRange<T extends Record<string, unknown>>(
+  items: T[],
+  start: Date,
+  end: Date,
+  dateKey = 'created_at',
+): number {
+  return items.reduce(
+    (count, item) =>
+      count + (isInDateRange(item[dateKey] as string, start, end) ? 1 : 0),
+    0,
+  );
+}
+
+export const getFeatureHealthStatus = (
+  current: number,
+  baseline: number,
+): '🟢 active' | '🟡 below trend' | '🔴 no usage' => {
+  if (current === 0) return '🔴 no usage';
+  if (baseline > 0 && current < baseline) return '🟡 below trend';
+  return '🟢 active';
+};
+
+// Top models calculation
+export const normalizeModelName = (modelName: string | null | undefined) => {
+  const trimmedModelName = modelName?.trim();
+  if (!trimmedModelName) return 'Unknown';
+
+  const modelWithoutVersion =
+    trimmedModelName.split(':')[0] ?? trimmedModelName;
+  const modelWithoutOwner =
+    modelWithoutVersion.split('/').pop() ?? modelWithoutVersion;
+  const normalizedModelName = modelWithoutOwner
+    .replace('-preview-tts', '')
+    .replace('-multilingual', '');
+
+  const friendlyModelLabels: Record<string, string> = {
+    chatterbox: 'Chatterbox',
+    'gemini-2.5-flash': 'Gemini Flash',
+    'gemini-2.5-pro': 'Gemini Pro',
+    grok: 'Grok',
+    'orpheus-3b-0.1-ft': 'Orpheus',
+    'voxtral-mini-tts-2603': 'Voxtral Clone',
+  };
+
+  return friendlyModelLabels[normalizedModelName] ?? normalizedModelName;
+};
+
+export const calculateUsageBreakdown = (
+  events: UsageBreakdownEvent[],
+): Map<string, number> => {
+  const breakdown = new Map<string, number>();
+  for (const event of events) {
+    const current = breakdown.get(event.source_type) ?? 0;
+    breakdown.set(event.source_type, current + event.credits_used);
+  }
+  return breakdown;
+};
+
+/**
+ * Pagination utilities for Supabase queries
+ *
+ * Supabase has a default limit of 1000 rows per query.
+ * Use these utilities to fetch all records from large tables.
+ */
+
+export const PAGE_SIZE = 1000;
+
+/**
+ * Paginates through all results from a Supabase query.
+ *
+ * @example
+ * ```ts
+ * const results = await fetchAllPages<{ user_id: string }>((offset) =>
+ *   supabase
+ *     .from("table")
+ *     .select("user_id")
+ *     .range(offset, offset + PAGE_SIZE - 1)
+ * );
+ * ```
+ *
+ * @param queryBuilder - A function that takes an offset and returns a Supabase query promise
+ * @returns All records from the query, concatenated together
+ */
+export async function fetchAllPages<T>(
+  queryBuilder: (
+    offset: number,
+  ) => PromiseLike<{ data: T[] | null; error: unknown }>,
+): Promise<T[]> {
+  const allData: T[] = [];
+  let offset = 0;
+
+  while (true) {
+    const { data, error } = await queryBuilder(offset);
+
+    if (error) {
+      const msg =
+        typeof error === 'object' && error !== null && 'message' in error
+          ? (error as { message: string }).message
+          : String(error);
+      throw new Error(msg);
+    }
+
+    if (!data || data.length === 0) {
+      break;
+    }
+
+    allData.push(...data);
+
+    if (data.length < PAGE_SIZE) {
+      break;
+    }
+
+    offset += PAGE_SIZE;
+  }
+
+  return allData;
 }

--- a/apps/web/app/api/daily-stats/utils.ts
+++ b/apps/web/app/api/daily-stats/utils.ts
@@ -272,11 +272,15 @@ export async function fetchAllPages<T>(
     const { data, error } = await queryBuilder(offset);
 
     if (error) {
+      if (error instanceof Error) {
+        throw error;
+      }
+
       const msg =
         typeof error === 'object' && error !== null && 'message' in error
           ? (error as { message: string }).message
           : String(error);
-      throw new Error(msg);
+      throw new Error(msg, { cause: error });
     }
 
     if (!data || data.length === 0) {

--- a/apps/web/components/audio-generator.test.tsx
+++ b/apps/web/components/audio-generator.test.tsx
@@ -1,9 +1,9 @@
 // @vitest-environment jsdom
-import "@testing-library/jest-dom/vitest";
-import { render, screen, waitFor, within } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import '@testing-library/jest-dom/vitest';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { AudioGenerator } from "@/components/audio-generator";
+import { AudioGenerator } from '@/components/audio-generator';
 
 const mockToastFn = vi.hoisted(() =>
   Object.assign(vi.fn(), {
@@ -12,33 +12,33 @@ const mockToastFn = vi.hoisted(() =>
   }),
 );
 
-vi.mock("@ai-sdk/react", () => ({
+vi.mock('@ai-sdk/react', () => ({
   useCompletion: () => ({
     complete: vi.fn(),
   }),
 }));
 
-vi.mock("@/app/[lang]/(dashboard)/dashboard/clone/audio-provider", () => ({
+vi.mock('@/app/[lang]/(dashboard)/dashboard/clone/audio-provider', () => ({
   useAudio: () => ({
     reset: vi.fn(),
   }),
 }));
 
-vi.mock("@/components/services/toast", () => ({
+vi.mock('@/components/services/toast', () => ({
   toast: mockToastFn,
 }));
 
-vi.mock("@/components/audio-player-with-context", () => ({
+vi.mock('@/components/audio-player-with-context', () => ({
   AudioPlayerWithContext: () => null,
 }));
 
-vi.mock("@/lib/ai", () => ({
+vi.mock('@/lib/ai', () => ({
   getCharactersLimit: vi.fn((model?: string, isPaidUser?: boolean) => {
-    if (model === "gpro") {
+    if (model === 'gpro') {
       return isPaidUser ? 2000 : 1000;
     }
 
-    if (model === "grok") {
+    if (model === 'grok') {
       return isPaidUser ? 2000 : 1000;
     }
 
@@ -46,92 +46,92 @@ vi.mock("@/lib/ai", () => ({
   }),
 }));
 
-vi.mock("@/lib/download", () => ({
+vi.mock('@/lib/download', () => ({
   downloadUrl: vi.fn(),
 }));
 
-vi.mock("@/lib/react-textarea-autosize", () => ({
+vi.mock('@/lib/react-textarea-autosize', () => ({
   resizeTextarea: vi.fn(),
 }));
 
 const baseDict = {
-  title: "Generate audio",
-  textAreaPlaceholder: "Enter text",
-  estimateCreditsButton: "Estimate credits",
-  languageLabel: "Language",
-  languageSelectPlaceholder: "Select a language",
-  langAutomatic: "Automatic",
-  ctaButton: "Generate",
-  generating: "Generating",
-  cancel: "Cancel",
-  playAudio: "Play audio",
-  resetPlayer: "Reset player",
-  downloadAudio: "Download audio",
-  notEnoughCredits: "Not enough credits",
-  success: "Success",
-  error: "Something went wrong",
-  errorEstimating: "Failed to estimate credits",
-  dailyLimitError: "Daily limit reached (__COUNT__)",
+  title: 'Generate audio',
+  textAreaPlaceholder: 'Enter text',
+  estimateCreditsButton: 'Estimate credits',
+  languageLabel: 'Language',
+  languageSelectPlaceholder: 'Select a language',
+  langAutomatic: 'Automatic',
+  ctaButton: 'Generate',
+  generating: 'Generating',
+  cancel: 'Cancel',
+  playAudio: 'Play audio',
+  resetPlayer: 'Reset player',
+  downloadAudio: 'Download audio',
+  notEnoughCredits: 'Not enough credits',
+  success: 'Success',
+  error: 'Something went wrong',
+  errorEstimating: 'Failed to estimate credits',
+  dailyLimitError: 'Daily limit reached (__COUNT__)',
   grok: {
-    helperText: "Use Grok tags to control delivery.",
-    inlineEffectPlaceholder: "Insert tags",
-    wrappingEffectPlaceholder: "Wrap selected text",
-    formatPlaceholder: "Select format",
+    helperText: 'Use Grok tags to control delivery.',
+    inlineEffectPlaceholder: 'Insert tags',
+    wrappingEffectPlaceholder: 'Wrap selected text',
+    formatPlaceholder: 'Select format',
     effects: {
-      pause: "Pause",
-      longPause: "Long pause",
-      humTune: "Hum tune",
-      laugh: "Laugh",
-      chuckle: "Chuckle",
-      giggle: "Giggle",
-      cry: "Cry",
-      tsk: "Tsk",
-      tongueClick: "Tongue click",
-      lipSmack: "Lip smack",
-      breath: "Breath",
-      inhale: "Inhale",
-      exhale: "Exhale",
-      sigh: "Sigh",
+      pause: 'Pause',
+      longPause: 'Long pause',
+      humTune: 'Hum tune',
+      laugh: 'Laugh',
+      chuckle: 'Chuckle',
+      giggle: 'Giggle',
+      cry: 'Cry',
+      tsk: 'Tsk',
+      tongueClick: 'Tongue click',
+      lipSmack: 'Lip smack',
+      breath: 'Breath',
+      inhale: 'Inhale',
+      exhale: 'Exhale',
+      sigh: 'Sigh',
     },
   },
 } as const;
 
 function createVoice(
-  overrides: Partial<Tables<"voices">> = {},
-): Tables<"voices"> {
+  overrides: Partial<Tables<'voices'>> = {},
+): Tables<'voices'> {
   return {
-    id: "voice-id",
-    name: "tara",
-    language: "en",
+    id: 'voice-id',
+    name: 'tara',
+    language: 'en',
     model:
-      "lucataco/orpheus-3b-0.1-ft:79f2a473e6a9720716a473d9b2f2951437dbf91dc02ccb7079fb3d89b881207f",
+      'lucataco/orpheus-3b-0.1-ft:79f2a473e6a9720716a473d9b2f2951437dbf91dc02ccb7079fb3d89b881207f',
     description: null,
     type: null,
     sort_order: 0,
-    feature: "tts",
+    feature: 'tts',
     sample_url: null,
     sample_prompt: null,
     user_id: null,
     created_at: null,
     ...overrides,
-  } as Tables<"voices">;
+  } as Tables<'voices'>;
 }
 
 function renderAudioGenerator(
   overrides: Partial<React.ComponentProps<typeof AudioGenerator>> = {},
 ) {
   const defaultProps: React.ComponentProps<typeof AudioGenerator> = {
-    dict: baseDict as unknown as (typeof import("@/messages/en.json"))["generate"],
+    dict: baseDict as unknown as typeof import('@/messages/en.json')['generate'],
     hasEnoughCredits: true,
     isPaidUser: true,
-    selectedStyle: "moan softly",
+    selectedStyle: 'moan softly',
     selectedVoice: createVoice(),
   };
 
   return render(<AudioGenerator {...defaultProps} {...overrides} />);
 }
 
-describe("AudioGenerator", () => {
+describe('AudioGenerator', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockToastFn.mockClear();
@@ -139,11 +139,11 @@ describe("AudioGenerator", () => {
     mockToastFn.error.mockClear();
   });
 
-  it("shows the Grok language selector with Automatic first and English second", async () => {
+  it('shows the Grok language selector with Automatic first and English second', async () => {
     renderAudioGenerator({
       selectedVoice: createVoice({
-        name: "eve",
-        model: "grok",
+        name: 'eve',
+        model: 'grok',
       }),
     });
 
@@ -153,37 +153,37 @@ describe("AudioGenerator", () => {
     const languageField = languageLabel.parentElement;
     expect(languageField).not.toBeNull();
 
-    const trigger = within(languageField as HTMLElement).getByRole("combobox");
+    const trigger = within(languageField as HTMLElement).getByRole('combobox');
     expect(trigger).toHaveTextContent(baseDict.langAutomatic);
 
     trigger.click();
 
-    const options = await screen.findAllByRole("option");
+    const options = await screen.findAllByRole('option');
     expect(options[0]).toHaveTextContent(baseDict.langAutomatic);
-    expect(options[1]).toHaveTextContent("English");
+    expect(options[1]).toHaveTextContent('English');
     expect(options).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          textContent: expect.stringContaining("Arabic (Egypt)"),
+          textContent: expect.stringContaining('Arabic (Egypt)'),
         }),
         expect.objectContaining({
-          textContent: expect.stringContaining("Arabic (Saudi Arabia)"),
+          textContent: expect.stringContaining('Arabic (Saudi Arabia)'),
         }),
       ]),
     );
   });
 
-  it("submits the selected Grok language in the generation request", async () => {
+  it('submits the selected Grok language in the generation request', async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
-      json: async () => ({ url: "https://example.com/audio.mp3" }),
+      json: async () => ({ url: 'https://example.com/audio.mp3' }),
     });
-    vi.stubGlobal("fetch", fetchMock);
+    vi.stubGlobal('fetch', fetchMock);
 
     renderAudioGenerator({
       selectedVoice: createVoice({
-        name: "eve",
-        model: "grok",
+        name: 'eve',
+        model: 'grok',
       }),
     });
 
@@ -191,45 +191,45 @@ describe("AudioGenerator", () => {
     const languageField = languageLabel.parentElement;
     expect(languageField).not.toBeNull();
 
-    const trigger = within(languageField as HTMLElement).getByRole("combobox");
+    const trigger = within(languageField as HTMLElement).getByRole('combobox');
     trigger.click();
 
-    const arabicEgyptOption = await screen.findByRole("option", {
-      name: "Arabic (Egypt)",
+    const arabicEgyptOption = await screen.findByRole('option', {
+      name: 'Arabic (Egypt)',
     });
     arabicEgyptOption.click();
 
     await waitFor(() => {
-      expect(trigger).toHaveTextContent("Arabic (Egypt)");
+      expect(trigger).toHaveTextContent('Arabic (Egypt)');
     });
 
     const editor = document.querySelector('[contenteditable="true"]');
     expect(editor).not.toBeNull();
 
     editor?.dispatchEvent(
-      new InputEvent("input", {
+      new InputEvent('input', {
         bubbles: true,
-        inputType: "insertText",
-        data: "مرحبا",
+        inputType: 'insertText',
+        data: 'مرحبا',
       }),
     );
 
-    const generateButton = screen.getByTestId("generate-button");
+    const generateButton = screen.getByTestId('generate-button');
     generateButton.click();
 
     await waitFor(() => {
       expect(fetchMock).toHaveBeenCalledWith(
-        "/api/generate-voice",
+        '/api/generate-voice',
         expect.objectContaining({
-          method: "POST",
+          method: 'POST',
           headers: {
-            "Content-Type": "application/json",
+            'Content-Type': 'application/json',
           },
           body: JSON.stringify({
-            text: "مرحبا",
-            voice: "eve",
-            styleVariant: "",
-            language: "ar-EG",
+            text: 'مرحبا',
+            voice: 'eve',
+            styleVariant: '',
+            language: 'ar-EG',
           }),
           signal: expect.any(AbortSignal),
         }),
@@ -237,47 +237,47 @@ describe("AudioGenerator", () => {
     });
   });
 
-  it("hides Gemini estimate credits UI for Grok voices", () => {
+  it('hides Gemini estimate credits UI for Grok voices', () => {
     renderAudioGenerator({
       selectedVoice: createVoice({
-        name: "eve",
-        model: "grok",
+        name: 'eve',
+        model: 'grok',
       }),
     });
 
     expect(
-      screen.queryByRole("button", { name: baseDict.estimateCreditsButton }),
+      screen.queryByRole('button', { name: baseDict.estimateCreditsButton }),
     ).not.toBeInTheDocument();
   });
 
-  it("hides the AI enhance button for Grok voices", () => {
+  it('hides the AI enhance button for Grok voices', () => {
     renderAudioGenerator({
       selectedVoice: createVoice({
-        name: "eve",
-        model: "grok",
+        name: 'eve',
+        model: 'grok',
       }),
     });
 
     expect(
-      screen.queryByTitle("Enhance text with AI emotion tags"),
+      screen.queryByTitle('Enhance text with AI emotion tags'),
     ).not.toBeInTheDocument();
     expect(
-      screen.queryByText("This model supports emotion tags"),
+      screen.queryByText('This model supports emotion tags'),
     ).not.toBeInTheDocument();
   });
 
-  it("shows Grok TTS editor for Grok voices", async () => {
+  it('shows Grok TTS editor for Grok voices', async () => {
     renderAudioGenerator({
       selectedVoice: createVoice({
-        name: "eve",
-        model: "grok",
+        name: 'eve',
+        model: 'grok',
       }),
     });
 
     // GrokTTSEditor is loaded dynamically, wait for it
     await waitFor(() => {
       expect(
-        screen.getByRole("button", { name: /insert tags/i }),
+        screen.getByRole('button', { name: /insert tags/i }),
       ).toBeInTheDocument();
     });
     // Should render the Tiptap contenteditable editor
@@ -288,17 +288,17 @@ describe("AudioGenerator", () => {
     // Codec selector is handled outside the editor and may not expose a combobox here
   });
 
-  it("does not show Grok TTS editor for Replicate voices", () => {
+  it('does not show Grok TTS editor for Replicate voices', () => {
     renderAudioGenerator({
       selectedVoice: createVoice({
-        name: "tara",
+        name: 'tara',
         model:
-          "lucataco/orpheus-3b-0.1-ft:79f2a473e6a9720716a473d9b2f2951437dbf91dc02ccb7079fb3d89b881207f",
+          'lucataco/orpheus-3b-0.1-ft:79f2a473e6a9720716a473d9b2f2951437dbf91dc02ccb7079fb3d89b881207f',
       }),
     });
 
     expect(
-      screen.queryByRole("button", { name: /insert tags/i }),
+      screen.queryByRole('button', { name: /insert tags/i }),
     ).not.toBeInTheDocument();
   });
 });

--- a/apps/web/components/audio-generator.tsx
+++ b/apps/web/components/audio-generator.tsx
@@ -1,8 +1,8 @@
-"use client";
+'use client';
 
-import { useCompletion } from "@ai-sdk/react";
-import { CircleStop, Download, Loader2, RotateCcw } from "lucide-react";
-import dynamic from "next/dynamic";
+import { useCompletion } from '@ai-sdk/react';
+import { CircleStop, Download, Loader2, RotateCcw } from 'lucide-react';
+import dynamic from 'next/dynamic';
 import {
   type ComponentPropsWithoutRef,
   forwardRef,
@@ -12,38 +12,37 @@ import {
   useMemo,
   useRef,
   useState,
-} from "react";
+} from 'react';
 
-import { useAudio } from "@/app/[lang]/(dashboard)/dashboard/clone/audio-provider";
-import { toast } from "@/components/services/toast";
-import { SpotlightField } from "@/components/spotlight-field";
-import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Textarea } from "@/components/ui/textarea";
-import { getCharactersLimit } from "@/lib/ai";
-import { downloadUrl } from "@/lib/download";
-import { APIError } from "@/lib/error-ts";
-import { resizeTextarea } from "@/lib/react-textarea-autosize";
-import { MAX_FREE_GENERATIONS } from "@/lib/supabase/constants";
-import { cn, getTtsProvider } from "@/lib/utils";
-import type messages from "@/messages/en.json";
+import { useAudio } from '@/app/[lang]/(dashboard)/dashboard/clone/audio-provider';
+import { toast } from '@/components/services/toast';
+import { SpotlightField } from '@/components/spotlight-field';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Textarea } from '@/components/ui/textarea';
+import { getCharactersLimit } from '@/lib/ai';
+import { downloadUrl } from '@/lib/download';
+import { APIError } from '@/lib/error-ts';
+import { resizeTextarea } from '@/lib/react-textarea-autosize';
+import { MAX_FREE_GENERATIONS } from '@/lib/supabase/constants';
+import { cn, getTtsProvider } from '@/lib/utils';
+import type messages from '@/messages/en.json';
 import {
   type AudioPlayerControls,
   AudioPlayerWithContext,
-} from "./audio-player-with-context";
-import { GenerateButton } from "./generate-button";
+} from './audio-player-with-context';
+import { GenerateButton } from './generate-button';
 
 const NonGrokPromptEditor = dynamic(
-  () => import("./non-grok-editor").then((mod) => mod.NonGrokPromptEditor),
+  () => import('./non-grok-editor').then((mod) => mod.NonGrokPromptEditor),
   { ssr: false },
 );
 
-import { GrokTTSEditor } from "./grok-tts-editor";
-import { Alert, AlertDescription } from "./ui/alert";
+import { GrokTTSEditor } from './grok-tts-editor';
+import { Alert, AlertDescription } from './ui/alert';
 
-interface AnimatedPromptTextareaProps extends ComponentPropsWithoutRef<
-  typeof Textarea
-> {
+interface AnimatedPromptTextareaProps
+  extends ComponentPropsWithoutRef<typeof Textarea> {
   children?: ReactNode;
 }
 
@@ -55,7 +54,7 @@ export const AnimatedPromptTextarea = forwardRef<
     <SpotlightField>
       <Textarea
         className={cn(
-          "border-0 bg-transparent focus-visible:ring-0 focus-visible:ring-offset-0",
+          'border-0 bg-transparent focus-visible:ring-0 focus-visible:ring-offset-0',
           className,
         )}
         onBlur={onBlur}
@@ -67,7 +66,7 @@ export const AnimatedPromptTextarea = forwardRef<
     </SpotlightField>
   );
 });
-AnimatedPromptTextarea.displayName = "AnimatedPromptTextarea";
+AnimatedPromptTextarea.displayName = 'AnimatedPromptTextarea';
 
 interface CreditEstimatorProps {
   buttonLabel: string;
@@ -115,11 +114,11 @@ function CreditEstimator({
 }
 
 interface AudioGeneratorProps {
-  dict: (typeof messages)["generate"];
+  dict: (typeof messages)['generate'];
   hasEnoughCredits: boolean;
   isPaidUser: boolean;
   selectedStyle?: string;
-  selectedVoice?: Tables<"voices">;
+  selectedVoice?: Tables<'voices'>;
 }
 
 export function AudioGenerator({
@@ -129,17 +128,17 @@ export function AudioGenerator({
   selectedStyle,
   selectedVoice,
 }: AudioGeneratorProps) {
-  const [text, setText] = useState("");
-  const [previousText, setPreviousText] = useState("");
+  const [text, setText] = useState('');
+  const [previousText, setPreviousText] = useState('');
   const [isGenerating, setIsGenerating] = useState(false);
-  const [audioURL, setAudioURL] = useState("");
+  const [audioURL, setAudioURL] = useState('');
   const [isEnhancingText, setIsEnhancingText] = useState(false);
   const [isEstimating, setIsEstimating] = useState(false);
   const [estimatedCredits, setEstimatedCredits] = useState<number | null>(null);
   const [playerControls, setPlayerControls] =
     useState<AudioPlayerControls | null>(null);
   const [isFullscreen, setIsFullscreen] = useState(false);
-  const [selectedGrokLanguage, setSelectedGrokLanguage] = useState("auto");
+  const [selectedGrokLanguage, setSelectedGrokLanguage] = useState('auto');
 
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
   const abortController = useRef<AbortController | null>(null);
@@ -150,26 +149,25 @@ export function AudioGenerator({
     () => getTtsProvider(selectedVoice?.model),
     [selectedVoice?.model],
   );
-  const isGeminiVoice = provider === "gemini";
-  const isGrokVoice = provider === "grok";
-  const showEnhanceButton = provider === "replicate";
-
+  const isGeminiVoice = provider === 'gemini';
+  const isGrokVoice = provider === 'grok';
+  const showEnhanceButton = provider === 'replicate';
 
   const charactersLimit = useMemo(
-    () => getCharactersLimit(selectedVoice?.model || "", isPaidUser),
+    () => getCharactersLimit(selectedVoice?.model || '', isPaidUser),
     [selectedVoice, isPaidUser],
   );
 
   const textareaRightPadding = useMemo(() => {
     if (isGeminiVoice) {
-      return "pr-10";
+      return 'pr-10';
     }
 
     if (showEnhanceButton) {
-      return "pr-20";
+      return 'pr-20';
     }
 
-    return "pr-16";
+    return 'pr-16';
   }, [isGeminiVoice, showEnhanceButton]);
 
   const textIsOverLimit = text.length > charactersLimit;
@@ -178,7 +176,7 @@ export function AudioGenerator({
     () => ({
       text,
       voice: selectedVoice?.name,
-      styleVariant: isGeminiVoice ? selectedStyle : "",
+      styleVariant: isGeminiVoice ? selectedStyle : '',
       language: isGrokVoice ? selectedGrokLanguage : undefined,
     }),
     [
@@ -201,10 +199,10 @@ export function AudioGenerator({
     try {
       abortController.current = new AbortController();
 
-      const response = await fetch("/api/generate-voice", {
-        method: "POST",
+      const response = await fetch('/api/generate-voice', {
+        method: 'POST',
         headers: {
-          "Content-Type": "application/json",
+          'Content-Type': 'application/json',
         },
         body: JSON.stringify(requestBody),
         signal: abortController.current.signal,
@@ -218,7 +216,7 @@ export function AudioGenerator({
             data.errorCode as keyof typeof dict
           ] as string;
           throw new APIError(
-            errorMessage.replace("__COUNT__", MAX_FREE_GENERATIONS.toString()),
+            errorMessage.replace('__COUNT__', MAX_FREE_GENERATIONS.toString()),
             response,
           );
         }
@@ -229,7 +227,7 @@ export function AudioGenerator({
       setAudioURL(data.url);
       toast.success(dict.success);
     } catch (error) {
-      if (error instanceof DOMException && error.name === "AbortError") {
+      if (error instanceof DOMException && error.name === 'AbortError') {
         return;
       }
 
@@ -245,21 +243,21 @@ export function AudioGenerator({
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
-      if ((event.metaKey || event.ctrlKey) && event.key === "Enter") {
+      if ((event.metaKey || event.ctrlKey) && event.key === 'Enter') {
         event.preventDefault();
 
         if (!isGenerating && text.trim() && selectedVoice && hasEnoughCredits) {
           handleGenerate().catch((error) => {
-            console.error("Keyboard shortcut generation failed:", error);
+            console.error('Keyboard shortcut generation failed:', error);
           });
         }
       }
     };
 
-    document.addEventListener("keydown", handleKeyDown);
+    document.addEventListener('keydown', handleKeyDown);
 
     return () => {
-      document.removeEventListener("keydown", handleKeyDown);
+      document.removeEventListener('keydown', handleKeyDown);
     };
   }, [handleGenerate, hasEnoughCredits, isGenerating, selectedVoice, text]);
 
@@ -277,9 +275,9 @@ export function AudioGenerator({
   const downloadAudio = async () => {
     if (!audioURL) return;
 
-    const anchorElement = document.createElement("a");
+    const anchorElement = document.createElement('a');
     document.body.appendChild(anchorElement);
-    anchorElement.style.display = "none";
+    anchorElement.style.display = 'none';
 
     try {
       await downloadUrl(audioURL, anchorElement);
@@ -289,8 +287,8 @@ export function AudioGenerator({
   };
 
   const { complete } = useCompletion({
-    api: "/api/generate-text",
-    streamProtocol: "text",
+    api: '/api/generate-text',
+    streamProtocol: 'text',
   });
 
   const handleEnhanceText = async () => {
@@ -306,16 +304,16 @@ export function AudioGenerator({
 
       if (enhancedText) {
         setText(enhancedText);
-        toast("Text enhanced with emotion tags!", {
+        toast('Text enhanced with emotion tags!', {
           action: {
-            label: "Undo",
+            label: 'Undo',
             onClick: () => setText(previousText),
           },
         });
       }
     } catch (error) {
-      console.error("Error enhancing text:", error);
-      toast.error("Failed to enhance text");
+      console.error('Error enhancing text:', error);
+      toast.error('Failed to enhance text');
     } finally {
       setIsEnhancingText(false);
     }
@@ -343,10 +341,10 @@ export function AudioGenerator({
 
     setIsEstimating(true);
     try {
-      const response = await fetch("/api/estimate-credits", {
-        method: "POST",
+      const response = await fetch('/api/estimate-credits', {
+        method: 'POST',
         headers: {
-          "Content-Type": "application/json",
+          'Content-Type': 'application/json',
         },
         body: JSON.stringify({
           text,
@@ -428,8 +426,8 @@ export function AudioGenerator({
 
         <div
           className={cn(
-            "grid grid-cols-1 justify-start gap-3 sm:grid-cols-[1fr_2fr]",
-            hasEnoughCredits ? "" : "flex flex-col items-start",
+            'grid grid-cols-1 justify-start gap-3 sm:grid-cols-[1fr_2fr]',
+            hasEnoughCredits ? '' : 'flex flex-col items-start',
           )}
         >
           {!hasEnoughCredits && (

--- a/apps/web/components/grok-tts-editor.tsx
+++ b/apps/web/components/grok-tts-editor.tsx
@@ -1,10 +1,10 @@
-"use client";
+'use client';
 
-import { Placeholder } from "@tiptap/extensions";
-import { TextSelection } from "@tiptap/pm/state";
-import { EditorContent, EditorContext, useEditor } from "@tiptap/react";
-import StarterKit from "@tiptap/starter-kit";
-import { ChevronDown, Crown, Sparkles } from "lucide-react";
+import { Placeholder } from '@tiptap/extensions';
+import { TextSelection } from '@tiptap/pm/state';
+import { EditorContent, EditorContext, useEditor } from '@tiptap/react';
+import StarterKit from '@tiptap/starter-kit';
+import { ChevronDown, Crown, Sparkles } from 'lucide-react';
 import {
   type MouseEvent,
   useCallback,
@@ -13,39 +13,39 @@ import {
   useMemo,
   useRef,
   useState,
-} from "react";
+} from 'react';
 
-import { AutoConvertGrokTags } from "@/components/grok-tts/extensions/auto-convert-grok-tags";
+import { AutoConvertGrokTags } from '@/components/grok-tts/extensions/auto-convert-grok-tags';
 import {
   createWrapperBoundaryNode,
   WrapperBoundary,
-} from "@/components/grok-tts/extensions/grok-wrapper-boundary";
+} from '@/components/grok-tts/extensions/grok-wrapper-boundary';
 import {
   createInstantTagNode,
   InstantTag,
-} from "@/components/grok-tts/extensions/instant-tag";
-import { UnsupportedGrokTagHighlight } from "@/components/grok-tts/extensions/unsupported-grok-tag-highlight";
-import { SpotlightField } from "@/components/spotlight-field";
-import { Button } from "@/components/ui/button";
+} from '@/components/grok-tts/extensions/instant-tag';
+import { UnsupportedGrokTagHighlight } from '@/components/grok-tts/extensions/unsupported-grok-tag-highlight';
+import { SpotlightField } from '@/components/spotlight-field';
+import { Button } from '@/components/ui/button';
 import {
   Popover,
   PopoverContent,
   PopoverTrigger,
-} from "@/components/ui/popover";
+} from '@/components/ui/popover';
 import {
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from "@/components/ui/select";
+} from '@/components/ui/select';
 import {
   Tooltip,
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
-} from "@/components/ui/tooltip";
-import { useUiEditorState } from "@/hooks/tiptap/use-ui-editor-state";
+} from '@/components/ui/tooltip';
+import { useUiEditorState } from '@/hooks/tiptap/use-ui-editor-state';
 import {
   GROK_EMPTY_WRAPPING_TEXT,
   GROK_INSTANT_TAG_DEFINITIONS,
@@ -54,17 +54,17 @@ import {
   type GrokInstantTag,
   grokTextToTipTapDoc,
   grokTipTapDocToText,
-} from "@/lib/tts-editor";
-import { cn } from "@/lib/utils";
-import type messages from "@/messages/en.json";
-import { UiState } from "./tiptap/tiptap-extension/ui-state-extension";
-import { SlashDropdownMenu } from "./tiptap/tiptap-ui/slash-dropdown-menu";
+} from '@/lib/tts-editor';
+import { cn } from '@/lib/utils';
+import type messages from '@/messages/en.json';
+import { UiState } from './tiptap/tiptap-extension/ui-state-extension';
+import { SlashDropdownMenu } from './tiptap/tiptap-ui/slash-dropdown-menu';
 import type {
   SuggestionItem,
   SuggestionMenuProps,
-} from "./tiptap/tiptap-ui-utils/suggestion-menu";
+} from './tiptap/tiptap-ui-utils/suggestion-menu';
 
-import "./grok-tts-editor.css";
+import './grok-tts-editor.css';
 
 const INSTANT_TAGS = GROK_INSTANT_TAG_DEFINITIONS;
 
@@ -88,29 +88,29 @@ function isKnownInstantTag(tag: string): tag is GrokInstantTag {
 }
 
 const XAI_LANGUAGE_OPTIONS = [
-  { value: "ar-EG", label: "langArabicEgypt" },
-  { value: "ar-SA", label: "langArabicSaudiArabia" },
-  { value: "ar-AE", label: "langArabicUnitedArabEmirates" },
-  { value: "bn", label: "langBengali" },
-  { value: "zh", label: "langChinese" },
-  { value: "fr", label: "langFrench" },
-  { value: "de", label: "langGerman" },
-  { value: "hi", label: "langHindi" },
-  { value: "id", label: "langIndonesian" },
-  { value: "it", label: "langItalian" },
-  { value: "ja", label: "langJapanese" },
-  { value: "ko", label: "langKorean" },
-  { value: "pt-BR", label: "langPortugueseBrazil" },
-  { value: "pt-PT", label: "langPortuguesePortugal" },
-  { value: "ru", label: "langRussian" },
-  { value: "es-ES", label: "langSpanishSpain" },
-  { value: "es-MX", label: "langSpanishMexico" },
-  { value: "tr", label: "langTurkish" },
-  { value: "vi", label: "langVietnamese" },
+  { value: 'ar-EG', label: 'langArabicEgypt' },
+  { value: 'ar-SA', label: 'langArabicSaudiArabia' },
+  { value: 'ar-AE', label: 'langArabicUnitedArabEmirates' },
+  { value: 'bn', label: 'langBengali' },
+  { value: 'zh', label: 'langChinese' },
+  { value: 'fr', label: 'langFrench' },
+  { value: 'de', label: 'langGerman' },
+  { value: 'hi', label: 'langHindi' },
+  { value: 'id', label: 'langIndonesian' },
+  { value: 'it', label: 'langItalian' },
+  { value: 'ja', label: 'langJapanese' },
+  { value: 'ko', label: 'langKorean' },
+  { value: 'pt-BR', label: 'langPortugueseBrazil' },
+  { value: 'pt-PT', label: 'langPortuguesePortugal' },
+  { value: 'ru', label: 'langRussian' },
+  { value: 'es-ES', label: 'langSpanishSpain' },
+  { value: 'es-MX', label: 'langSpanishMexico' },
+  { value: 'tr', label: 'langTurkish' },
+  { value: 'vi', label: 'langVietnamese' },
 ] as const;
 
 interface GrokTTSEditorProps {
-  dict: (typeof messages)["generate"]["grok"];
+  dict: (typeof messages)['generate']['grok'];
   isPaidUser?: boolean;
   maxLength: number;
   onChange: (text: string) => void;
@@ -165,10 +165,10 @@ function getDomSelectionSnapshot(
 }
 
 interface GrokSlashMenuConfig {
-  allow?: NonNullable<SuggestionMenuProps["allow"]>;
+  allow?: NonNullable<SuggestionMenuProps['allow']>;
   customItems: SuggestionItem[];
   pluginKey: string;
-  triggerChar: "[" | "<";
+  triggerChar: '[' | '<';
 }
 
 interface EditorContentAreaProps {
@@ -218,7 +218,7 @@ export function EditorContentArea({ slashMenus }: EditorContentAreaProps) {
       editor={editor}
       role="presentation"
       style={{
-        cursor: isDragging ? "grabbing" : "auto",
+        cursor: isDragging ? 'grabbing' : 'auto',
       }}
     >
       {slashMenus.map((menu) => (
@@ -276,7 +276,7 @@ export function GrokTTSEditor({
       }),
       Placeholder.configure({
         placeholder,
-        emptyNodeClass: "is-empty with-slash",
+        emptyNodeClass: 'is-empty with-slash',
       }),
       InstantTag,
       WrapperBoundary,
@@ -287,13 +287,13 @@ export function GrokTTSEditor({
     content: plainTextToDoc(value),
     editorProps: {
       attributes: {
-        "aria-label": placeholder ?? "TTS editor",
-        role: "textbox",
-        "aria-multiline": "true",
+        'aria-label': placeholder ?? 'TTS editor',
+        role: 'textbox',
+        'aria-multiline': 'true',
         class:
-          "min-h-[8rem] w-full bg-transparent text-sm leading-6 outline-none whitespace-pre-wrap break-words",
-        autoCorrect: "false",
-        spellCheck: "false",
+          'min-h-[8rem] w-full bg-transparent text-sm leading-6 outline-none whitespace-pre-wrap break-words',
+        autoCorrect: 'false',
+        spellCheck: 'false',
       },
       handleDOMEvents: {
         keydown: () => false,
@@ -346,7 +346,7 @@ export function GrokTTSEditor({
       const serialized = grokTipTapDocToText(editor.getJSON());
       const selectedTextLength = selection.empty
         ? 0
-        : editor.state.doc.textBetween(selection.from, selection.to, "\n")
+        : editor.state.doc.textBetween(selection.from, selection.to, '\n')
             .length;
       const nextLength =
         serialized.length - selectedTextLength + tag.tag.length;
@@ -383,12 +383,12 @@ export function GrokTTSEditor({
       }
 
       const openBoundary = createWrapperBoundaryNode(
-        "open",
+        'open',
         tag.tag,
         tag.closeTag,
       );
       const closeBoundary = createWrapperBoundaryNode(
-        "close",
+        'close',
         tag.tag,
         tag.closeTag,
       );
@@ -461,7 +461,7 @@ export function GrokTTSEditor({
 
   const handleInsertTag = useCallback(
     (tag: TagDef) => {
-      if ("closeTag" in tag) {
+      if ('closeTag' in tag) {
         insertWrapperTag(tag);
         return;
       }
@@ -473,8 +473,8 @@ export function GrokTTSEditor({
 
   const translatedGrokLanguages = useMemo(
     () => [
-      { value: "auto", label: dict.langAutomatic },
-      { value: "en", label: dict.langEnglish },
+      { value: 'auto', label: dict.langAutomatic },
+      { value: 'en', label: dict.langEnglish },
       ...XAI_LANGUAGE_OPTIONS.map(({ value, label }) => ({
         value,
         label: dict[label as keyof typeof dict] as string,
@@ -489,21 +489,21 @@ export function GrokTTSEditor({
         customItems: INSTANT_TAGS.map((tag) =>
           createInstantTagSuggestionItem(tag, () => handleInsertTag(tag)),
         ),
-        pluginKey: "grokInstantTagMenu",
-        triggerChar: "[",
+        pluginKey: 'grokInstantTagMenu',
+        triggerChar: '[',
       },
       {
         allow: ({
           editor,
           range,
-        }: Parameters<NonNullable<SuggestionMenuProps["allow"]>>[0]) => {
+        }: Parameters<NonNullable<SuggestionMenuProps['allow']>>[0]) => {
           const resolvedPosition = editor.state.doc.resolve(range.to);
           const nodeAfter = resolvedPosition.nodeAfter;
-          const nextText = nodeAfter?.isText ? (nodeAfter.text ?? "") : "";
+          const nextText = nodeAfter?.isText ? (nodeAfter.text ?? '') : '';
           const previousNode = resolvedPosition.nodeBefore;
           const previousText = previousNode?.isText
-            ? (previousNode.text ?? "")
-            : "";
+            ? (previousNode.text ?? '')
+            : '';
           const combinedTagText = `${previousText}${nextText}`;
 
           return !WRAPPING_TAGS.some((tag) => {
@@ -517,8 +517,8 @@ export function GrokTTSEditor({
         customItems: WRAPPING_TAGS.map((tag) =>
           createWrapperTagSuggestionItem(tag, () => handleInsertTag(tag)),
         ),
-        pluginKey: "grokWrapperTagMenu",
-        triggerChar: "<",
+        pluginKey: 'grokWrapperTagMenu',
+        triggerChar: '<',
       },
     ],
     [handleInsertTag],
@@ -640,8 +640,8 @@ export function GrokTTSEditor({
 
             <div
               className={cn(
-                "flex items-center justify-end gap-1.5 text-muted-foreground text-sm",
-                currentLength > maxLength ? "font-bold text-red-500" : "",
+                'flex items-center justify-end gap-1.5 text-muted-foreground text-sm',
+                currentLength > maxLength ? 'font-bold text-red-500' : '',
               )}
             >
               {currentLength} / {maxLength}
@@ -650,18 +650,18 @@ export function GrokTTSEditor({
                   <TooltipTrigger asChild>
                     <Crown
                       className={cn(
-                        "h-3.5 w-3.5 cursor-default",
+                        'h-3.5 w-3.5 cursor-default',
                         isPaidUser
-                          ? "text-muted-foreground/50"
-                          : "text-yellow-400",
+                          ? 'text-muted-foreground/50'
+                          : 'text-yellow-400',
                       )}
                     />
                   </TooltipTrigger>
                   <TooltipContent>
                     <p>
                       {isPaidUser
-                        ? "Paid users enjoy 2× character limit"
-                        : "Upgrade to a paid plan for 2× character limit"}
+                        ? 'Paid users enjoy 2× character limit'
+                        : 'Upgrade to a paid plan for 2× character limit'}
                     </p>
                   </TooltipContent>
                 </Tooltip>

--- a/apps/web/components/non-grok-editor.tsx
+++ b/apps/web/components/non-grok-editor.tsx
@@ -1,29 +1,22 @@
-"use client";
+'use client';
 
-import {
-  Crown,
-  Info,
-  Loader2,
-  Maximize2,
-  Minimize2,
-  Sparkles,
-} from "lucide-react";
-import type { CSSProperties, RefObject } from "react";
+import { Crown, Loader2, Maximize2, Minimize2, Sparkles } from 'lucide-react';
+import type { CSSProperties, RefObject } from 'react';
 
-import { cn } from "@/lib/utils";
-import type messages from "@/messages/en.json";
-import { AnimatedPromptTextarea } from "./audio-generator";
-import { Button } from "./ui/button";
+import { cn } from '@/lib/utils';
+import type messages from '@/messages/en.json';
+import { AnimatedPromptTextarea } from './audio-generator';
+import { Button } from './ui/button';
 import {
   Tooltip,
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
-} from "./ui/tooltip";
+} from './ui/tooltip';
 
 interface NonGrokPromptEditorProps {
   charactersLimit: number;
-  dict: (typeof messages)["generate"];
+  dict: (typeof messages)['generate'];
   isEnhancingText: boolean;
   isFullscreen: boolean;
   isGenerating: boolean;
@@ -58,7 +51,7 @@ export function NonGrokPromptEditor({
     <>
       <AnimatedPromptTextarea
         className={cn(
-          "textarea-2 bg-transparent transition-[height] duration-200 ease-in-out",
+          'textarea-2 bg-transparent transition-[height] duration-200 ease-in-out',
           textareaRightPadding,
         )}
         maxLength={charactersLimit + 10}
@@ -67,7 +60,7 @@ export function NonGrokPromptEditor({
         ref={textareaRef}
         style={
           {
-            "--ta2-height": isFullscreen ? "30vh" : "8rem",
+            '--ta2-height': isFullscreen ? '30vh' : '8rem',
           } as CSSProperties
         }
         value={text}
@@ -106,8 +99,8 @@ export function NonGrokPromptEditor({
 
       <div
         className={cn(
-          "flex items-center justify-end gap-1.5 text-muted-foreground text-sm",
-          textIsOverLimit ? "font-bold text-red-500" : "",
+          'flex items-center justify-end gap-1.5 text-muted-foreground text-sm',
+          textIsOverLimit ? 'font-bold text-red-500' : '',
         )}
       >
         {text.length} / {charactersLimit}
@@ -116,16 +109,16 @@ export function NonGrokPromptEditor({
             <TooltipTrigger asChild>
               <Crown
                 className={cn(
-                  "h-3.5 w-3.5 cursor-default",
-                  isPaidUser ? "text-muted-foreground/50" : "text-yellow-400",
+                  'h-3.5 w-3.5 cursor-default',
+                  isPaidUser ? 'text-muted-foreground/50' : 'text-yellow-400',
                 )}
               />
             </TooltipTrigger>
             <TooltipContent>
               <p>
                 {isPaidUser
-                  ? "Paid users enjoy 2× character limit"
-                  : "Upgrade to a paid plan for 2× character limit"}
+                  ? 'Paid users enjoy 2× character limit'
+                  : 'Upgrade to a paid plan for 2× character limit'}
               </p>
             </TooltipContent>
           </Tooltip>

--- a/apps/web/components/voice-selector.tsx
+++ b/apps/web/components/voice-selector.tsx
@@ -1,5 +1,5 @@
-"use client";
-import { Info, Maximize2, Minimize2, Sparkles } from "lucide-react";
+'use client';
+import { Info, Maximize2, Minimize2, Sparkles } from 'lucide-react';
 import {
   type Dispatch,
   type SetStateAction,
@@ -7,16 +7,16 @@ import {
   useMemo,
   useRef,
   useState,
-} from "react";
+} from 'react';
 
-import { AudioProvider } from "@/app/[lang]/(dashboard)/dashboard/clone/audio-provider";
+import { AudioProvider } from '@/app/[lang]/(dashboard)/dashboard/clone/audio-provider';
 import {
   Card,
   CardContent,
   CardDescription,
   CardHeader,
   CardTitle,
-} from "@/components/ui/card";
+} from '@/components/ui/card';
 import {
   Select,
   SelectContent,
@@ -25,32 +25,32 @@ import {
   SelectLabel,
   SelectTrigger,
   SelectValue,
-} from "@/components/ui/select";
-import { getEmotionTags } from "@/lib/ai";
-import { resizeTextarea } from "@/lib/react-textarea-autosize";
-import { capitalizeFirstLetter, cn, getTtsProvider } from "@/lib/utils";
-import { isFeaturedVoice } from "@/lib/voices";
-import type messages from "@/messages/en.json";
-import { AudioPlayerWithContext } from "./audio-player-with-context";
-import { Button } from "./ui/button";
-import { Textarea } from "./ui/textarea";
+} from '@/components/ui/select';
+import { getEmotionTags } from '@/lib/ai';
+import { resizeTextarea } from '@/lib/react-textarea-autosize';
+import { capitalizeFirstLetter, cn, getTtsProvider } from '@/lib/utils';
+import { isFeaturedVoice } from '@/lib/voices';
+import type messages from '@/messages/en.json';
+import { AudioPlayerWithContext } from './audio-player-with-context';
+import { Button } from './ui/button';
+import { Textarea } from './ui/textarea';
 import {
   Tooltip,
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
-} from "./ui/tooltip";
+} from './ui/tooltip';
 
 interface VoiceGroup {
   label: string;
-  voices: Tables<"voices">[];
+  voices: Tables<'voices'>[];
 }
 
-function isMultilingualVoice(voice: Tables<"voices">) {
-  return voice.model === "grok" || voice.language === "multiple";
+function isMultilingualVoice(voice: Tables<'voices'>) {
+  return voice.model === 'grok' || voice.language === 'multiple';
 }
 
-function sortVoices(voices: Tables<"voices">[]) {
+function sortVoices(voices: Tables<'voices'>[]) {
   return [...voices].sort((voiceA, voiceB) => {
     const isFeaturedA = isFeaturedVoice(voiceA);
     const isFeaturedB = isFeaturedVoice(voiceB);
@@ -70,30 +70,30 @@ export function VoiceSelector({
   setSelectedStyle,
   dict,
 }: {
-  publicVoices: Tables<"voices">[];
-  selectedVoice?: Tables<"voices">;
+  publicVoices: Tables<'voices'>[];
+  selectedVoice?: Tables<'voices'>;
   setSelectedVoice: Dispatch<SetStateAction<string>>;
   selectedStyle?: string;
   setSelectedStyle: Dispatch<SetStateAction<string | undefined>>;
-  dict: (typeof messages)["generate"];
+  dict: (typeof messages)['generate'];
 }) {
   const provider = useMemo(
     () => getTtsProvider(selectedVoice?.model),
     [selectedVoice?.model],
   );
-  const isGeminiVoice = provider === "gemini";
-  const isGrokVoice = provider === "grok";
+  const isGeminiVoice = provider === 'gemini';
+  const isGrokVoice = provider === 'grok';
   const voiceSelectorLabels =
     dict.voiceSelector as typeof dict.voiceSelector & {
       featuredBadge?: string;
       featuredGroupLabel?: string;
       multilingualGroupLabel?: string;
     };
-  const featuredBadgeLabel = voiceSelectorLabels.featuredBadge ?? "Featured";
+  const featuredBadgeLabel = voiceSelectorLabels.featuredBadge ?? 'Featured';
   const featuredGroupLabel =
-    voiceSelectorLabels.featuredGroupLabel ?? "Featured  ✨";
+    voiceSelectorLabels.featuredGroupLabel ?? 'Featured  ✨';
   const multilingualGroupLabel =
-    voiceSelectorLabels.multilingualGroupLabel ?? "Multilingual 🌍";
+    voiceSelectorLabels.multilingualGroupLabel ?? 'Multilingual 🌍';
   const [isFullscreen, setIsFullscreen] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
 
@@ -101,7 +101,7 @@ export function VoiceSelector({
   useEffect(() => {
     // Auto-resize textarea when content changes
     if (textareaRef.current && !isFullscreen) {
-      resizeTextarea(textareaRef.current, 4, 10, "--ta1-height");
+      resizeTextarea(textareaRef.current, 4, 10, '--ta1-height');
     }
   }, [selectedStyle]);
 
@@ -128,7 +128,7 @@ export function VoiceSelector({
           acc[language].push(voice);
           return acc;
         },
-        {} as Record<string, Tables<"voices">[]>,
+        {} as Record<string, Tables<'voices'>[]>,
       ),
     )
       .map(
@@ -211,8 +211,8 @@ export function VoiceSelector({
                     return (
                       <SelectItem
                         className={cn(
-                          "cursor-pointer py-3",
-                          isFeatured && "font-medium",
+                          'cursor-pointer py-3',
+                          isFeatured && 'font-medium',
                         )}
                         key={voice.id}
                         value={voice.name}
@@ -278,14 +278,14 @@ export function VoiceSelector({
               ref={textareaRef}
               style={
                 {
-                  "--ta1-height": isFullscreen ? "30vh" : "4rem",
+                  '--ta1-height': isFullscreen ? '30vh' : '4rem',
                 } as React.CSSProperties
               }
               value={selectedStyle}
             />
             <Button
               className={
-                "absolute top-2 right-2 h-8 w-8 text-zinc-400 hover:bg-zinc-800 hover:text-white"
+                'absolute top-2 right-2 h-8 w-8 text-zinc-400 hover:bg-zinc-800 hover:text-white'
               }
               onClick={() => setIsFullscreen(!isFullscreen)}
               size="icon"

--- a/apps/web/supabase/functions/telegram-bot/index.ts
+++ b/apps/web/supabase/functions/telegram-bot/index.ts
@@ -159,23 +159,14 @@ async function generateTodayStats(): Promise<string> {
   try {
     // Parallel Fetching
     const [
-      audioTodayResult,
       audioWeekResult,
       audioTotalCountResult,
       clonesResult,
-      profilesRecentResult,
       profilesTotalCountResult,
       callSessionsWeekResult,
       callSessionsTotalCountResult,
       apiKeysTodayResult,
     ] = await Promise.all([
-      // Audio files today
-      supabase
-        .from('audio_files')
-        .select('id, created_at, model, voice_id, voices(name)')
-        .gte('created_at', today.toISOString())
-        .lt('created_at', now.toISOString()),
-
       // Audio files last 7 days
       supabase
         .from('audio_files')
@@ -198,13 +189,6 @@ async function generateTodayStats(): Promise<string> {
           'resemble-ai/chatterbox',
           'voxtral-mini-tts-2603',
         ])
-        .gte('created_at', sevenDaysAgo.toISOString())
-        .lt('created_at', now.toISOString()),
-
-      // Profiles last 7 days
-      supabase
-        .from('profiles')
-        .select('id, created_at, username')
         .gte('created_at', sevenDaysAgo.toISOString())
         .lt('created_at', now.toISOString()),
 
@@ -235,8 +219,66 @@ async function generateTodayStats(): Promise<string> {
         .lt('created_at', now.toISOString()),
     ]);
 
-    // Fetch credit transactions with pagination (to avoid 1000-row cap)
-    const allCreditTransactions: {
+    // Paginated fetch helpers
+
+    const fetchAudioFilesToday = async (): Promise<
+      { id: string; created_at: string; model: string | null }[]
+    > => {
+      const allAudio: { id: string; created_at: string; model: string | null }[] = [];
+      const pageSize = 1000;
+      let offset = 0;
+      let hasMore = true;
+      while (hasMore) {
+        const { data, error } = await supabase
+          .from('audio_files')
+          .select('id, created_at, model')
+          .gte('created_at', today.toISOString())
+          .lt('created_at', now.toISOString())
+          .order('created_at', { ascending: true })
+          .order('id', { ascending: true })
+          .range(offset, offset + pageSize - 1);
+        if (error) throw error;
+        if (data && data.length > 0) {
+          allAudio.push(...data);
+          offset += pageSize;
+          hasMore = data.length === pageSize;
+        } else {
+          hasMore = false;
+        }
+      }
+      return allAudio;
+    };
+
+    const fetchProfilesInRange = async (
+      start: Date,
+      end: Date,
+    ): Promise<{ id: string; created_at: string; username: string | null }[]> => {
+      const allProfiles: { id: string; created_at: string; username: string | null }[] = [];
+      const pageSize = 1000;
+      let offset = 0;
+      let hasMore = true;
+      while (hasMore) {
+        const { data, error } = await supabase
+          .from('profiles')
+          .select('id, created_at, username')
+          .gte('created_at', start.toISOString())
+          .lt('created_at', end.toISOString())
+          .order('created_at', { ascending: true })
+          .order('id', { ascending: true })
+          .range(offset, offset + pageSize - 1);
+        if (error) throw error;
+        if (data && data.length > 0) {
+          allProfiles.push(...data);
+          offset += pageSize;
+          hasMore = data.length === pageSize;
+        } else {
+          hasMore = false;
+        }
+      }
+      return allProfiles;
+    };
+
+    const fetchCreditTransactions = async (): Promise<{
       id: string;
       user_id: string;
       created_at: string;
@@ -245,8 +287,17 @@ async function generateTodayStats(): Promise<string> {
       // biome-ignore lint/suspicious/noExplicitAny: Metadata structure varies
       metadata: any;
       profiles: { username: string } | null;
-    }[] = [];
-    {
+    }[]> => {
+      const allTransactions: {
+        id: string;
+        user_id: string;
+        created_at: string;
+        type: string;
+        description: string | null;
+        // biome-ignore lint/suspicious/noExplicitAny: Metadata structure varies
+        metadata: any;
+        profiles: { username: string } | null;
+      }[] = [];
       const pageSize = 1000;
       let offset = 0;
       let hasMore = true;
@@ -260,23 +311,24 @@ async function generateTodayStats(): Promise<string> {
           .not('description', 'ilike', '%manual%')
           .lt('created_at', now.toISOString())
           .order('created_at', { ascending: true })
+          .order('id', { ascending: true })
           .range(offset, offset + pageSize - 1);
-
         if (error) throw error;
         if (data && data.length > 0) {
-          allCreditTransactions.push(...data);
+          allTransactions.push(...data);
           offset += pageSize;
           hasMore = data.length === pageSize;
         } else {
           hasMore = false;
         }
       }
-    }
+      return allTransactions;
+    };
 
-    // Fetch usage events with pagination
     // biome-ignore lint/suspicious/noExplicitAny: it's ok
-    const allUsageEvents: any[] = [];
-    {
+    const fetchUsageEvents = async (): Promise<any[]> => {
+      // biome-ignore lint/suspicious/noExplicitAny: it's ok
+      const allEvents: any[] = [];
       const pageSize = 1000;
       let offset = 0;
       let hasMore = true;
@@ -289,23 +341,30 @@ async function generateTodayStats(): Promise<string> {
           .gte('occurred_at', sevenDaysAgo.toISOString())
           .lt('occurred_at', now.toISOString())
           .order('occurred_at', { ascending: true })
+          .order('id', { ascending: true })
           .range(offset, offset + pageSize - 1);
-
         if (error) throw error;
         if (data && data.length > 0) {
-          allUsageEvents.push(...data);
+          allEvents.push(...data);
           offset += pageSize;
           hasMore = data.length === pageSize;
         } else {
           hasMore = false;
         }
       }
-    }
+      return allEvents;
+    };
+
+    const [audioTodayData, profilesRecentData, allCreditTransactions, allUsageEvents] = await Promise.all([
+      fetchAudioFilesToday(),
+      fetchProfilesInRange(sevenDaysAgo, now),
+      fetchCreditTransactions(),
+      fetchUsageEvents(),
+    ]);
 
     // --- Processing ---
 
     // Audio
-    const audioTodayData = audioTodayResult.data ?? [];
     const audioTodayCount = audioTodayData.length;
     const audioWeekCount = audioWeekResult.count ?? 0;
     const audioTotalCount = audioTotalCountResult.count ?? 0;
@@ -316,7 +375,6 @@ async function generateTodayStats(): Promise<string> {
     const cloneWeekCount = clonesData.length;
 
     // Profiles
-    const profilesRecentData = profilesRecentResult.data ?? [];
     const profilesTodayData = filterByDateRange(profilesRecentData, today, now);
     const profilesTodayCount = profilesTodayData.length;
     const profilesWeekCount = profilesRecentData.length;

--- a/apps/web/tests/components/grok-tts-editor.test.tsx
+++ b/apps/web/tests/components/grok-tts-editor.test.tsx
@@ -358,6 +358,7 @@ describe('GrokTTSEditor', () => {
     }
 
     await user.click(paragraph);
+    placeCaretAtEnd(editor);
     await user.keyboard('ab');
 
     await waitFor(() => {


### PR DESCRIPTION
Both queries were hitting Supabase's 1000-row cap, causing the audio count
to always show 1000 and the all-time avg call duration to be calculated from
only the first 1000 of 3670+ sessions.

https://claude.ai/code/session_018T6iTvCXZ5ByUhkjfmi7Ny