### PR TITLE
Codex: automation sentry may 11

### DIFF
--- a/apps/web/app/[lang]/actions/stripe.ts
+++ b/apps/web/app/[lang]/actions/stripe.ts
@@ -1,6 +1,6 @@
 'use server';
 
-import { captureException } from '@sentry/nextjs';
+import { captureException, captureMessage } from '@sentry/nextjs';
 import type { Stripe } from 'stripe';
 
 import { getTopupPackages, type PackageType } from '@/lib/stripe/pricing';
@@ -22,6 +22,9 @@ const isCheckoutPackageId = (value: unknown): value is CheckoutPackageId =>
   CHECKOUT_PACKAGE_IDS.includes(value as CheckoutPackageId);
 
 const shouldReportCheckoutConfigurationError = () =>
+  process.env.VERCEL_ENV === 'production';
+
+const shouldReportInvalidCheckoutPackageId = () =>
   process.env.VERCEL_ENV === 'production';
 
 const isCheckoutSetupError = (
@@ -125,6 +128,24 @@ export async function createCheckoutSession(
   } catch (error) {
     console.error('Error creating checkout session:', error);
     if (isCheckoutSetupError(error)) {
+      if (
+        error.cause === CHECKOUT_INVALID_PACKAGE_ID &&
+        shouldReportInvalidCheckoutPackageId()
+      ) {
+        captureMessage('Invalid checkout package id submitted.', {
+          level: 'info',
+          tags: {
+            section: 'stripe_actions',
+            event_type: 'invalid_package_id',
+          },
+          extra: {
+            packageId,
+            available_packages: CHECKOUT_PACKAGE_IDS,
+            vercelEnv: process.env.VERCEL_ENV ?? null,
+          },
+        });
+      }
+
       if (
         error.cause === CHECKOUT_CONFIGURATION_ERROR &&
         shouldReportCheckoutConfigurationError()

--- a/apps/web/app/[lang]/actions/stripe.ts
+++ b/apps/web/app/[lang]/actions/stripe.ts
@@ -1,6 +1,6 @@
 'use server';
 
-import * as Sentry from '@sentry/nextjs';
+import { captureException } from '@sentry/nextjs';
 import type { Stripe } from 'stripe';
 
 import { getTopupPackages, type PackageType } from '@/lib/stripe/pricing';
@@ -8,10 +8,29 @@ import { stripe } from '@/lib/stripe/stripe-admin';
 import { getUserById } from '@/lib/supabase/queries';
 import { createClient } from '@/lib/supabase/server';
 
+const CHECKOUT_CONFIGURATION_ERROR = 'CHECKOUT_CONFIGURATION_ERROR';
+const CHECKOUT_INVALID_PACKAGE_ID = 'CHECKOUT_INVALID_PACKAGE_ID';
+const CHECKOUT_PACKAGE_IDS = ['starter', 'standard', 'pro'] as const;
+
+type CheckoutPackageId = (typeof CHECKOUT_PACKAGE_IDS)[number];
+
+const isCheckoutPackageId = (value: unknown): value is CheckoutPackageId =>
+  typeof value === 'string' &&
+  CHECKOUT_PACKAGE_IDS.includes(value as CheckoutPackageId);
+
+const shouldReportCheckoutConfigurationError = () =>
+  process.env.VERCEL_ENV === 'production';
+
+const isCheckoutSetupError = (error: unknown) =>
+  Error.isError(error) &&
+  [CHECKOUT_CONFIGURATION_ERROR, CHECKOUT_INVALID_PACKAGE_ID].includes(
+    String(error.cause),
+  );
+
 export interface CheckoutMetadata {
   credits: string;
   dollarAmount: string;
-  packageId: PackageType;
+  packageId: CheckoutPackageId;
   promo?: string;
   type: 'topup';
   userId: string;
@@ -26,26 +45,19 @@ export async function createCheckoutSession(
       'uiMode',
     ) as Stripe.Checkout.SessionCreateParams.UiMode;
 
+    if (!isCheckoutPackageId(packageId)) {
+      throw new Error('Invalid checkout package', {
+        cause: CHECKOUT_INVALID_PACKAGE_ID,
+      });
+    }
+
     const package_ = getTopupPackages('en')[packageId];
 
     // Verify the price ID exists to avoid runtime errors
     if (!package_?.priceId) {
-      const error = new Error('Invalid package id');
-      console.error(
-        `Missing price ID for package id: ${packageId} - priceId: ${package_?.priceId}`,
-      );
-      Sentry.captureException(error, {
-        tags: {
-          section: 'stripe_actions',
-          event_type: 'missing_price_id',
-        },
-        extra: {
-          packageId,
-          priceId: package_?.priceId,
-          available_packages: Object.keys(getTopupPackages('en')),
-        },
+      throw new Error('Checkout package missing price ID', {
+        cause: CHECKOUT_CONFIGURATION_ERROR,
       });
-      throw error;
     }
 
     const supabase = await createClient();
@@ -57,7 +69,7 @@ export async function createCheckoutSession(
     // biome-ignore lint/complexity/useOptionalChain: needed
     if (!(userData && userData.stripe_id)) {
       const error = new Error('User not found or Stripe ID missing');
-      Sentry.captureException(error, {
+      captureException(error, {
         user: { id: user?.id, email: user?.email },
         tags: {
           section: 'stripe_actions',
@@ -107,7 +119,29 @@ export async function createCheckoutSession(
     };
   } catch (error) {
     console.error('Error creating checkout session:', error);
-    Sentry.captureException(error, {
+    if (isCheckoutSetupError(error)) {
+      if (
+        Error.isError(error) &&
+        error.cause === CHECKOUT_CONFIGURATION_ERROR &&
+        shouldReportCheckoutConfigurationError()
+      ) {
+        captureException(error, {
+          tags: {
+            section: 'stripe_actions',
+            event_type: 'missing_price_id',
+          },
+          extra: {
+            packageId,
+            available_packages: Object.keys(getTopupPackages('en')),
+            vercelEnv: process.env.VERCEL_ENV ?? null,
+          },
+        });
+      }
+
+      throw error;
+    }
+
+    captureException(error, {
       tags: {
         section: 'stripe_actions',
         event_type: 'checkout_session_creation_error',

--- a/apps/web/app/[lang]/actions/stripe.ts
+++ b/apps/web/app/[lang]/actions/stripe.ts
@@ -10,9 +10,12 @@ import { createClient } from '@/lib/supabase/server';
 
 const CHECKOUT_CONFIGURATION_ERROR = 'CHECKOUT_CONFIGURATION_ERROR';
 const CHECKOUT_INVALID_PACKAGE_ID = 'CHECKOUT_INVALID_PACKAGE_ID';
-const CHECKOUT_PACKAGE_IDS = ['starter', 'standard', 'pro'] as const;
 
-type CheckoutPackageId = (typeof CHECKOUT_PACKAGE_IDS)[number];
+type CheckoutPackageId = Exclude<PackageType, 'free'>;
+
+const CHECKOUT_PACKAGE_IDS = Object.keys(getTopupPackages('en')).filter(
+  (packageId): packageId is CheckoutPackageId => packageId !== 'free',
+);
 
 const isCheckoutPackageId = (value: unknown): value is CheckoutPackageId =>
   typeof value === 'string' &&
@@ -21,7 +24,9 @@ const isCheckoutPackageId = (value: unknown): value is CheckoutPackageId =>
 const shouldReportCheckoutConfigurationError = () =>
   process.env.VERCEL_ENV === 'production';
 
-const isCheckoutSetupError = (error: unknown) =>
+const isCheckoutSetupError = (
+  error: unknown,
+): error is Error & { cause: unknown } =>
   Error.isError(error) &&
   [CHECKOUT_CONFIGURATION_ERROR, CHECKOUT_INVALID_PACKAGE_ID].includes(
     String(error.cause),
@@ -38,7 +43,7 @@ export interface CheckoutMetadata {
 
 export async function createCheckoutSession(
   data: FormData,
-  packageId: PackageType,
+  packageId: CheckoutPackageId,
 ): Promise<{ client_secret: string | null; url: string | null }> {
   try {
     const ui_mode = data.get(
@@ -121,7 +126,6 @@ export async function createCheckoutSession(
     console.error('Error creating checkout session:', error);
     if (isCheckoutSetupError(error)) {
       if (
-        Error.isError(error) &&
         error.cause === CHECKOUT_CONFIGURATION_ERROR &&
         shouldReportCheckoutConfigurationError()
       ) {

--- a/apps/web/app/api/generate-voice/route.ts
+++ b/apps/web/app/api/generate-voice/route.ts
@@ -185,7 +185,7 @@ export async function POST(request: Request) {
     });
 
     // const requestedGrokCodec = normalizeXaiTtsCodec(outputCodec);
-    const fileExtension = isGeminiVoice ? 'wav' : isGrokVoice ? 'mp3' : 'wav';
+    const fileExtension = isGrokVoice ? 'mp3' : 'wav';
     const filename = `${path}.${fileExtension}`;
     const result = await redis.get<string>(filename);
 
@@ -659,6 +659,15 @@ export async function POST(request: Request) {
     }
 
     if (Error.isError(error) && error.cause === 'PROHIBITED_CONTENT') {
+      return NextResponse.json(
+        {
+          error: error.message || 'Voice generation failed, please retry',
+        },
+        { status: getErrorStatusCode(error.cause) },
+      );
+    }
+
+    if (Error.isError(error) && error.cause === 'OTHER_GEMINI_BLOCK') {
       return NextResponse.json(
         {
           error: error.message || 'Voice generation failed, please retry',

--- a/apps/web/app/auth/callback/route.ts
+++ b/apps/web/app/auth/callback/route.ts
@@ -42,6 +42,58 @@ const getOauthCodeFingerprint = (code: string | null) => {
   };
 };
 
+const getErrorStringProperty = (
+  error: unknown,
+  property: 'message' | 'name',
+) => {
+  if (error instanceof Error) {
+    return error[property];
+  }
+
+  if (typeof error !== 'object' || error === null || !(property in error)) {
+    return '';
+  }
+
+  const value = (error as Record<typeof property, unknown>)[property];
+  return typeof value === 'string' ? value : String(value ?? '');
+};
+
+const isPkceCodeVerifierMissingError = (error: unknown) => {
+  const errorName = getErrorStringProperty(error, 'name');
+  const errorMessage = getErrorStringProperty(error, 'message');
+  return (
+    errorName === 'AuthPKCECodeVerifierMissingError' ||
+    errorMessage.includes('PKCE code verifier not found')
+  );
+};
+
+const getOauthCallbackCookieContext = (request: Request) => {
+  const cookieHeader = request.headers.get('cookie') ?? '';
+  const cookieNames = cookieHeader
+    .split(';')
+    .map((cookie) => cookie.split('=')[0]?.trim())
+    .filter((name): name is string => Boolean(name));
+  const supabaseCookieNames = cookieNames.filter((name) => {
+    const lowerName = name.toLowerCase();
+    return lowerName.startsWith('sb-') || lowerName.includes('supabase');
+  });
+
+  return {
+    hasCookieHeader: Boolean(cookieHeader),
+    cookieCount: cookieNames.length,
+    supabaseCookieCount: supabaseCookieNames.length,
+    hasSupabaseAuthCookie: supabaseCookieNames.some((name) =>
+      name.includes('auth-token'),
+    ),
+    hasSupabaseCodeVerifierCookie: supabaseCookieNames.some((name) =>
+      name.includes('code-verifier'),
+    ),
+    hasOauthCallbackMarkerCookie: cookieNames.includes(
+      OAUTH_CALLBACK_COOKIE_NAME,
+    ),
+  };
+};
+
 const createOauthRedirectResponse = (url: string) => {
   const response = NextResponse.redirect(url);
   const markerValue = createOauthCallbackMarkerValue();
@@ -72,6 +124,7 @@ export async function GET(request: Request) {
   const locale = getLocaleFromRedirectPath(redirectTo);
   const loginPath = `/${locale}/login`;
   const oauthCodeContext = getOauthCodeFingerprint(code);
+  const oauthCookieContext = getOauthCallbackCookieContext(request);
 
   try {
     if (!code) {
@@ -84,6 +137,26 @@ export async function GET(request: Request) {
     } = await supabase.auth.exchangeCodeForSession(code);
 
     if (exchangeError) {
+      if (isPkceCodeVerifierMissingError(exchangeError)) {
+        captureMessage('OAuth callback missing PKCE code verifier.', {
+          level: 'warning',
+          tags: {
+            area: 'auth',
+            flow: 'oauth-callback',
+            error_type: 'pkce_code_verifier_missing',
+          },
+          extra: {
+            redirectTo,
+            locale,
+            ...oauthCodeContext,
+            ...oauthCookieContext,
+            errorMessage: exchangeError.message,
+          },
+        });
+
+        return NextResponse.redirect(`${origin}${loginPath}`);
+      }
+
       captureException(exchangeError, {
         tags: {
           area: 'auth',
@@ -93,6 +166,7 @@ export async function GET(request: Request) {
           redirectTo,
           locale,
           ...oauthCodeContext,
+          ...oauthCookieContext,
         },
       });
 
@@ -153,6 +227,26 @@ export async function GET(request: Request) {
       `${origin}/${routing.defaultLocale}/dashboard`,
     );
   } catch (error) {
+    if (isPkceCodeVerifierMissingError(error)) {
+      captureMessage('OAuth callback missing PKCE code verifier.', {
+        level: 'warning',
+        tags: {
+          area: 'auth',
+          flow: 'oauth-callback',
+          error_type: 'pkce_code_verifier_missing',
+        },
+        extra: {
+          redirectTo,
+          locale,
+          ...oauthCodeContext,
+          ...oauthCookieContext,
+          errorMessage: error instanceof Error ? error.message : String(error),
+        },
+      });
+
+      return NextResponse.redirect(`${origin}${loginPath}`);
+    }
+
     captureException(error, {
       tags: {
         area: 'auth',
@@ -162,6 +256,7 @@ export async function GET(request: Request) {
         redirectTo,
         locale,
         ...oauthCodeContext,
+        ...oauthCookieContext,
       },
     });
 

--- a/apps/web/app/auth/callback/route.ts
+++ b/apps/web/app/auth/callback/route.ts
@@ -54,8 +54,15 @@ const getErrorStringProperty = (
     return '';
   }
 
-  const value = (error as Record<typeof property, unknown>)[property];
-  return typeof value === 'string' ? value : String(value ?? '');
+  return String((error as Record<string, unknown>)[property] ?? '');
+};
+
+const getErrorMessage = (error: unknown) => {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return String(error);
 };
 
 const isPkceCodeVerifierMissingError = (error: unknown) => {
@@ -63,6 +70,7 @@ const isPkceCodeVerifierMissingError = (error: unknown) => {
   const errorMessage = getErrorStringProperty(error, 'message');
   return (
     errorName === 'AuthPKCECodeVerifierMissingError' ||
+    // Defensive fallback for serialized Supabase errors that preserve only message text.
     errorMessage.includes('PKCE code verifier not found')
   );
 };
@@ -125,6 +133,25 @@ export async function GET(request: Request) {
   const loginPath = `/${locale}/login`;
   const oauthCodeContext = getOauthCodeFingerprint(code);
   const oauthCookieContext = getOauthCallbackCookieContext(request);
+  const reportPkceCodeVerifierMissing = (error: unknown) => {
+    captureMessage('OAuth callback missing PKCE code verifier.', {
+      level: 'warning',
+      tags: {
+        area: 'auth',
+        flow: 'oauth-callback',
+        error_type: 'pkce-code-verifier-missing',
+      },
+      extra: {
+        redirectTo,
+        locale,
+        ...oauthCodeContext,
+        ...oauthCookieContext,
+        errorMessage: getErrorMessage(error),
+      },
+    });
+
+    return NextResponse.redirect(`${origin}${loginPath}`);
+  };
 
   try {
     if (!code) {
@@ -138,23 +165,7 @@ export async function GET(request: Request) {
 
     if (exchangeError) {
       if (isPkceCodeVerifierMissingError(exchangeError)) {
-        captureMessage('OAuth callback missing PKCE code verifier.', {
-          level: 'warning',
-          tags: {
-            area: 'auth',
-            flow: 'oauth-callback',
-            error_type: 'pkce_code_verifier_missing',
-          },
-          extra: {
-            redirectTo,
-            locale,
-            ...oauthCodeContext,
-            ...oauthCookieContext,
-            errorMessage: exchangeError.message,
-          },
-        });
-
-        return NextResponse.redirect(`${origin}${loginPath}`);
+        return reportPkceCodeVerifierMissing(exchangeError);
       }
 
       captureException(exchangeError, {
@@ -228,23 +239,7 @@ export async function GET(request: Request) {
     );
   } catch (error) {
     if (isPkceCodeVerifierMissingError(error)) {
-      captureMessage('OAuth callback missing PKCE code verifier.', {
-        level: 'warning',
-        tags: {
-          area: 'auth',
-          flow: 'oauth-callback',
-          error_type: 'pkce_code_verifier_missing',
-        },
-        extra: {
-          redirectTo,
-          locale,
-          ...oauthCodeContext,
-          ...oauthCookieContext,
-          errorMessage: error instanceof Error ? error.message : String(error),
-        },
-      });
-
-      return NextResponse.redirect(`${origin}${loginPath}`);
+      return reportPkceCodeVerifierMissing(error);
     }
 
     captureException(error, {

--- a/apps/web/lib/edge-config/call-instructions.ts
+++ b/apps/web/lib/edge-config/call-instructions.ts
@@ -19,11 +19,16 @@ const FALLBACK_CONFIG: CallInstructionConfig = {
 const shouldReportEdgeConfigError = () =>
   process.env.VERCEL_ENV === 'production';
 
+let hasReportedMissingEdgeConfig = false;
+let hasReportedEdgeConfigLoadFailure = false;
+
 export async function getCallInstructionConfig(): Promise<CallInstructionConfig> {
   if (!process.env.EDGE_CONFIG) {
-    if (shouldReportEdgeConfigError()) {
+    if (shouldReportEdgeConfigError() && !hasReportedMissingEdgeConfig) {
+      hasReportedMissingEdgeConfig = true;
       captureMessage('Edge Config connection string missing.', {
         level: 'warning',
+        fingerprint: ['edge-config-missing'],
         tags: {
           area: 'edge-config',
           config: 'call-instructions',
@@ -45,8 +50,10 @@ export async function getCallInstructionConfig(): Promise<CallInstructionConfig>
       presetInstructions: config?.presetInstructions,
     };
   } catch (error) {
-    if (shouldReportEdgeConfigError()) {
+    if (shouldReportEdgeConfigError() && !hasReportedEdgeConfigLoadFailure) {
+      hasReportedEdgeConfigLoadFailure = true;
       captureException(error, {
+        fingerprint: ['edge-config-load-failure'],
         extra: {
           message: 'Failed to load "call-instructions" from Edge Config',
         },

--- a/apps/web/lib/edge-config/call-instructions.ts
+++ b/apps/web/lib/edge-config/call-instructions.ts
@@ -1,4 +1,4 @@
-import { captureException } from '@sentry/nextjs';
+import { captureException, captureMessage } from '@sentry/nextjs';
 import { get } from '@vercel/edge-config';
 
 import { instructions as fallbackInstructions } from '@/data/default-config';
@@ -16,7 +16,24 @@ const FALLBACK_CONFIG: CallInstructionConfig = {
   initialInstruction: fallbackInitialInstruction,
 };
 
+const shouldReportEdgeConfigError = () =>
+  process.env.VERCEL_ENV === 'production';
+
 export async function getCallInstructionConfig(): Promise<CallInstructionConfig> {
+  if (!process.env.EDGE_CONFIG) {
+    if (shouldReportEdgeConfigError()) {
+      captureMessage('Edge Config connection string missing.', {
+        level: 'warning',
+        tags: {
+          area: 'edge-config',
+          config: 'call-instructions',
+        },
+      });
+    }
+
+    return FALLBACK_CONFIG;
+  }
+
   try {
     const config =
       await get<Partial<CallInstructionConfig>>('call-instructions');
@@ -28,11 +45,13 @@ export async function getCallInstructionConfig(): Promise<CallInstructionConfig>
       presetInstructions: config?.presetInstructions,
     };
   } catch (error) {
-    captureException(error, {
-      extra: {
-        message: 'Failed to load "call-instructions" from Edge Config',
-      },
-    });
+    if (shouldReportEdgeConfigError()) {
+      captureException(error, {
+        extra: {
+          message: 'Failed to load "call-instructions" from Edge Config',
+        },
+      });
+    }
 
     return FALLBACK_CONFIG;
   }

--- a/apps/web/tests/auth-callback.test.ts
+++ b/apps/web/tests/auth-callback.test.ts
@@ -1,0 +1,140 @@
+import { captureException, captureMessage } from '@sentry/nextjs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { GET } from '@/app/auth/callback/route';
+import { createClient } from '@/lib/supabase/server';
+
+vi.mock('@/lib/stripe/stripe-admin', () => ({
+  createOrRetrieveCustomer: vi.fn().mockResolvedValue('cus_test'),
+}));
+
+vi.mock('@/lib/posthog', () => ({
+  default: vi.fn(() => ({
+    capture: vi.fn(),
+    shutdown: vi.fn().mockResolvedValue(undefined),
+  })),
+}));
+
+vi.mock('next/server', () => ({
+  NextResponse: {
+    redirect: (url: string | URL, init?: ResponseInit | number) => {
+      const responseInit = typeof init === 'object' ? init : undefined;
+      return new Response(null, {
+        ...responseInit,
+        status: typeof init === 'number' ? init : (responseInit?.status ?? 307),
+        headers: {
+          location: String(url),
+        },
+      });
+    },
+  },
+}));
+
+describe('OAuth callback route', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('downgrades missing PKCE verifier errors to warning telemetry', async () => {
+    const exchangeError = new Error('PKCE code verifier not found in storage.');
+    exchangeError.name = 'AuthPKCECodeVerifierMissingError';
+    const exchangeCodeForSession = vi.fn().mockResolvedValue({
+      data: { user: null },
+      error: exchangeError,
+    });
+
+    vi.mocked(createClient).mockResolvedValueOnce({
+      auth: { exchangeCodeForSession },
+    } as unknown as Awaited<ReturnType<typeof createClient>>);
+
+    const response = await GET(
+      new Request(
+        'https://sexyvoice.ai/auth/callback?code=abc123&redirect_to=%2Fen%2Fdashboard',
+        {
+          headers: {
+            cookie:
+              'sb-test-auth-token=token; sv_oauth_callback_ok=marker-value',
+          },
+        },
+      ),
+    );
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get('location')).toBe(
+      'https://sexyvoice.ai/en/login',
+    );
+    expect(exchangeCodeForSession).toHaveBeenCalledWith('abc123');
+    expect(captureException).not.toHaveBeenCalled();
+    expect(captureMessage).toHaveBeenCalledWith(
+      'OAuth callback missing PKCE code verifier.',
+      expect.objectContaining({
+        level: 'warning',
+        tags: {
+          area: 'auth',
+          flow: 'oauth-callback',
+          error_type: 'pkce_code_verifier_missing',
+        },
+        extra: expect.objectContaining({
+          redirectTo: '/en/dashboard',
+          locale: 'en',
+          hasCode: true,
+          codeLength: 6,
+          hasCookieHeader: true,
+          cookieCount: 2,
+          supabaseCookieCount: 1,
+          hasSupabaseAuthCookie: true,
+          hasSupabaseCodeVerifierCookie: false,
+          hasOauthCallbackMarkerCookie: true,
+          errorMessage: 'PKCE code verifier not found in storage.',
+        }),
+      }),
+    );
+  });
+
+  it('keeps unexpected exchange failures as exceptions with cookie context', async () => {
+    const exchangeError = new Error('Unexpected auth exchange failure');
+    const exchangeCodeForSession = vi.fn().mockResolvedValue({
+      data: { user: null },
+      error: exchangeError,
+    });
+
+    vi.mocked(createClient).mockResolvedValueOnce({
+      auth: { exchangeCodeForSession },
+    } as unknown as Awaited<ReturnType<typeof createClient>>);
+
+    const response = await GET(
+      new Request(
+        'https://sexyvoice.ai/auth/callback?code=abc123&redirect_to=%2Fen%2Fdashboard',
+        {
+          headers: {
+            cookie:
+              'sb-test-auth-token=token; sb-test-auth-token-code-verifier=verifier',
+          },
+        },
+      ),
+    );
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get('location')).toBe(
+      'https://sexyvoice.ai/en/login',
+    );
+    expect(captureMessage).not.toHaveBeenCalledWith(
+      'OAuth callback missing PKCE code verifier.',
+      expect.anything(),
+    );
+    expect(captureException).toHaveBeenCalledWith(
+      exchangeError,
+      expect.objectContaining({
+        tags: {
+          area: 'auth',
+          flow: 'oauth-callback',
+        },
+        extra: expect.objectContaining({
+          hasSupabaseAuthCookie: true,
+          hasSupabaseCodeVerifierCookie: true,
+          supabaseCookieCount: 2,
+        }),
+      }),
+    );
+  });
+});

--- a/apps/web/tests/auth-callback.test.ts
+++ b/apps/web/tests/auth-callback.test.ts
@@ -72,7 +72,7 @@ describe('OAuth callback route', () => {
         tags: {
           area: 'auth',
           flow: 'oauth-callback',
-          error_type: 'pkce_code_verifier_missing',
+          error_type: 'pkce-code-verifier-missing',
         },
         extra: expect.objectContaining({
           redirectTo: '/en/dashboard',

--- a/apps/web/tests/call-instructions.test.ts
+++ b/apps/web/tests/call-instructions.test.ts
@@ -1,0 +1,77 @@
+import { captureException, captureMessage } from '@sentry/nextjs';
+import { get } from '@vercel/edge-config';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { getCallInstructionConfig } from '@/lib/edge-config/call-instructions';
+
+vi.mock('@vercel/edge-config', () => ({
+  get: vi.fn(),
+}));
+
+describe('getCallInstructionConfig()', () => {
+  const originalEdgeConfig = process.env.EDGE_CONFIG;
+  const originalVercelEnv = process.env.VERCEL_ENV;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    if (originalEdgeConfig === undefined) {
+      delete process.env.EDGE_CONFIG;
+    } else {
+      process.env.EDGE_CONFIG = originalEdgeConfig;
+    }
+
+    if (originalVercelEnv === undefined) {
+      delete process.env.VERCEL_ENV;
+    } else {
+      process.env.VERCEL_ENV = originalVercelEnv;
+    }
+  });
+
+  it('uses fallback config quietly when Edge Config is not configured outside production', async () => {
+    delete process.env.EDGE_CONFIG;
+    process.env.VERCEL_ENV = 'preview';
+
+    const config = await getCallInstructionConfig();
+
+    expect(config.defaultInstructions).toBeTruthy();
+    expect(config.initialInstruction).toBeTruthy();
+    expect(get).not.toHaveBeenCalled();
+    expect(captureMessage).not.toHaveBeenCalled();
+    expect(captureException).not.toHaveBeenCalled();
+  });
+
+  it('reports missing Edge Config only in Vercel production', async () => {
+    delete process.env.EDGE_CONFIG;
+    process.env.VERCEL_ENV = 'production';
+
+    await getCallInstructionConfig();
+
+    expect(get).not.toHaveBeenCalled();
+    expect(captureMessage).toHaveBeenCalledWith(
+      'Edge Config connection string missing.',
+      expect.objectContaining({
+        level: 'warning',
+        tags: {
+          area: 'edge-config',
+          config: 'call-instructions',
+        },
+      }),
+    );
+  });
+
+  it('suppresses Edge Config fetch failures outside Vercel production', async () => {
+    process.env.EDGE_CONFIG = 'edge-config-connection';
+    process.env.VERCEL_ENV = 'preview';
+    vi.mocked(get).mockRejectedValueOnce(new Error('Edge Config unavailable'));
+
+    const config = await getCallInstructionConfig();
+
+    expect(config.defaultInstructions).toBeTruthy();
+    expect(config.initialInstruction).toBeTruthy();
+    expect(get).toHaveBeenCalledWith('call-instructions');
+    expect(captureException).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/tests/call-instructions.test.ts
+++ b/apps/web/tests/call-instructions.test.ts
@@ -48,12 +48,15 @@ describe('getCallInstructionConfig()', () => {
     process.env.VERCEL_ENV = 'production';
 
     await getCallInstructionConfig();
+    await getCallInstructionConfig();
 
     expect(get).not.toHaveBeenCalled();
+    expect(captureMessage).toHaveBeenCalledTimes(1);
     expect(captureMessage).toHaveBeenCalledWith(
       'Edge Config connection string missing.',
       expect.objectContaining({
         level: 'warning',
+        fingerprint: ['edge-config-missing'],
         tags: {
           area: 'edge-config',
           config: 'call-instructions',
@@ -73,5 +76,27 @@ describe('getCallInstructionConfig()', () => {
     expect(config.initialInstruction).toBeTruthy();
     expect(get).toHaveBeenCalledWith('call-instructions');
     expect(captureException).not.toHaveBeenCalled();
+  });
+
+  it('reports Edge Config fetch failures once in Vercel production', async () => {
+    process.env.EDGE_CONFIG = 'edge-config-connection';
+    process.env.VERCEL_ENV = 'production';
+    const error = new Error('Edge Config unavailable');
+    vi.mocked(get).mockRejectedValue(error);
+
+    await getCallInstructionConfig();
+    await getCallInstructionConfig();
+
+    expect(get).toHaveBeenCalledTimes(2);
+    expect(captureException).toHaveBeenCalledTimes(1);
+    expect(captureException).toHaveBeenCalledWith(
+      error,
+      expect.objectContaining({
+        fingerprint: ['edge-config-load-failure'],
+        extra: {
+          message: 'Failed to load "call-instructions" from Edge Config',
+        },
+      }),
+    );
   });
 });

--- a/apps/web/tests/generate-voice.test.ts
+++ b/apps/web/tests/generate-voice.test.ts
@@ -1147,6 +1147,22 @@ As I held up her dress, stared at her mom's eye, white as can be, on the toilet,
       expect(json.error).toBe(
         getErrorMessage('OTHER_GEMINI_BLOCK', 'voice-generation'),
       );
+      expect(Sentry.captureException).toHaveBeenCalledTimes(1);
+      expect(Sentry.captureException).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: 'Gemini 200 — no audio data',
+        }),
+        expect.objectContaining({
+          extra: expect.objectContaining({
+            finishReason: undefined,
+            hasData: false,
+            mimeType: 'audio/wav',
+            model: 'gemini-2.5-flash-preview-tts',
+            voice: 'kore',
+          }),
+          user: { id: 'test-user-id' },
+        }),
+      );
     });
 
     it('should throw error when Gemini response has no mimeType', async () => {
@@ -1186,6 +1202,22 @@ As I held up her dress, stared at her mom's eye, white as can be, on the toilet,
       expect(response.status).toBe(500);
       expect(json.error).toBe(
         getErrorMessage('OTHER_GEMINI_BLOCK', 'voice-generation'),
+      );
+      expect(Sentry.captureException).toHaveBeenCalledTimes(1);
+      expect(Sentry.captureException).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: 'Gemini 200 — no audio data',
+        }),
+        expect.objectContaining({
+          extra: expect.objectContaining({
+            finishReason: undefined,
+            hasData: true,
+            mimeType: undefined,
+            model: 'gemini-2.5-flash-preview-tts',
+            voice: 'kore',
+          }),
+          user: { id: 'test-user-id' },
+        }),
       );
     });
 

--- a/apps/web/tests/generate-voice.test.ts
+++ b/apps/web/tests/generate-voice.test.ts
@@ -1163,6 +1163,12 @@ As I held up her dress, stared at her mom's eye, white as can be, on the toilet,
           user: { id: 'test-user-id' },
         }),
       );
+      expect(Sentry.captureException).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: getErrorMessage('OTHER_GEMINI_BLOCK', 'voice-generation'),
+        }),
+        expect.anything(),
+      );
     });
 
     it('should throw error when Gemini response has no mimeType', async () => {
@@ -1218,6 +1224,12 @@ As I held up her dress, stared at her mom's eye, white as can be, on the toilet,
           }),
           user: { id: 'test-user-id' },
         }),
+      );
+      expect(Sentry.captureException).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: getErrorMessage('OTHER_GEMINI_BLOCK', 'voice-generation'),
+        }),
+        expect.anything(),
       );
     });
 

--- a/apps/web/tests/stripe-actions.test.ts
+++ b/apps/web/tests/stripe-actions.test.ts
@@ -1,0 +1,91 @@
+import { captureException } from '@sentry/nextjs';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createCheckoutSession } from '@/app/[lang]/actions/stripe';
+import { stripe } from '@/lib/stripe/stripe-admin';
+
+vi.mock('@/lib/stripe/stripe-admin', () => ({
+  stripe: {
+    checkout: {
+      sessions: {
+        create: vi.fn(),
+      },
+    },
+  },
+}));
+
+describe('createCheckoutSession()', () => {
+  const originalVercelEnv = process.env.VERCEL_ENV;
+  const originalStarterPriceId = process.env.STRIPE_TOPUP_5_PRICE_ID;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    if (originalVercelEnv === undefined) {
+      delete process.env.VERCEL_ENV;
+    } else {
+      process.env.VERCEL_ENV = originalVercelEnv;
+    }
+
+    if (originalStarterPriceId === undefined) {
+      delete process.env.STRIPE_TOPUP_5_PRICE_ID;
+    } else {
+      process.env.STRIPE_TOPUP_5_PRICE_ID = originalStarterPriceId;
+    }
+  });
+
+  it('rejects invalid package IDs without Sentry error noise', async () => {
+    const formData = new FormData();
+    formData.set('uiMode', 'hosted');
+
+    await expect(createCheckoutSession(formData, 'free')).rejects.toThrow(
+      'Invalid checkout package',
+    );
+
+    expect(stripe.checkout.sessions.create).not.toHaveBeenCalled();
+    expect(captureException).not.toHaveBeenCalled();
+  });
+
+  it('does not report missing top-up price IDs outside Vercel production', async () => {
+    delete process.env.STRIPE_TOPUP_5_PRICE_ID;
+    process.env.VERCEL_ENV = 'preview';
+    const formData = new FormData();
+    formData.set('uiMode', 'hosted');
+
+    await expect(createCheckoutSession(formData, 'starter')).rejects.toThrow(
+      'Checkout package missing price ID',
+    );
+
+    expect(stripe.checkout.sessions.create).not.toHaveBeenCalled();
+    expect(captureException).not.toHaveBeenCalled();
+  });
+
+  it('reports missing top-up price IDs in Vercel production', async () => {
+    delete process.env.STRIPE_TOPUP_5_PRICE_ID;
+    process.env.VERCEL_ENV = 'production';
+    const formData = new FormData();
+    formData.set('uiMode', 'hosted');
+
+    await expect(createCheckoutSession(formData, 'starter')).rejects.toThrow(
+      'Checkout package missing price ID',
+    );
+
+    expect(captureException).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: 'Checkout package missing price ID',
+      }),
+      expect.objectContaining({
+        tags: {
+          section: 'stripe_actions',
+          event_type: 'missing_price_id',
+        },
+        extra: expect.objectContaining({
+          packageId: 'starter',
+          vercelEnv: 'production',
+        }),
+      }),
+    );
+  });
+});

--- a/apps/web/tests/stripe-actions.test.ts
+++ b/apps/web/tests/stripe-actions.test.ts
@@ -1,4 +1,4 @@
-import { captureException } from '@sentry/nextjs';
+import { captureException, captureMessage } from '@sentry/nextjs';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { createCheckoutSession } from '@/app/[lang]/actions/stripe';
@@ -37,6 +37,7 @@ describe('createCheckoutSession()', () => {
   });
 
   it('rejects invalid package IDs without Sentry error noise', async () => {
+    process.env.VERCEL_ENV = 'preview';
     const formData = new FormData();
     formData.set('uiMode', 'hosted');
 
@@ -46,6 +47,35 @@ describe('createCheckoutSession()', () => {
 
     expect(stripe.checkout.sessions.create).not.toHaveBeenCalled();
     expect(captureException).not.toHaveBeenCalled();
+    expect(captureMessage).not.toHaveBeenCalled();
+  });
+
+  it('reports invalid package IDs as info telemetry in Vercel production', async () => {
+    process.env.VERCEL_ENV = 'production';
+    const formData = new FormData();
+    formData.set('uiMode', 'hosted');
+
+    await expect(
+      createCheckoutSession(formData, 'free' as never),
+    ).rejects.toThrow('Invalid checkout package');
+
+    expect(stripe.checkout.sessions.create).not.toHaveBeenCalled();
+    expect(captureException).not.toHaveBeenCalled();
+    expect(captureMessage).toHaveBeenCalledWith(
+      'Invalid checkout package id submitted.',
+      expect.objectContaining({
+        level: 'info',
+        tags: {
+          section: 'stripe_actions',
+          event_type: 'invalid_package_id',
+        },
+        extra: expect.objectContaining({
+          packageId: 'free',
+          available_packages: ['starter', 'standard', 'pro'],
+          vercelEnv: 'production',
+        }),
+      }),
+    );
   });
 
   it('does not report missing top-up price IDs outside Vercel production', async () => {

--- a/apps/web/tests/stripe-actions.test.ts
+++ b/apps/web/tests/stripe-actions.test.ts
@@ -40,9 +40,9 @@ describe('createCheckoutSession()', () => {
     const formData = new FormData();
     formData.set('uiMode', 'hosted');
 
-    await expect(createCheckoutSession(formData, 'free')).rejects.toThrow(
-      'Invalid checkout package',
-    );
+    await expect(
+      createCheckoutSession(formData, 'free' as never),
+    ).rejects.toThrow('Invalid checkout package');
 
     expect(stripe.checkout.sessions.create).not.toHaveBeenCalled();
     expect(captureException).not.toHaveBeenCalled();


### PR DESCRIPTION
**Findings**

1. Voice-generation failures are currently one cluster, not two independent bugs.
   `SEXYVOICE-AI-9Z` (`Error: Gemini 200 — no audio data`) was first seen on May 10, 2026, has `24` events / `14` users, and was last seen at `2026-05-11T06:59:46Z`. Representative event `596ff7a9d6fc4d91b6b09c1a2949c7b4` shows `finishReason: "OTHER"`, `hasData: false`, `model: "gemini-2.5-flash-preview-tts"`, `environment: "vercel-production"`, and a long explicit-content prompt in `textPreview`. The same second also produced `SEXYVOICE-AI-81` (`Error: Voice generation failed, please retry`), which has `1672` events / `357` users and the same last-seen timestamp. That strongly suggests `9Z` is the rich inner failure and `81` is the outer wrapper from [`apps/web/app/api/generate-voice/route.ts`](/Users/gianpaj_it/.codex/worktrees/f9f9/sexyvoice/apps/web/app/api/generate-voice/route.ts:360) and its catch block at [`route.ts`](/Users/gianpaj_it/.codex/worktrees/f9f9/sexyvoice/apps/web/app/api/generate-voice/route.ts:651).
   Minimal fix: keep `9Z`, suppress or downgrade the outer `captureException` for `cause === 'OTHER_GEMINI_BLOCK'` so Sentry stops double-counting the same request. If you want a behavior change too, add one bounded retry or return `503` for the `finishReason !== STOP && !data` branch after both Gemini models fail. Existing tests already cover the no-data / no-mimeType path in [`apps/web/tests/generate-voice.test.ts`](/Users/gianpaj_it/.codex/worktrees/f9f9/sexyvoice/apps/web/tests/generate-voice.test.ts:1120), but they do not assert “one Sentry issue, not two”.

2. The PKCE callback issue looks persistent and partly user-flow-driven, not like a fresh regression.
   `SEXYVOICE-AI-7X` (`AuthPKCECodeVerifierMissingError`) has `678` events, was first seen on March 26, 2026, and was last seen on May 11, 2026 at `06:34:36Z`. Sentry attributes it to Supabase auth-js during `exchangeCodeForSession`, which matches [`apps/web/app/auth/callback/route.ts`](/Users/gianpaj_it/.codex/worktrees/f9f9/sexyvoice/apps/web/app/auth/callback/route.ts:64). OAuth starts client-side in [`login-form.tsx`](/Users/gianpaj_it/.codex/worktrees/f9f9/sexyvoice/apps/web/app/[lang]/(auth)/login/login-form.tsx:56) and [`signup-form.tsx`](/Users/gianpaj_it/.codex/worktrees/f9f9/sexyvoice/apps/web/app/[lang]/(auth)/signup/signup-form.tsx:74), while middleware only tracks the custom callback marker in [`apps/web/lib/supabase/middleware.ts`](/Users/gianpaj_it/.codex/worktrees/f9f9/sexyvoice/apps/web/lib/supabase/middleware.ts:59).
   Minimal fix: treat this specific Supabase error as diagnosable noise first. Capture it as a warning with marker/cookie presence instead of an exception, and add callback-side telemetry for whether the Supabase PKCE cookie existed when `/auth/callback` ran. That will tell you whether this is mostly “different tab/device/storage cleared” versus an app bug. Current tests only cover the marker helper in [`apps/web/tests/oauth-callback-marker.test.ts`](/Users/gianpaj_it/.codex/worktrees/f9f9/sexyvoice/apps/web/tests/oauth-callback-marker.test.ts:1); there is no callback-flow test.

3. Two hot issues look like config/deployment noise, not product logic failures.
   `SEXYVOICE-AI-9W` (`@vercel/edge-config: No connection string provided`) has `108` events and comes from [`apps/web/lib/edge-config/call-instructions.ts`](/Users/gianpaj_it/.codex/worktrees/f9f9/sexyvoice/apps/web/lib/edge-config/call-instructions.ts:19). Representative event `e218bf90df73487b9cd47f536948b57c` was `GET http://localhost:3100/en/dashboard/call` from `HeadlessChrome 138` on macOS, even though the tag said `environment: production`. That is consistent with local/preview automation opening the call page without `EDGE_CONFIG`. Minimal fix: short-circuit to fallback when the connection string env is absent and only report to Sentry on real `vercel-production` traffic.
   `SEXYVOICE-AI-9X` (`Invalid package id`) has `14` events, first appeared on May 9, 2026, and comes from [`apps/web/app/[lang]/actions/stripe.ts`](/Users/gianpaj_it/.codex/worktrees/f9f9/sexyvoice/apps/web/app/[lang]/actions/stripe.ts:20). The throw only happens when `getTopupPackages('en')[packageId]` has no `priceId`, and the UI only submits `starter|standard|pro` from [`credit-topup.tsx`](/Users/gianpaj_it/.codex/worktrees/f9f9/sexyvoice/apps/web/app/[lang]/(dashboard)/dashboard/credits/credit-topup.tsx:123). That makes missing `STRIPE_TOPUP_*_PRICE_ID` env in a deployment more likely than arbitrary bad form input, though Sentry alone does not prove it. Minimal fix: validate Stripe top-up envs at boot or degrade this path to a user-facing “billing temporarily unavailable” without exception noise in preview/local builds. The relevant env-backed package definitions are in [`apps/web/lib/stripe/pricing.ts`](/Users/gianpaj_it/.codex/worktrees/f9f9/sexyvoice/apps/web/lib/stripe/pricing.ts:31).
