### PR TITLE
Add credit cost info to reference audio enhancement help text

### DIFF
--- a/apps/web/messages/da.json
+++ b/apps/web/messages/da.json
@@ -576,7 +576,7 @@
     },
     "legalConsentCheckbox": "Ved at bruge stemmekloning bekræfter du, at du har alle juridiske samtykker/rettigheder til at klone disse stemmeprøver, og at du ikke vil bruge noget genereret til ulovlige eller skadelige formål.",
     "referenceAudioEnhancementLabel": "Rens referenceaudioen",
-    "referenceAudioEnhancementHelp": "Fjerner baggrundsstøj og forbedrer taleaudio. Anbefales til støjende optagelser eller optagelser fra mobiltelefon.",
+    "referenceAudioEnhancementHelp": "Fjerner baggrundsstøj og forbedrer taleaudio. Anbefales til støjende optagelser eller optagelser fra mobiltelefon. Dette koster 10 kreditter pr. sekund af det trimmede referenceaudio.",
     "errorEnhancingReferenceAudio": "Referenceaudio kunne ikke forbedres. Prøv igen, eller slå forbedring af referenceaudio fra.",
     "failedToLoadAudioProcessor": "Kunne ikke indlæse lydprocessoren",
     "failedToStartRecording": "Kunne ikke starte optagelse: __ERROR__",

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -580,7 +580,7 @@
     },
     "legalConsentCheckbox": "Durch die Nutzung der Stimmklonung bestätigen Sie, dass Sie alle rechtlichen Einwilligungen/Rechte zum Klonen dieser Stimmproben haben und dass Sie nichts Generiertes für illegale oder schädliche Zwecke verwenden werden.",
     "referenceAudioEnhancementLabel": "Referenz-Audio bereinigen",
-    "referenceAudioEnhancementHelp": "Entfernt Hintergrundgeräusche und verbessert Sprachaufnahmen. Empfohlen für verrauschte oder mit dem Handy aufgenommene Audios.",
+    "referenceAudioEnhancementHelp": "Entfernt Hintergrundgeräusche und verbessert Sprachaufnahmen. Empfohlen für verrauschte oder mit dem Handy aufgenommene Audios. Dies kostet 10 Credits pro Sekunde des zugeschnittenen Referenz-Audios.",
     "errorEnhancingReferenceAudio": "Das Referenz-Audio konnte nicht verbessert werden. Bitte versuchen Sie es erneut oder deaktivieren Sie die Referenz-Audio-Verbesserung.",
     "failedToLoadAudioProcessor": "Audioprozessor konnte nicht geladen werden",
     "failedToStartRecording": "Aufnahme konnte nicht gestartet werden: __ERROR__",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -578,7 +578,7 @@
     },
     "legalConsentCheckbox": "By using voice cloning, you certify that you have all legal consents/rights to clone these voice samples and that you will not use anything generated for illegal or harmful purposes.",
     "referenceAudioEnhancementLabel": "Clean up the reference audio",
-    "referenceAudioEnhancementHelp": "Removes background noise and enhances speech audio. Recommended for noisy or mobile phone recordings.",
+    "referenceAudioEnhancementHelp": "Removes background noise and enhances speech audio. Recommended for noisy or mobile phone recordings. This costs 10 credits per second of reference trimmed audio.",
     "errorEnhancingReferenceAudio": "Failed to enhance reference audio. Please try again or turn off reference audio enhancement.",
     "failedToLoadAudioProcessor": "Failed to load audio processor",
     "failedToStartRecording": "Failed to start recording: __ERROR__",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -578,7 +578,7 @@
     },
     "legalConsentCheckbox": "By using voice cloning, you certify that you have all legal consents/rights to clone these voice samples and that you will not use anything generated for illegal or harmful purposes.",
     "referenceAudioEnhancementLabel": "Clean up the reference audio",
-    "referenceAudioEnhancementHelp": "Removes background noise and enhances speech audio. Recommended for noisy or mobile phone recordings. This costs 10 credits per second of reference trimmed audio.",
+    "referenceAudioEnhancementHelp": "Removes background noise and enhances speech audio. Recommended for noisy or mobile phone recordings. This costs 10 credits per second of trimmed reference audio.",
     "errorEnhancingReferenceAudio": "Failed to enhance reference audio. Please try again or turn off reference audio enhancement.",
     "failedToLoadAudioProcessor": "Failed to load audio processor",
     "failedToStartRecording": "Failed to start recording: __ERROR__",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -580,7 +580,7 @@
     },
     "legalConsentCheckbox": "Al usar la clonación de voz, certificas que tienes todos los consentimientos/derechos legales para clonar estas muestras de voz y que no usarás nada de lo generado para fines ilegales o dañinos.",
     "referenceAudioEnhancementLabel": "Limpiar el audio de referencia",
-    "referenceAudioEnhancementHelp": "Elimina el ruido de fondo y mejora el audio de voz. Recomendado para grabaciones ruidosas o hechas con móvil.",
+    "referenceAudioEnhancementHelp": "Elimina el ruido de fondo y mejora el audio de voz. Recomendado para grabaciones ruidosas o hechas con móvil. Esto cuesta 10 créditos por segundo de audio de referencia recortado.",
     "errorEnhancingReferenceAudio": "No se pudo mejorar el audio de referencia. Inténtalo de nuevo o desactiva la mejora del audio de referencia.",
     "failedToLoadAudioProcessor": "No se pudo cargar el procesador de audio",
     "failedToStartRecording": "No se pudo iniciar la grabación: __ERROR__",

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -580,7 +580,7 @@
     },
     "legalConsentCheckbox": "En utilisant le clonage vocal, vous certifiez que vous disposez de tous les consentements/droits légaux pour cloner ces échantillons vocaux et que vous n'utiliserez rien de ce qui est généré à des fins illégales ou nuisibles.",
     "referenceAudioEnhancementLabel": "Nettoyer l'audio de référence",
-    "referenceAudioEnhancementHelp": "Supprime le bruit de fond et améliore l'audio vocal. Recommandé pour les enregistrements bruyants ou réalisés sur téléphone.",
+    "referenceAudioEnhancementHelp": "Supprime le bruit de fond et améliore l'audio vocal. Recommandé pour les enregistrements bruyants ou réalisés sur téléphone. Cela coûte 10 crédits par seconde d'audio de référence découpé.",
     "errorEnhancingReferenceAudio": "Impossible d'améliorer l'audio de référence. Réessayez ou désactivez l'amélioration de l'audio de référence.",
     "failedToLoadAudioProcessor": "Impossible de charger le processeur audio",
     "failedToStartRecording": "Impossible de démarrer l'enregistrement : __ERROR__",

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -580,7 +580,7 @@
     },
     "legalConsentCheckbox": "Utilizzando la clonazione vocale, certifico di avere tutti i consensi/diritti legali per clonare questi campioni vocali e che non utilizzerò nulla di generato per scopi illegali o dannosi.",
     "referenceAudioEnhancementLabel": "Pulisci l'audio di riferimento",
-    "referenceAudioEnhancementHelp": "Rimuove il rumore di fondo e migliora l'audio parlato. Consigliato per registrazioni rumorose o da telefono.",
+    "referenceAudioEnhancementHelp": "Rimuove il rumore di fondo e migliora l'audio parlato. Consigliato per registrazioni rumorose o da telefono. Questo costa 10 crediti al secondo di audio di riferimento ritagliato.",
     "errorEnhancingReferenceAudio": "Impossibile migliorare l'audio di riferimento. Riprova oppure disattiva il miglioramento dell'audio di riferimento.",
     "failedToLoadAudioProcessor": "Impossibile caricare il processore audio",
     "failedToStartRecording": "Impossibile avviare la registrazione: __ERROR__",


### PR DESCRIPTION
Updates the `referenceAudioEnhancementHelp` translation in all 6 locales (en, es, de, da, it, fr) to inform users that audio cleanup costs 10 credits per second of trimmed reference audio.

https://claude.ai/code/session_01UDbqi9AaSkjg8QwUHx8GD3