### PR TITLE
Reduce noisy Sentry groups across voice, auth, and editor flows

### DIFF
--- a/apps/web/app/api/clone-voice/route.ts
+++ b/apps/web/app/api/clone-voice/route.ts
@@ -34,7 +34,12 @@ import {
   saveAudioFile,
 } from '@/lib/supabase/queries';
 import { createClient } from '@/lib/supabase/server';
-import { estimateCredits, getDollarCost } from '@/lib/utils';
+import {
+  ERROR_CODES,
+  estimateCredits,
+  getDollarCost,
+  getErrorMessage,
+} from '@/lib/utils';
 
 const ALLOWED_TYPES = [
   'audio/mpeg',
@@ -151,6 +156,7 @@ type CloneRouteErrorCode =
   | 'errors.invalidFileType'
   | 'errors.missingLocale'
   | 'errors.missingRequiredParameters'
+  | 'errors.providerUnavailable'
   | 'errors.referenceAudioEnhancementInputTooLarge'
   | 'errors.referenceAudioEnhancementInputTooLong'
   | 'errors.textTooLong'
@@ -932,7 +938,7 @@ async function cloneVoiceWithReplicate(
     onProgress,
   )) as ReplicateResponse;
 
-  if (typeof output === 'object' && 'error' in output) {
+  if (output && typeof output === 'object' && 'error' in output) {
     logger.warn('Replicate voice cloning provider failed', {
       extra: {
         locale,
@@ -942,9 +948,9 @@ async function cloneVoiceWithReplicate(
       },
     });
     throw createRouteError(
-      'Voice cloning provider is temporarily unavailable. Please try again.',
+      getErrorMessage(ERROR_CODES.PROVIDER_UNAVAILABLE, 'voice-cloning'),
       503,
-      'errors.internalError',
+      'errors.providerUnavailable',
       { provider: 'replicate' },
     );
   }

--- a/apps/web/app/api/clone-voice/route.ts
+++ b/apps/web/app/api/clone-voice/route.ts
@@ -222,6 +222,14 @@ function routeErrorResponse(
   );
 }
 
+function getUnknownErrorName(error: unknown): string {
+  return Error.isError(error) ? error.name : typeof error;
+}
+
+function getUnknownErrorMessage(error: unknown): string {
+  return Error.isError(error) ? error.message : String(error);
+}
+
 // ============================================================================
 // Utilities
 // ============================================================================
@@ -799,6 +807,19 @@ function isMistralGuardrailError(error: unknown): boolean {
   );
 }
 
+function isExpectedReferenceAudioEnhancementFailure(error: unknown): boolean {
+  const errorName = getUnknownErrorName(error);
+  const errorMessage = getUnknownErrorMessage(error).toLowerCase();
+
+  return (
+    errorName === 'TimeoutError' ||
+    errorName === 'ValidationError' ||
+    errorMessage.includes('unprocessable entity') ||
+    errorMessage.includes('aborted due to timeout') ||
+    errorMessage.includes('operation was aborted due to timeout')
+  );
+}
+
 // ============================================================================
 // Voice Generation Functions
 // ============================================================================
@@ -913,27 +934,20 @@ async function cloneVoiceWithReplicate(
   )) as ReplicateResponse;
 
   if (typeof output === 'object' && 'error' in output) {
-    const errorObj = {
-      text,
-      locale,
-      language,
-      audioReferenceUrl,
-      model,
-      errorData: output.error,
-    };
-    const error = new Error(
-      output.error || 'Voice cloning failed, please try again',
-      {
-        cause: 'REPLICATE_ERROR',
+    logger.warn('Replicate voice cloning provider failed', {
+      extra: {
+        locale,
+        language,
+        model,
+        errorMessage: output.error || null,
       },
+    });
+    throw createRouteError(
+      'Voice cloning provider is temporarily unavailable. Please try again.',
+      503,
+      'errors.internalError',
+      { provider: 'replicate' },
     );
-    captureException(error, {
-      extra: errorObj,
-    });
-    console.error(errorObj);
-    throw new Error(output.error || 'Voice cloning failed, please try again', {
-      cause: 'REPLICATE_ERROR',
-    });
   }
 
   const audioBlob = await (output as ReplicateOutput).blob();
@@ -1292,19 +1306,27 @@ export async function POST(request: Request) {
           wasTrimmed: processedAudio.wasTrimmed,
         };
       } catch (enhancementError) {
-        captureException(enhancementError, {
-          user: { id: user.id },
-          extra: {
-            locale,
-            mimeType: processedAudio.mimeType,
-            filename: referenceAudioFile.name,
-          },
-        });
+        const expectedEnhancementFailure =
+          isExpectedReferenceAudioEnhancementFailure(enhancementError);
+
+        if (!expectedEnhancementFailure) {
+          captureException(enhancementError, {
+            user: { id: user.id },
+            extra: {
+              locale,
+              mimeType: processedAudio.mimeType,
+              filename: referenceAudioFile.name,
+            },
+          });
+        }
         logger.info(
           'Reference audio enhancement failed; using original audio',
           {
             user: { id: user.id },
             extra: {
+              errorMessage: getUnknownErrorMessage(enhancementError),
+              errorName: getUnknownErrorName(enhancementError),
+              expectedEnhancementFailure,
               locale,
               mimeType: processedAudio.mimeType,
               filename: referenceAudioFile.name,

--- a/apps/web/app/api/clone-voice/route.ts
+++ b/apps/web/app/api/clone-voice/route.ts
@@ -813,8 +813,8 @@ function isExpectedReferenceAudioEnhancementFailure(error: unknown): boolean {
 
   return (
     errorName === 'TimeoutError' ||
-    errorName === 'ValidationError' ||
-    errorMessage.includes('unprocessable entity') ||
+    (errorName === 'ValidationError' &&
+      errorMessage.includes('unprocessable entity')) ||
     errorMessage.includes('aborted due to timeout')
   );
 }

--- a/apps/web/app/api/clone-voice/route.ts
+++ b/apps/web/app/api/clone-voice/route.ts
@@ -815,8 +815,7 @@ function isExpectedReferenceAudioEnhancementFailure(error: unknown): boolean {
     errorName === 'TimeoutError' ||
     errorName === 'ValidationError' ||
     errorMessage.includes('unprocessable entity') ||
-    errorMessage.includes('aborted due to timeout') ||
-    errorMessage.includes('operation was aborted due to timeout')
+    errorMessage.includes('aborted due to timeout')
   );
 }
 

--- a/apps/web/app/api/generate-voice/route.ts
+++ b/apps/web/app/api/generate-voice/route.ts
@@ -750,26 +750,6 @@ export async function POST(request: Request) {
       }
     }
 
-    // if Gemini error
-    if (Error.isError(error) && error.message.includes('googleapis')) {
-      const message = JSON.parse(error.message);
-      // You exceeded your current quota
-      if (message.error.code === 429) {
-        return NextResponse.json(
-          {
-            error: getErrorMessage(
-              userHasPaid
-                ? ERROR_CODES.THIRD_P_QUOTA_EXCEEDED
-                : ERROR_CODES.FREE_QUOTA_EXCEEDED,
-              'voice-generation',
-            ),
-          },
-          { status: 500 },
-        );
-      }
-      return NextResponse.json({ error: error.message }, { status: 500 });
-    }
-
     const errorObj = {
       text,
       voice,

--- a/apps/web/app/api/generate-voice/route.ts
+++ b/apps/web/app/api/generate-voice/route.ts
@@ -725,7 +725,7 @@ export async function POST(request: Request) {
               'voice-generation',
             ),
           },
-          { status: 500 },
+          { status: 429 },
         );
       }
 

--- a/apps/web/app/api/generate-voice/route.ts
+++ b/apps/web/app/api/generate-voice/route.ts
@@ -37,6 +37,8 @@ import {
   getErrorStatusCode,
   getTtsProvider,
 } from '@/lib/utils';
+import { getGoogleApiErrorStatus } from '@/utils/google-rpc-status';
+import { type GoogleApiError, parseGoogleApiError } from '@/utils/googleErrors';
 
 const { logger, captureException } = Sentry;
 
@@ -50,6 +52,19 @@ function isAbortError(error: unknown): boolean {
   if (error.name === 'AbortError') return true;
   const msg = error.message.toLowerCase();
   return /\babort(?:ed| ?error)\b/.test(msg);
+}
+
+function isGoogleQuotaError(errorPayload: GoogleApiError): boolean {
+  return getGoogleApiErrorStatus(errorPayload) === 'RESOURCE_EXHAUSTED';
+}
+
+function isGoogleTransientProviderError(errorPayload: GoogleApiError): boolean {
+  const status = getGoogleApiErrorStatus(errorPayload);
+  return (
+    status === 'INTERNAL' ||
+    status === 'UNAVAILABLE' ||
+    errorPayload.code >= 500
+  );
 }
 
 // https://vercel.com/docs/functions/configuring-functions/duration
@@ -687,33 +702,51 @@ export async function POST(request: Request) {
       );
     }
 
-    const errorObj = {
-      text,
-      voice,
-      errorData: error,
-    };
-    captureException(error, {
-      extra: errorObj,
-      user: user ? { id: user.id, email: user.email } : undefined,
-    });
-    console.error(errorObj);
-    console.error('Voice generation error:', error);
+    const googleApiError = parseGoogleApiError(error);
+    if (googleApiError) {
+      const googleStatus = getGoogleApiErrorStatus(googleApiError);
+      if (isGoogleQuotaError(googleApiError)) {
+        logger.warn('Gemini quota exhausted', {
+          user: user ? { id: user.id, email: user.email } : undefined,
+          extra: {
+            textLength: text.length,
+            voice,
+            googleStatus,
+            googleCode: googleApiError.code,
+          },
+        });
 
-    // Check for transient errors (INTERNAL status) from Google API
-    if (Error.isError(error)) {
-      try {
-        const message = JSON.parse(error.message);
-        if (message.error?.status === 'INTERNAL') {
-          return NextResponse.json(
-            {
-              error:
-                'Voice generation service temporarily unavailable. Please retry.',
-            },
-            { status: 503 },
-          );
-        }
-      } catch {
-        // Not JSON or doesn't have the expected structure, continue to next check
+        return NextResponse.json(
+          {
+            error: getErrorMessage(
+              userHasPaid
+                ? ERROR_CODES.THIRD_P_QUOTA_EXCEEDED
+                : ERROR_CODES.FREE_QUOTA_EXCEEDED,
+              'voice-generation',
+            ),
+          },
+          { status: 500 },
+        );
+      }
+
+      if (isGoogleTransientProviderError(googleApiError)) {
+        logger.warn('Gemini provider temporarily unavailable', {
+          user: user ? { id: user.id, email: user.email } : undefined,
+          extra: {
+            textLength: text.length,
+            voice,
+            googleStatus,
+            googleCode: googleApiError.code,
+          },
+        });
+
+        return NextResponse.json(
+          {
+            error:
+              'Voice generation service temporarily unavailable. Please retry.',
+          },
+          { status: 503 },
+        );
       }
     }
 
@@ -736,6 +769,19 @@ export async function POST(request: Request) {
       }
       return NextResponse.json({ error: error.message }, { status: 500 });
     }
+
+    const errorObj = {
+      text,
+      voice,
+      errorData: error,
+    };
+    captureException(error, {
+      extra: errorObj,
+      user: user ? { id: user.id, email: user.email } : undefined,
+    });
+    console.error(errorObj);
+    console.error('Voice generation error:', error);
+
     if (
       Error.isError(error) &&
       Object.keys(ERROR_CODES).includes(String(error.cause))

--- a/apps/web/app/api/generate-voice/route.ts
+++ b/apps/web/app/api/generate-voice/route.ts
@@ -63,7 +63,7 @@ function isGoogleTransientProviderError(errorPayload: GoogleApiError): boolean {
   return (
     status === 'INTERNAL' ||
     status === 'UNAVAILABLE' ||
-    errorPayload.code >= 500
+    status === 'DEADLINE_EXCEEDED'
   );
 }
 

--- a/apps/web/app/api/generate-voice/route.ts
+++ b/apps/web/app/api/generate-voice/route.ts
@@ -742,8 +742,10 @@ export async function POST(request: Request) {
 
         return NextResponse.json(
           {
-            error:
-              'Voice generation service temporarily unavailable. Please retry.',
+            error: getErrorMessage(
+              ERROR_CODES.GEMINI_PROVIDER_UNAVAILABLE,
+              'voice-generation',
+            ),
           },
           { status: 503 },
         );

--- a/apps/web/app/auth/callback/route.ts
+++ b/apps/web/app/auth/callback/route.ts
@@ -75,6 +75,15 @@ const isPkceCodeVerifierMissingError = (error: unknown) => {
   );
 };
 
+const isExpiredAuthFlowStateError = (error: unknown) => {
+  const errorMessage = getErrorStringProperty(error, 'message').toLowerCase();
+
+  return (
+    errorMessage.includes('invalid flow state') ||
+    errorMessage.includes('flow state has expired')
+  );
+};
+
 const getOauthCallbackCookieContext = (request: Request) => {
   const cookieHeader = request.headers.get('cookie') ?? '';
   const cookieNames = cookieHeader
@@ -133,13 +142,17 @@ export async function GET(request: Request) {
   const loginPath = `/${locale}/login`;
   const oauthCodeContext = getOauthCodeFingerprint(code);
   const oauthCookieContext = getOauthCallbackCookieContext(request);
-  const reportPkceCodeVerifierMissing = (error: unknown) => {
-    captureMessage('OAuth callback missing PKCE code verifier.', {
+  const reportKnownOauthCallbackFailure = (
+    message: string,
+    errorType: string,
+    error: unknown,
+  ) => {
+    captureMessage(message, {
       level: 'warning',
       tags: {
         area: 'auth',
         flow: 'oauth-callback',
-        error_type: 'pkce-code-verifier-missing',
+        error_type: errorType,
       },
       extra: {
         redirectTo,
@@ -152,6 +165,18 @@ export async function GET(request: Request) {
 
     return NextResponse.redirect(`${origin}${loginPath}`);
   };
+  const reportPkceCodeVerifierMissing = (error: unknown) =>
+    reportKnownOauthCallbackFailure(
+      'OAuth callback missing PKCE code verifier.',
+      'pkce-code-verifier-missing',
+      error,
+    );
+  const reportExpiredAuthFlowState = (error: unknown) =>
+    reportKnownOauthCallbackFailure(
+      'OAuth callback flow state expired.',
+      'flow-state-expired',
+      error,
+    );
 
   try {
     if (!code) {
@@ -166,6 +191,10 @@ export async function GET(request: Request) {
     if (exchangeError) {
       if (isPkceCodeVerifierMissingError(exchangeError)) {
         return reportPkceCodeVerifierMissing(exchangeError);
+      }
+
+      if (isExpiredAuthFlowStateError(exchangeError)) {
+        return reportExpiredAuthFlowState(exchangeError);
       }
 
       captureException(exchangeError, {
@@ -240,6 +269,10 @@ export async function GET(request: Request) {
   } catch (error) {
     if (isPkceCodeVerifierMissingError(error)) {
       return reportPkceCodeVerifierMissing(error);
+    }
+
+    if (isExpiredAuthFlowStateError(error)) {
+      return reportExpiredAuthFlowState(error);
     }
 
     captureException(error, {

--- a/apps/web/app/auth/callback/route.ts
+++ b/apps/web/app/auth/callback/route.ts
@@ -44,9 +44,9 @@ const getOauthCodeFingerprint = (code: string | null) => {
 
 const getErrorStringProperty = (
   error: unknown,
-  property: 'message' | 'name',
+  property: 'code' | 'message' | 'name',
 ) => {
-  if (error instanceof Error) {
+  if (error instanceof Error && property !== 'code') {
     return error[property];
   }
 
@@ -76,9 +76,14 @@ const isPkceCodeVerifierMissingError = (error: unknown) => {
 };
 
 const isExpiredAuthFlowStateError = (error: unknown) => {
+  const errorName = getErrorStringProperty(error, 'name');
+  const errorCode = getErrorStringProperty(error, 'code');
   const errorMessage = getErrorStringProperty(error, 'message').toLowerCase();
 
   return (
+    (errorName === 'AuthApiError' &&
+      (errorCode === 'flow_state_expired' ||
+        errorCode === 'flow_state_not_found')) ||
     errorMessage.includes('invalid flow state') ||
     errorMessage.includes('flow state has expired')
   );
@@ -159,7 +164,9 @@ export async function GET(request: Request) {
         locale,
         ...oauthCodeContext,
         ...oauthCookieContext,
+        errorCode: getErrorStringProperty(error, 'code') || null,
         errorMessage: getErrorMessage(error),
+        errorName: getErrorStringProperty(error, 'name') || null,
       },
     });
 

--- a/apps/web/components/call/chat.tsx
+++ b/apps/web/components/call/chat.tsx
@@ -5,7 +5,6 @@ import {
   useConnectionState,
   // useVoiceAssistant,
 } from '@livekit/components-react';
-import * as Sentry from '@sentry/nextjs';
 import { AnimatePresence, motion } from 'framer-motion';
 import { ConnectionState } from 'livekit-client';
 import { useEffect, useState } from 'react';
@@ -37,8 +36,6 @@ export function Chat() {
         disconnect();
         setHasSeenAgent(false);
 
-        Sentry.captureMessage('Agent Unavailable');
-
         console.error('Agent Unavailable');
 
         toast.error(dict.agentUnavailable);
@@ -60,7 +57,6 @@ export function Chat() {
           disconnect();
           setHasSeenAgent(false);
           toast.info(dict.disconnected);
-          Sentry.captureMessage('Disconnected');
         }
       }, 5000);
     }

--- a/apps/web/components/grok-tts-editor.tsx
+++ b/apps/web/components/grok-tts-editor.tsx
@@ -309,7 +309,7 @@ export function GrokTTSEditor({
   const [currentLength, setCurrentLength] = useState(value.length);
   const charactersLimitRef = useRef(charactersLimit);
   const enforceCharactersLimitRef = useRef(enforceCharactersLimit);
-  const selectionResetFromContentRef = useRef(false);
+  const contentResetSelectionRef = useRef<EditorSelectionSnapshot | null>(null);
   const lastSelectionRef = useRef<EditorSelectionSnapshot>({
     empty: true,
     from: 1,
@@ -370,7 +370,18 @@ export function GrokTTSEditor({
       lastSelectionRef.current = getEditorSelectionSnapshot(nextEditor);
     },
     onSelectionUpdate: ({ editor: nextEditor }) => {
-      lastSelectionRef.current = getEditorSelectionSnapshot(nextEditor);
+      const selection = getEditorSelectionSnapshot(nextEditor);
+      const resetSelection = contentResetSelectionRef.current;
+      lastSelectionRef.current = selection;
+
+      if (
+        resetSelection &&
+        (!selection.empty ||
+          selection.from !== resetSelection.from ||
+          selection.to !== resetSelection.to)
+      ) {
+        contentResetSelectionRef.current = null;
+      }
     },
     onUpdate: ({ editor: nextEditor }) => {
       const fullText = grokTipTapDocToText(nextEditor.getJSON());
@@ -380,8 +391,9 @@ export function GrokTTSEditor({
 
       if (text !== fullText) {
         nextEditor.commands.setContent(plainTextToDoc(text));
-        lastSelectionRef.current = moveEditorSelectionToEnd(nextEditor);
-        selectionResetFromContentRef.current = true;
+        const resetSelection = moveEditorSelectionToEnd(nextEditor);
+        lastSelectionRef.current = resetSelection;
+        contentResetSelectionRef.current = resetSelection;
       }
 
       setCurrentLength(text.length);
@@ -401,8 +413,9 @@ export function GrokTTSEditor({
     }
 
     editor.commands.setContent(plainTextToDoc(value));
-    lastSelectionRef.current = moveEditorSelectionToEnd(editor);
-    selectionResetFromContentRef.current = true;
+    const resetSelection = moveEditorSelectionToEnd(editor);
+    lastSelectionRef.current = resetSelection;
+    contentResetSelectionRef.current = resetSelection;
     setCurrentLength(value.length);
   }, [editor, value]);
 
@@ -526,16 +539,16 @@ export function GrokTTSEditor({
     (event: MouseEvent<HTMLButtonElement>) => {
       if (editor) {
         const snapshot = getDomSelectionSnapshot(editor);
+        const resetSelection = contentResetSelectionRef.current;
+        const isContentResetSnapshot =
+          snapshot && resetSelection && snapshot.empty;
 
-        if (
-          snapshot &&
-          !(snapshot.empty && selectionResetFromContentRef.current)
-        ) {
+        if (snapshot && !isContentResetSnapshot) {
           lastSelectionRef.current = snapshot;
-        } else if (!selectionResetFromContentRef.current) {
+        } else if (!isContentResetSnapshot) {
           lastSelectionRef.current = getEditorSelectionSnapshot(editor);
         }
-        selectionResetFromContentRef.current = false;
+        contentResetSelectionRef.current = null;
       }
 
       event.preventDefault();

--- a/apps/web/components/grok-tts-editor.tsx
+++ b/apps/web/components/grok-tts-editor.tsx
@@ -168,6 +168,56 @@ function getDomSelectionSnapshot(
   }
 }
 
+function clampEditorPosition(editor: EditorInstance, position: number): number {
+  const maxPosition = Math.max(1, editor.state.doc.content.size - 1);
+
+  return Math.min(Math.max(position, 1), maxPosition);
+}
+
+function normalizeEditorSelectionSnapshot(
+  editor: EditorInstance,
+  selection: EditorSelectionSnapshot,
+): EditorSelectionSnapshot {
+  const from = clampEditorPosition(editor, selection.from);
+  const to = clampEditorPosition(editor, selection.to);
+  const normalizedFrom = Math.min(from, to);
+  const normalizedTo = Math.max(from, to);
+
+  return {
+    empty: normalizedFrom === normalizedTo,
+    from: normalizedFrom,
+    to: normalizedTo,
+  };
+}
+
+function getEditorSelectionSnapshot(
+  editor: EditorInstance,
+): EditorSelectionSnapshot {
+  const { empty, from, to } = editor.state.selection;
+
+  return { empty, from, to };
+}
+
+function getEditorEndSelectionSnapshot(
+  editor: EditorInstance,
+): EditorSelectionSnapshot {
+  const position = clampEditorPosition(
+    editor,
+    editor.state.doc.content.size - 1,
+  );
+
+  return { empty: true, from: position, to: position };
+}
+
+function moveEditorSelectionToEnd(
+  editor: EditorInstance,
+): EditorSelectionSnapshot {
+  const selection = getEditorEndSelectionSnapshot(editor);
+  editor.commands.setTextSelection(selection.from);
+
+  return selection;
+}
+
 interface GrokSlashMenuConfig {
   allow?: NonNullable<SuggestionMenuProps['allow']>;
   customItems: SuggestionItem[];
@@ -259,6 +309,7 @@ export function GrokTTSEditor({
   const [currentLength, setCurrentLength] = useState(value.length);
   const charactersLimitRef = useRef(charactersLimit);
   const enforceCharactersLimitRef = useRef(enforceCharactersLimit);
+  const selectionResetFromContentRef = useRef(false);
   const lastSelectionRef = useRef<EditorSelectionSnapshot>({
     empty: true,
     from: 1,
@@ -316,12 +367,10 @@ export function GrokTTSEditor({
       handleTextInput: () => false,
     },
     onCreate: ({ editor: nextEditor }) => {
-      const { empty, from, to } = nextEditor.state.selection;
-      lastSelectionRef.current = { empty, from, to };
+      lastSelectionRef.current = getEditorSelectionSnapshot(nextEditor);
     },
     onSelectionUpdate: ({ editor: nextEditor }) => {
-      const { empty, from, to } = nextEditor.state.selection;
-      lastSelectionRef.current = { empty, from, to };
+      lastSelectionRef.current = getEditorSelectionSnapshot(nextEditor);
     },
     onUpdate: ({ editor: nextEditor }) => {
       const fullText = grokTipTapDocToText(nextEditor.getJSON());
@@ -331,6 +380,8 @@ export function GrokTTSEditor({
 
       if (text !== fullText) {
         nextEditor.commands.setContent(plainTextToDoc(text));
+        lastSelectionRef.current = moveEditorSelectionToEnd(nextEditor);
+        selectionResetFromContentRef.current = true;
       }
 
       setCurrentLength(text.length);
@@ -350,6 +401,8 @@ export function GrokTTSEditor({
     }
 
     editor.commands.setContent(plainTextToDoc(value));
+    lastSelectionRef.current = moveEditorSelectionToEnd(editor);
+    selectionResetFromContentRef.current = true;
     setCurrentLength(value.length);
   }, [editor, value]);
 
@@ -359,7 +412,11 @@ export function GrokTTSEditor({
         return;
       }
 
-      const selection = lastSelectionRef.current;
+      const selection = normalizeEditorSelectionSnapshot(
+        editor,
+        lastSelectionRef.current,
+      );
+      lastSelectionRef.current = selection;
       const serialized = grokTipTapDocToText(editor.getJSON());
       const selectedTextLength = selection.empty
         ? 0
@@ -389,7 +446,11 @@ export function GrokTTSEditor({
         return;
       }
 
-      const selection = lastSelectionRef.current;
+      const selection = normalizeEditorSelectionSnapshot(
+        editor,
+        lastSelectionRef.current,
+      );
+      lastSelectionRef.current = selection;
       const wrapperLength = tag.tag.length + tag.closeTag.length;
 
       const serialized = grokTipTapDocToText(editor.getJSON());
@@ -466,9 +527,15 @@ export function GrokTTSEditor({
       if (editor) {
         const snapshot = getDomSelectionSnapshot(editor);
 
-        if (snapshot) {
+        if (
+          snapshot &&
+          !(snapshot.empty && selectionResetFromContentRef.current)
+        ) {
           lastSelectionRef.current = snapshot;
+        } else if (!selectionResetFromContentRef.current) {
+          lastSelectionRef.current = getEditorSelectionSnapshot(editor);
         }
+        selectionResetFromContentRef.current = false;
       }
 
       event.preventDefault();

--- a/apps/web/lib/sentry/client-filters.ts
+++ b/apps/web/lib/sentry/client-filters.ts
@@ -71,7 +71,6 @@ export function shouldDropClientSentryEvent(event: SentryClientEvent): boolean {
   const message = event.message ?? '';
 
   return (
-    reactDomMutationNoisePatterns.some((pattern) => pattern.test(message)) ||
     reactHydrationRecoverablePattern.test(message) ||
     rscConnectionClosedPattern.test(message)
   );

--- a/apps/web/lib/sentry/client-filters.ts
+++ b/apps/web/lib/sentry/client-filters.ts
@@ -22,37 +22,57 @@ interface SentryClientEvent {
 const reactRemoveChildNotFoundPattern =
   /Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node/i;
 
-const reactCommitDeletionFramePattern =
-  /commitDeletionEffectsOnFiber|commitMutationEffectsOnFiber|recursivelyTraverseMutationEffects|react-dom-client/i;
+const reactDomMutationNoisePatterns = [
+  reactRemoveChildNotFoundPattern,
+  /Failed to execute 'insertBefore' on 'Node': The node before which the new node is to be inserted is not a child of this node/i,
+  /Cannot read properties of null \(reading 'removeChild'\)/i,
+  /NotFoundError: The object can not be found here/i,
+];
 
-function frameMatchesReactCommitDeletion(frame: SentryStackFrame): boolean {
+const reactHydrationRecoverablePattern =
+  /^(Hydration Error|Hydration failed - the server rendered HTML didn't match the client\.)/i;
+
+const rscConnectionClosedPattern = /^Connection closed\.$/i;
+
+const reactCommitDeletionFramePattern =
+  /commitDeletionEffectsOnFiber|commitMutationEffectsOnFiber|recursivelyTraverseMutationEffects|react-dom-client|react-server-dom/i;
+
+function frameMatchesReactInternals(frame: SentryStackFrame): boolean {
   return reactCommitDeletionFramePattern.test(
     [frame.filename, frame.function, frame.module].filter(Boolean).join(' '),
   );
 }
 
-function isReactRemoveChildNotFoundException(
-  exception: SentryException,
-): boolean {
+function isReactDomNoiseException(exception: SentryException): boolean {
   const exceptionText = [exception.type, exception.value]
     .filter(Boolean)
     .join(' ');
 
-  if (!reactRemoveChildNotFoundPattern.test(exceptionText)) {
+  if (
+    !reactDomMutationNoisePatterns.some((pattern) =>
+      pattern.test(exceptionText),
+    )
+  ) {
     return false;
   }
 
   const frames = exception.stacktrace?.frames ?? [];
 
-  return frames.length === 0 || frames.some(frameMatchesReactCommitDeletion);
+  return frames.length === 0 || frames.some(frameMatchesReactInternals);
 }
 
 export function shouldDropClientSentryEvent(event: SentryClientEvent): boolean {
   const exceptions = event.exception?.values ?? [];
 
-  if (exceptions.some(isReactRemoveChildNotFoundException)) {
+  if (exceptions.some(isReactDomNoiseException)) {
     return true;
   }
 
-  return reactRemoveChildNotFoundPattern.test(event.message ?? '');
+  const message = event.message ?? '';
+
+  return (
+    reactDomMutationNoisePatterns.some((pattern) => pattern.test(message)) ||
+    reactHydrationRecoverablePattern.test(message) ||
+    rscConnectionClosedPattern.test(message)
+  );
 }

--- a/apps/web/lib/sentry/client-filters.ts
+++ b/apps/web/lib/sentry/client-filters.ts
@@ -30,7 +30,7 @@ const reactDomMutationNoisePatterns = [
 ];
 
 const reactHydrationRecoverablePattern =
-  /^(Hydration Error|Hydration failed - the server rendered HTML didn't match the client\.)/i;
+  /^(Hydration failed because the server rendered HTML didn't match the client|There was an error while hydrating|Text content does not match server-rendered HTML|Hydration Error)/i;
 
 const rscConnectionClosedPattern = /^Connection closed\.$/i;
 

--- a/apps/web/lib/utils.ts
+++ b/apps/web/lib/utils.ts
@@ -243,6 +243,7 @@ export const ERROR_CODES = {
   OTHER_GEMINI_BLOCK: 'OTHER_GEMINI_BLOCK',
   REPLICATE_ERROR: 'REPLICATE_ERROR',
   XAI_TTS_ERROR: 'XAI_TTS_ERROR',
+  GEMINI_PROVIDER_UNAVAILABLE: 'GEMINI_PROVIDER_UNAVAILABLE',
   INTERNAL_SERVER_ERROR: 'INTERNAL_SERVER_ERROR',
 } as const;
 
@@ -258,6 +259,7 @@ export const ERROR_STATUS_CODES: Record<keyof typeof ERROR_CODES, number> = {
   OTHER_GEMINI_BLOCK: 500,
   REPLICATE_ERROR: 500,
   XAI_TTS_ERROR: 500,
+  GEMINI_PROVIDER_UNAVAILABLE: 503,
   THIRD_P_QUOTA_EXCEEDED: 503,
   INTERNAL_SERVER_ERROR: 500,
 };
@@ -311,6 +313,10 @@ export const getErrorMessage = (
     },
     XAI_TTS_ERROR: {
       default: 'Voice generation failed, please retry',
+    },
+    GEMINI_PROVIDER_UNAVAILABLE: {
+      default:
+        'Voice generation service temporarily unavailable. Please retry.',
     },
     INTERNAL_SERVER_ERROR: {
       default: 'An internal server error occurred. Please try again later.',

--- a/apps/web/lib/utils.ts
+++ b/apps/web/lib/utils.ts
@@ -244,6 +244,7 @@ export const ERROR_CODES = {
   REPLICATE_ERROR: 'REPLICATE_ERROR',
   XAI_TTS_ERROR: 'XAI_TTS_ERROR',
   GEMINI_PROVIDER_UNAVAILABLE: 'GEMINI_PROVIDER_UNAVAILABLE',
+  PROVIDER_UNAVAILABLE: 'PROVIDER_UNAVAILABLE',
   INTERNAL_SERVER_ERROR: 'INTERNAL_SERVER_ERROR',
 } as const;
 
@@ -260,6 +261,7 @@ export const ERROR_STATUS_CODES: Record<keyof typeof ERROR_CODES, number> = {
   REPLICATE_ERROR: 500,
   XAI_TTS_ERROR: 500,
   GEMINI_PROVIDER_UNAVAILABLE: 503,
+  PROVIDER_UNAVAILABLE: 503,
   THIRD_P_QUOTA_EXCEEDED: 503,
   INTERNAL_SERVER_ERROR: 500,
 };
@@ -317,6 +319,11 @@ export const getErrorMessage = (
     GEMINI_PROVIDER_UNAVAILABLE: {
       default:
         'Voice generation service temporarily unavailable. Please retry.',
+    },
+    PROVIDER_UNAVAILABLE: {
+      default: 'Provider is temporarily unavailable. Please try again.',
+      'voice-cloning':
+        'Voice cloning provider is temporarily unavailable. Please try again.',
     },
     INTERNAL_SERVER_ERROR: {
       default: 'An internal server error occurred. Please try again later.',

--- a/apps/web/messages/da.json
+++ b/apps/web/messages/da.json
@@ -581,6 +581,7 @@
       "guardrailViolation": "Denne anmodning blev blokeret af en tredjeparts sikkerhedspolitik for stemmekloning. Prøv med en anden tekst eller en anden referencelyd.",
       "insufficientCredits": "Du skal bruge __CREDITS__ kreditter for at klone denne lyd.",
       "internalError": "Kunne ikke klone stemmen. Prøv igen.",
+      "providerUnavailable": "Udbyderen af stemmekloning er midlertidigt utilgængelig. Prøv igen.",
       "invalidContentType": "Uploadanmodningen er ugyldig. Prøv igen.",
       "invalidFileType": "Ugyldig filtype. Upload MP3, OGG, Opus, M4A, WAV eller WebM.",
       "missingLocale": "Vælg et sprog.",

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -581,6 +581,7 @@
       "guardrailViolation": "Diese Anfrage wurde durch die Sicherheitsrichtlinie eines Drittanbieters für das Klonen von Stimmen blockiert. Bitte versuchen Sie es mit anderem Text oder anderem Referenz-Audio.",
       "insufficientCredits": "Sie benötigen __CREDITS__ Credits, um dieses Audio zu klonen.",
       "internalError": "Die Stimme konnte nicht geklont werden. Bitte versuchen Sie es erneut.",
+      "providerUnavailable": "Der Anbieter für das Klonen von Stimmen ist vorübergehend nicht verfügbar. Bitte versuchen Sie es erneut.",
       "invalidContentType": "Die Upload-Anfrage ist ungültig. Bitte versuchen Sie es erneut.",
       "invalidFileType": "Ungültiger Dateityp. Bitte laden Sie MP3, OGG, Opus, M4A, WAV oder WebM hoch.",
       "missingLocale": "Bitte wählen Sie eine Sprache.",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -581,6 +581,7 @@
       "guardrailViolation": "This request was blocked by a third-party voice cloning safety policy. Please try different text or a different reference audio.",
       "insufficientCredits": "You need __CREDITS__ credits to clone this audio.",
       "internalError": "Failed to clone voice. Please try again.",
+      "providerUnavailable": "Voice cloning provider is temporarily unavailable. Please try again.",
       "invalidContentType": "The upload request is invalid. Please try again.",
       "invalidFileType": "Invalid file type. Please upload MP3, OGG, Opus, M4A, WAV, or WebM.",
       "missingLocale": "Please select a language.",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -581,6 +581,7 @@
       "guardrailViolation": "Esta solicitud fue bloqueada por una política de seguridad de clonación de voz de un tercero. Prueba con otro texto o con otro audio de referencia.",
       "insufficientCredits": "Necesitas __CREDITS__ créditos para clonar este audio.",
       "internalError": "No se pudo clonar la voz. Inténtalo de nuevo.",
+      "providerUnavailable": "El proveedor de clonación de voz no está disponible temporalmente. Inténtalo de nuevo.",
       "invalidContentType": "La solicitud de subida no es válida. Inténtalo de nuevo.",
       "invalidFileType": "Tipo de archivo no válido. Sube MP3, OGG, Opus, M4A, WAV o WebM.",
       "missingLocale": "Selecciona un idioma.",

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -581,6 +581,7 @@
       "guardrailViolation": "Cette demande a été bloquée par une politique de sécurité de clonage vocal d'un tiers. Essayez avec un autre texte ou un autre audio de référence.",
       "insufficientCredits": "Il vous faut __CREDITS__ crédits pour cloner cet audio.",
       "internalError": "Impossible de cloner la voix. Veuillez réessayer.",
+      "providerUnavailable": "Le fournisseur de clonage vocal est temporairement indisponible. Veuillez réessayer.",
       "invalidContentType": "La demande de téléversement n'est pas valide. Veuillez réessayer.",
       "invalidFileType": "Type de fichier non valide. Veuillez téléverser MP3, OGG, Opus, M4A, WAV ou WebM.",
       "missingLocale": "Veuillez sélectionner une langue.",

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -581,6 +581,7 @@
       "guardrailViolation": "Questa richiesta è stata bloccata da una policy di sicurezza di terze parti per la clonazione vocale. Prova con un testo diverso o con un altro audio di riferimento.",
       "insufficientCredits": "Servono __CREDITS__ crediti per clonare questo audio.",
       "internalError": "Impossibile clonare la voce. Riprova.",
+      "providerUnavailable": "Il provider di clonazione vocale è temporaneamente non disponibile. Riprova.",
       "invalidContentType": "La richiesta di caricamento non è valida. Riprova.",
       "invalidFileType": "Tipo di file non valido. Carica MP3, OGG, Opus, M4A, WAV o WebM.",
       "missingLocale": "Seleziona una lingua.",

--- a/apps/web/tests/auth-callback.test.ts
+++ b/apps/web/tests/auth-callback.test.ts
@@ -185,4 +185,42 @@ describe('OAuth callback route', () => {
       }),
     );
   });
+
+  it('downgrades typed expired auth flow state errors to warning telemetry', async () => {
+    const exchangeError = Object.assign(new Error('OAuth flow is no longer valid'), {
+      code: 'flow_state_expired',
+      name: 'AuthApiError',
+    });
+    const exchangeCodeForSession = vi.fn().mockResolvedValue({
+      data: { user: null },
+      error: exchangeError,
+    });
+
+    vi.mocked(createClient).mockResolvedValueOnce({
+      auth: { exchangeCodeForSession },
+    } as unknown as Awaited<ReturnType<typeof createClient>>);
+
+    const response = await GET(
+      new Request('https://sexyvoice.ai/auth/callback?code=abc123', {
+        headers: {
+          cookie:
+            'sb-test-auth-token=token; sb-test-auth-token-code-verifier=verifier',
+        },
+      }),
+    );
+
+    expect(response.status).toBe(307);
+    expect(captureException).not.toHaveBeenCalled();
+    expect(captureMessage).toHaveBeenCalledWith(
+      'OAuth callback flow state expired.',
+      expect.objectContaining({
+        tags: expect.objectContaining({
+          error_type: 'flow-state-expired',
+        }),
+        extra: expect.objectContaining({
+          errorName: 'AuthApiError',
+        }),
+      }),
+    );
+  });
 });

--- a/apps/web/tests/auth-callback.test.ts
+++ b/apps/web/tests/auth-callback.test.ts
@@ -137,4 +137,52 @@ describe('OAuth callback route', () => {
       }),
     );
   });
+
+  it('downgrades expired auth flow state errors to warning telemetry', async () => {
+    const exchangeError = new Error('invalid flow state, flow state has expired');
+    exchangeError.name = 'AuthApiError';
+    const exchangeCodeForSession = vi.fn().mockResolvedValue({
+      data: { user: null },
+      error: exchangeError,
+    });
+
+    vi.mocked(createClient).mockResolvedValueOnce({
+      auth: { exchangeCodeForSession },
+    } as unknown as Awaited<ReturnType<typeof createClient>>);
+
+    const response = await GET(
+      new Request(
+        'https://sexyvoice.ai/auth/callback?code=abc123&redirect_to=%2Fes%2Fdashboard',
+        {
+          headers: {
+            cookie:
+              'sb-test-auth-token=token; sb-test-auth-token-code-verifier=verifier',
+          },
+        },
+      ),
+    );
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get('location')).toBe(
+      'https://sexyvoice.ai/es/login',
+    );
+    expect(captureException).not.toHaveBeenCalled();
+    expect(captureMessage).toHaveBeenCalledWith(
+      'OAuth callback flow state expired.',
+      expect.objectContaining({
+        level: 'warning',
+        tags: {
+          area: 'auth',
+          flow: 'oauth-callback',
+          error_type: 'flow-state-expired',
+        },
+        extra: expect.objectContaining({
+          errorMessage: 'invalid flow state, flow state has expired',
+          hasSupabaseCodeVerifierCookie: true,
+          locale: 'es',
+          redirectTo: '/es/dashboard',
+        }),
+      }),
+    );
+  });
 });

--- a/apps/web/tests/clone-voice.test.ts
+++ b/apps/web/tests/clone-voice.test.ts
@@ -1400,11 +1400,12 @@ describe('Clone Voice API Route', () => {
       const response = await POST(request);
       const json = await response.json();
 
-      expect(response.status).toBe(500);
+      expect(response.status).toBe(503);
       expect(json.error).toBe(
-        'An unexpected error occurred while cloning voice. Please try again.',
+        'Voice cloning provider is temporarily unavailable. Please try again. (503)',
       );
       expect(json.code).toBe('errors.internalError');
+      expect(json.details).toEqual({ provider: 'replicate' });
     });
 
     it('should handle request abortion gracefully', async () => {
@@ -1642,19 +1643,13 @@ describe('Clone Voice API Route', () => {
       expect(json.code).toBe('errors.internalError');
     });
 
-    it('should log errors to Sentry', async () => {
+    it('should log unexpected errors to Sentry', async () => {
       const { captureException } = await import('@sentry/nextjs');
 
-      // Mock an error scenario on the Replicate fallback path
-      mockReplicateRun.mockResolvedValueOnce({
-        error: 'Test error',
-      });
-
-      const formData = createFormDataWithAudio(
-        'こんにちは',
-        createMockAudioFile(),
-        'ja',
+      vi.mocked(queries.getCredits).mockRejectedValueOnce(
+        new Error('Database connection failed'),
       );
+      const formData = createFormDataWithAudio('Hello world');
 
       const request = new Request('http://localhost/api/clone-voice', {
         method: 'POST',
@@ -1664,6 +1659,58 @@ describe('Clone Voice API Route', () => {
       await POST(request);
 
       expect(captureException).toHaveBeenCalled();
+    });
+
+    it('does not log expected fal.ai validation failures to Sentry when falling back to original audio', async () => {
+      const { captureException } = await import('@sentry/nextjs');
+      const validationError = new Error('Unprocessable Entity');
+      validationError.name = 'ValidationError';
+      mockFalSubscribe.mockRejectedValueOnce(validationError);
+
+      const formData = createFormDataWithAudio(
+        'Hello world',
+        createMockAudioFile(),
+        'en',
+        true,
+      );
+
+      const request = new Request('http://localhost/api/clone-voice', {
+        method: 'POST',
+        body: formData,
+      });
+
+      const response = await POST(request);
+      const json = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(json.url).toContain('files.sexyvoice.ai');
+      expect(captureException).not.toHaveBeenCalled();
+    });
+
+    it('does not log expected fal.ai timeout failures to Sentry when falling back to original audio', async () => {
+      const { captureException } = await import('@sentry/nextjs');
+      const timeoutError = new Error('The operation was aborted due to timeout');
+      timeoutError.name = 'TimeoutError';
+      mockFalSubscribe.mockRejectedValueOnce(timeoutError);
+
+      const formData = createFormDataWithAudio(
+        'Hello world',
+        createMockAudioFile(),
+        'en',
+        true,
+      );
+
+      const request = new Request('http://localhost/api/clone-voice', {
+        method: 'POST',
+        body: formData,
+      });
+
+      const response = await POST(request);
+      const json = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(json.url).toContain('files.sexyvoice.ai');
+      expect(captureException).not.toHaveBeenCalled();
     });
 
     it('should handle R2 storage upload failures', async () => {

--- a/apps/web/tests/clone-voice.test.ts
+++ b/apps/web/tests/clone-voice.test.ts
@@ -1687,6 +1687,39 @@ describe('Clone Voice API Route', () => {
       expect(captureException).not.toHaveBeenCalled();
     });
 
+    it('logs generic validation failures to Sentry when enhancement falls back', async () => {
+      const { captureException } = await import('@sentry/nextjs');
+      const validationError = new Error('Invalid local state');
+      validationError.name = 'ValidationError';
+      mockFalSubscribe.mockRejectedValueOnce(validationError);
+
+      const formData = createFormDataWithAudio(
+        'Hello world',
+        createMockAudioFile(),
+        'en',
+        true,
+      );
+
+      const request = new Request('http://localhost/api/clone-voice', {
+        method: 'POST',
+        body: formData,
+      });
+
+      const response = await POST(request);
+      const json = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(json.url).toContain('files.sexyvoice.ai');
+      expect(captureException).toHaveBeenCalledWith(
+        validationError,
+        expect.objectContaining({
+          extra: expect.objectContaining({
+            locale: 'en',
+          }),
+        }),
+      );
+    });
+
     it('does not log expected fal.ai timeout failures to Sentry when falling back to original audio', async () => {
       const { captureException } = await import('@sentry/nextjs');
       const timeoutError = new Error('The operation was aborted due to timeout');

--- a/apps/web/tests/clone-voice.test.ts
+++ b/apps/web/tests/clone-voice.test.ts
@@ -1404,7 +1404,7 @@ describe('Clone Voice API Route', () => {
       expect(json.error).toBe(
         'Voice cloning provider is temporarily unavailable. Please try again. (503)',
       );
-      expect(json.code).toBe('errors.internalError');
+      expect(json.code).toBe('errors.providerUnavailable');
       expect(json.details).toEqual({ provider: 'replicate' });
     });
 

--- a/apps/web/tests/components/grok-tts-editor.test.tsx
+++ b/apps/web/tests/components/grok-tts-editor.test.tsx
@@ -308,6 +308,44 @@ describe('GrokTTSEditor', () => {
     });
   });
 
+  it('clamps a saved selection after external value changes', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const rendered = renderEditor({ onChange, value: 'Hello world' });
+
+    const editor = await findEditor();
+    selectEditorText(editor, 'world');
+
+    rendered.rerender(
+      <GrokTTSEditor
+        characterLimitPaidTooltip={messages.generate.paidCharacterLimitTooltip}
+        characterLimitUpgradeTooltip={
+          messages.generate.upgradeCharacterLimitTooltip
+        }
+        charactersLimit={500}
+        dict={baseDict}
+        onChange={onChange}
+        placeholder={messages.generate.textAreaPlaceholder}
+        selectedGrokLanguage="auto"
+        setSelectedGrokLanguage={vi.fn()}
+        value="Hi"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(editor).toHaveTextContent('Hi');
+    });
+
+    await user.click(
+      screen.getByRole('button', { name: baseDict.inlineEffectPlaceholder }),
+    );
+    await user.click(await screen.findByRole('button', { name: /\[pause\]/i }));
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenLastCalledWith('Hi[pause]');
+    });
+  });
+
   it('wraps selected text with a wrapping tag', async () => {
     const user = userEvent.setup();
     const onChange = vi.fn();

--- a/apps/web/tests/generate-voice.test.ts
+++ b/apps/web/tests/generate-voice.test.ts
@@ -1123,7 +1123,7 @@ describe('Generate Voice API Route', () => {
       const response = await POST(request);
       const json = await response.json();
 
-      expect(response.status).toBe(500);
+      expect(response.status).toBe(429);
       expect(json.error).toContain(
         getErrorMessage('FREE_QUOTA_EXCEEDED', 'voice-generation'),
       );

--- a/apps/web/tests/generate-voice.test.ts
+++ b/apps/web/tests/generate-voice.test.ts
@@ -6,7 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { POST } from '@/app/api/generate-voice/route';
 import { createClient } from '@/lib/supabase/server';
 import { estimateCredits, getErrorMessage } from '@/lib/utils';
-import type { GoogleApiError } from '@/utils/googleErrors';
+import type { GoogleApiErrorWithStatus } from '@/utils/google-rpc-status';
 import {
   mockRedisGet,
   mockRedisKeys,
@@ -1003,8 +1003,16 @@ describe('Generate Voice API Route', () => {
       expect(json.url).toContain('files.sexyvoice.ai');
     });
 
-    it('should return 500 when flash model fails for free Gemini users', async () => {
-      const flashError = new Error('Flash model failed');
+    it('returns 503 without Sentry capture when flash model has a transient provider failure', async () => {
+      const flashError = new Error(
+        JSON.stringify({
+          error: {
+            code: 500,
+            message: 'An internal error has occurred.',
+            status: 'INTERNAL',
+          },
+        }),
+      );
 
       let callCount = 0;
 
@@ -1032,16 +1040,17 @@ describe('Generate Voice API Route', () => {
       const response = await POST(request);
       const json = await response.json();
 
-      expect(response.status).toBe(500);
+      expect(response.status).toBe(503);
       expect(callCount).toBe(1);
-      expect(Sentry.captureException).toHaveBeenCalledTimes(1);
-      expect(Sentry.captureException).toHaveBeenCalledWith(
-        flashError,
+      expect(Sentry.captureException).not.toHaveBeenCalled();
+      expect(Sentry.logger.warn).toHaveBeenCalledWith(
+        'Gemini provider temporarily unavailable',
         expect.objectContaining({
           extra: expect.objectContaining({
-            text: 'dramatic: Hello world',
+            googleCode: 500,
+            googleStatus: 'INTERNAL',
+            textLength: 'dramatic: Hello world'.length,
             voice: 'kore',
-            errorData: flashError,
           }),
           user: {
             id: 'test-user-id',
@@ -1060,7 +1069,9 @@ describe('Generate Voice API Route', () => {
         expect.anything(),
       );
 
-      expect(json.error).toBe('Failed to generate voice');
+      expect(json.error).toBe(
+        'Voice generation service temporarily unavailable. Please retry.',
+      );
     });
 
     it('should handle Google API quota exceeded error', async () => {
@@ -1069,7 +1080,7 @@ describe('Generate Voice API Route', () => {
         models: {
           generateContent: vi.fn().mockImplementation(() => {
             // Both pro and flash models will throw the same quota error
-            const apiError: GoogleApiError = {
+            const apiError: GoogleApiErrorWithStatus = {
               code: 429,
               message:
                 'You exceeded your current quota, please check your plan and billing details. For more information on this error, head to: https://ai.google.dev/gemini-api/docs/rate-limits.\n* Quota exceeded for metric: generativelanguage.googleapis.com/generate_requests_per_model_per_day, limit: 0',
@@ -1078,7 +1089,6 @@ describe('Generate Voice API Route', () => {
                 {
                   '@type': 'type.googleapis.com/google.rpc.QuotaFailure',
                   violations: [
-                    // @ts-expect-error - taken from logs
                     {
                       quotaMetric:
                         'generativelanguage.googleapis.com/generate_requests_per_model_per_day',
@@ -1117,6 +1127,7 @@ describe('Generate Voice API Route', () => {
       expect(json.error).toContain(
         getErrorMessage('FREE_QUOTA_EXCEEDED', 'voice-generation'),
       );
+      expect(Sentry.captureException).not.toHaveBeenCalled();
     });
 
     it('should return 403 when freemium user exceeds gpro voice limit', async () => {

--- a/apps/web/tests/sentry-client-filters.test.ts
+++ b/apps/web/tests/sentry-client-filters.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest';
 import { shouldDropClientSentryEvent } from '@/lib/sentry/client-filters';
 
 describe('shouldDropClientSentryEvent', () => {
-  it('drops React commit-phase removeChild NotFoundError events', () => {
+  it('drops known React DOM mutation noise with React internals frames', () => {
     expect(
       shouldDropClientSentryEvent({
         exception: {
@@ -11,13 +11,12 @@ describe('shouldDropClientSentryEvent', () => {
             {
               type: 'NotFoundError',
               value:
-                "Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.",
+                "Failed to execute 'insertBefore' on 'Node': The node before which the new node is to be inserted is not a child of this node.",
               stacktrace: {
                 frames: [
                   {
-                    filename:
-                      'node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.production.js',
-                    function: 'commitDeletionEffectsOnFiber',
+                    filename: 'react-dom-client.production.js',
+                    function: 'commitMutationEffectsOnFiber',
                   },
                 ],
               },
@@ -28,19 +27,20 @@ describe('shouldDropClientSentryEvent', () => {
     ).toBe(true);
   });
 
-  it('keeps unrelated NotFoundError events', () => {
+  it('does not drop app exceptions that only look superficially similar', () => {
     expect(
       shouldDropClientSentryEvent({
         exception: {
           values: [
             {
-              type: 'NotFoundError',
-              value: 'Microphone input device was not found.',
+              type: 'Error',
+              value:
+                "Failed to execute 'insertBefore' on 'Node': The node before which the new node is to be inserted is not a child of this node.",
               stacktrace: {
                 frames: [
                   {
-                    filename: 'https://sexyvoice.ai/_next/static/app.js',
-                    function: 'connectCall',
+                    filename: 'apps/web/components/example.tsx',
+                    function: 'insertUserNode',
                   },
                 ],
               },
@@ -49,5 +49,14 @@ describe('shouldDropClientSentryEvent', () => {
         },
       }),
     ).toBe(false);
+  });
+
+  it('drops recoverable hydration and RSC connection messages', () => {
+    expect(shouldDropClientSentryEvent({ message: 'Hydration Error' })).toBe(
+      true,
+    );
+    expect(shouldDropClientSentryEvent({ message: 'Connection closed.' })).toBe(
+      true,
+    );
   });
 });

--- a/apps/web/tests/sentry-client-filters.test.ts
+++ b/apps/web/tests/sentry-client-filters.test.ts
@@ -51,6 +51,14 @@ describe('shouldDropClientSentryEvent', () => {
     ).toBe(false);
   });
 
+  it('does not drop DOM mutation text without React frame evidence', () => {
+    expect(
+      shouldDropClientSentryEvent({
+        message: "Cannot read properties of null (reading 'removeChild')",
+      }),
+    ).toBe(false);
+  });
+
   it('drops recoverable hydration and RSC connection messages', () => {
     expect(
       shouldDropClientSentryEvent({

--- a/apps/web/tests/sentry-client-filters.test.ts
+++ b/apps/web/tests/sentry-client-filters.test.ts
@@ -52,6 +52,12 @@ describe('shouldDropClientSentryEvent', () => {
   });
 
   it('drops recoverable hydration and RSC connection messages', () => {
+    expect(
+      shouldDropClientSentryEvent({
+        message:
+          "Hydration failed because the server rendered HTML didn't match the client.",
+      }),
+    ).toBe(true);
     expect(shouldDropClientSentryEvent({ message: 'Hydration Error' })).toBe(
       true,
     );

--- a/apps/web/tests/utils/redis-test-utils.ts
+++ b/apps/web/tests/utils/redis-test-utils.ts
@@ -1,5 +1,6 @@
 import { Redis } from 'ioredis';
 import { RedisMemoryServer } from 'redis-memory-server';
+import type { RedisMemoryServerOptsT } from 'redis-memory-server/lib/RedisMemoryServer';
 
 let redisServer: RedisMemoryServer | null = null;
 let redisClient: Redis | null = null;
@@ -32,7 +33,7 @@ export async function setupRedis(): Promise<Redis> {
 
   // Local development: use in-memory Redis server
   // Configure redis-memory-server with explicit settings for faster downloads
-  const config: any = {
+  const config: RedisMemoryServerOptsT = {
     instance: {
       port: undefined, // auto-assign available port
     },
@@ -43,7 +44,7 @@ export async function setupRedis(): Promise<Redis> {
 
   // Only set downloadDir if the environment variable is defined
   if (process.env.REDIS_MEMORY_SERVER_CACHE_DIR) {
-    config.binary.downloadDir = process.env.REDIS_MEMORY_SERVER_CACHE_DIR;
+    config.binary!.downloadDir = process.env.REDIS_MEMORY_SERVER_CACHE_DIR;
   }
 
   redisServer = new RedisMemoryServer(config);

--- a/apps/web/utils/google-rpc-status.ts
+++ b/apps/web/utils/google-rpc-status.ts
@@ -35,6 +35,8 @@ export function mapHttpToGoogleRpcStatus(
       return 'PERMISSION_DENIED';
     case 404:
       return 'NOT_FOUND';
+    case 408:
+      return 'DEADLINE_EXCEEDED';
     case 409:
       return 'ALREADY_EXISTS';
     case 429:
@@ -43,12 +45,13 @@ export function mapHttpToGoogleRpcStatus(
       return 'INTERNAL';
     case 501:
       return 'UNIMPLEMENTED';
+    case 502:
     case 503:
       return 'UNAVAILABLE';
     case 504:
       return 'DEADLINE_EXCEEDED';
     default:
-      return 'INTERNAL';
+      return 'UNKNOWN';
   }
 }
 

--- a/apps/web/utils/google-rpc-status.ts
+++ b/apps/web/utils/google-rpc-status.ts
@@ -1,0 +1,59 @@
+import type { GoogleApiError } from './googleErrors';
+
+export type GoogleRpcStatus =
+  | 'INVALID_ARGUMENT'
+  | 'FAILED_PRECONDITION'
+  | 'OUT_OF_RANGE'
+  | 'UNAUTHENTICATED'
+  | 'PERMISSION_DENIED'
+  | 'NOT_FOUND'
+  | 'ABORTED'
+  | 'ALREADY_EXISTS'
+  | 'RESOURCE_EXHAUSTED'
+  | 'CANCELLED'
+  | 'UNKNOWN'
+  | 'INTERNAL'
+  | 'DATA_LOSS'
+  | 'UNIMPLEMENTED'
+  | 'UNAVAILABLE'
+  | 'DEADLINE_EXCEEDED'
+  | (string & {});
+
+export type GoogleApiErrorWithStatus = GoogleApiError & {
+  status?: GoogleRpcStatus;
+};
+
+export function mapHttpToGoogleRpcStatus(
+  httpStatus: number | undefined,
+): GoogleRpcStatus {
+  switch (httpStatus) {
+    case 400:
+      return 'INVALID_ARGUMENT';
+    case 401:
+      return 'UNAUTHENTICATED';
+    case 403:
+      return 'PERMISSION_DENIED';
+    case 404:
+      return 'NOT_FOUND';
+    case 409:
+      return 'ALREADY_EXISTS';
+    case 429:
+      return 'RESOURCE_EXHAUSTED';
+    case 500:
+      return 'INTERNAL';
+    case 501:
+      return 'UNIMPLEMENTED';
+    case 503:
+      return 'UNAVAILABLE';
+    case 504:
+      return 'DEADLINE_EXCEEDED';
+    default:
+      return 'INTERNAL';
+  }
+}
+
+export function getGoogleApiErrorStatus(
+  error: GoogleApiErrorWithStatus,
+): GoogleRpcStatus {
+  return error.status ?? mapHttpToGoogleRpcStatus(error.code);
+}

--- a/apps/web/utils/googleErrors.ts
+++ b/apps/web/utils/googleErrors.ts
@@ -1,4 +1,4 @@
-// https://github.com/google-gemini/gemini-cli/blob/0a3e492e6b9edda654395a6e028a09c92596ab8b/packages/core/src/utils/googleErrors.ts#L107
+// https://github.com/google-gemini/gemini-cli/blob/5611ff40e7ace8157fbeee97d459178e988862f3/packages/core/src/utils/googleErrors.ts
 /**
  * @license
  * Copyright 2025 Google LLC
@@ -11,14 +11,35 @@
  */
 
 /**
+ * Sanitize a JSON string before parsing to handle known SSE stream corruption.
+ * SSE stream parsing can inject stray commas — the observed pattern is a comma
+ * at the end of one line followed by a stray comma on the next line, e.g.:
+ *   `"domain": "cloudcode-pa.googleapis.com",\n ,       "metadata": {`
+ * This collapses duplicate commas (possibly separated by whitespace/newlines)
+ * into a single comma, preserving the whitespace.
+ */
+function sanitizeJsonString(jsonStr: string): string {
+  // Match a comma, optional whitespace/newlines, then another comma.
+  // Replace with just a comma + the captured whitespace.
+  // Loop to handle cases like `,,,` which would otherwise become `,,` on a single pass.
+  let prev: string;
+  do {
+    prev = jsonStr;
+    // biome-ignore lint/style/noParameterAssign: keep original
+    jsonStr = jsonStr.replace(/,(\s*),/g, ',$1');
+  } while (jsonStr !== prev);
+  return jsonStr;
+}
+
+/**
  * Based on google/rpc/error_details.proto
  */
 
 export interface ErrorInfo {
   '@type': 'type.googleapis.com/google.rpc.ErrorInfo';
+  domain?: string;
+  metadata?: { [key: string]: string };
   reason: string;
-  domain: string;
-  metadata: { [key: string]: string };
 }
 
 export interface RetryInfo {
@@ -28,20 +49,20 @@ export interface RetryInfo {
 
 export interface DebugInfo {
   '@type': 'type.googleapis.com/google.rpc.DebugInfo';
-  stackEntries: string[];
   detail: string;
+  stackEntries: string[];
 }
 
 export interface QuotaFailure {
   '@type': 'type.googleapis.com/google.rpc.QuotaFailure';
   violations: Array<{
-    subject: string;
-    description: string;
+    subject?: string;
+    description?: string;
     apiService?: string;
     quotaMetric?: string;
     quotaId?: string;
     quotaDimensions?: { [key: string]: string };
-    quotaValue?: number;
+    quotaValue?: string | number;
     futureQuotaValue?: number;
   }>;
 }
@@ -79,10 +100,10 @@ export interface RequestInfo {
 
 export interface ResourceInfo {
   '@type': 'type.googleapis.com/google.rpc.ResourceInfo';
-  resourceType: string;
-  resourceName: string;
-  owner: string;
   description: string;
+  owner: string;
+  resourceName: string;
+  resourceType: string;
 }
 
 export interface Help {
@@ -107,9 +128,15 @@ export type GoogleApiErrorDetail =
 
 export interface GoogleApiError {
   code: number;
-  message: string;
   details: GoogleApiErrorDetail[];
+  message: string;
 }
+
+type ErrorShape = {
+  message?: string;
+  details?: unknown[];
+  code?: number;
+};
 
 /**
  * Parses an error object to check if it's a structured Google API error
@@ -133,23 +160,111 @@ export function parseGoogleApiError(error: unknown): GoogleApiError | null {
   // If error is a string, try to parse it.
   if (typeof errorObj === 'string') {
     try {
-      errorObj = JSON.parse(errorObj);
-    } catch (_) {
+      errorObj = JSON.parse(sanitizeJsonString(errorObj));
+    } catch {
       // Not a JSON string, can't parse.
       return null;
     }
+  }
+
+  if (Array.isArray(errorObj) && errorObj.length > 0) {
+    errorObj = errorObj[0];
   }
 
   if (typeof errorObj !== 'object' || errorObj === null) {
     return null;
   }
 
-  type ErrorShape = {
-    message?: string;
-    details?: unknown[];
-    code?: number;
-  };
+  let currentError: ErrorShape | undefined =
+    fromGaxiosError(errorObj) ?? fromApiError(errorObj);
 
+  let depth = 0;
+  const maxDepth = 10;
+  // Handle cases where the actual error object is stringified inside the message
+  // by drilling down until we find an error that doesn't have a stringified message.
+  while (
+    currentError &&
+    typeof currentError.message === 'string' &&
+    depth < maxDepth
+  ) {
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      const parsedMessage = JSON.parse(
+        sanitizeJsonString(
+          currentError.message.replace(/\u00A0/g, '').replace(/\n/g, ' '),
+        ),
+      );
+      if (parsedMessage.error) {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        currentError = parsedMessage.error;
+        depth++;
+      } else {
+        // The message is a JSON string, but not a nested error object.
+        break;
+      }
+    } catch {
+      // It wasn't a JSON string, so we've drilled down as far as we can.
+      break;
+    }
+  }
+
+  if (!currentError) {
+    return null;
+  }
+
+  const code = currentError.code;
+  const message = currentError.message;
+  const errorDetails = currentError.details;
+
+  if (code && message) {
+    const details: GoogleApiErrorDetail[] = [];
+    if (Array.isArray(errorDetails)) {
+      for (const detail of errorDetails) {
+        if (detail && typeof detail === 'object') {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+          const detailObj = detail as Record<string, unknown>;
+          const typeKey = Object.keys(detailObj).find(
+            (key) => key.trim() === '@type',
+          );
+          if (typeKey) {
+            if (typeKey !== '@type') {
+              detailObj['@type'] = detailObj[typeKey];
+              delete detailObj[typeKey];
+            }
+            // Basic structural check before casting.
+            // Since the proto definitions are loose, we primarily rely on @type presence.
+            // eslint-disable-next-line no-restricted-syntax
+            if (typeof detailObj['@type'] === 'string') {
+              // We can just cast it; the consumer will have to switch on @type
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+              details.push(detailObj as unknown as GoogleApiErrorDetail);
+            }
+          }
+        }
+      }
+    }
+
+    return {
+      code,
+      message,
+      details,
+    };
+  }
+
+  return null;
+}
+
+function isErrorShape(obj: unknown): obj is ErrorShape {
+  return (
+    typeof obj === 'object' &&
+    obj !== null &&
+    (('message' in obj &&
+      typeof (obj as { message: unknown }).message === 'string') ||
+      ('code' in obj && typeof (obj as { code: unknown }).code === 'number'))
+  );
+}
+
+function fromGaxiosError(errorObj: object): ErrorShape | undefined {
   const gaxiosError = errorObj as {
     response?: {
       status?: number;
@@ -165,79 +280,93 @@ export function parseGoogleApiError(error: unknown): GoogleApiError | null {
 
   let outerError: ErrorShape | undefined;
   if (gaxiosError.response?.data) {
-    if (typeof gaxiosError.response.data === 'string') {
+    let data = gaxiosError.response.data;
+
+    if (typeof data === 'string') {
       try {
-        const parsedData = JSON.parse(gaxiosError.response.data);
-        if (parsedData.error) {
-          outerError = parsedData.error;
-        }
-      } catch (_) {
-        // Not a JSON string, or doesn't contain .error
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        data = JSON.parse(sanitizeJsonString(data));
+      } catch {
+        // Not a JSON string, can't parse.
       }
-    } else if (
-      typeof gaxiosError.response.data === 'object' &&
-      gaxiosError.response.data !== null
-    ) {
-      outerError = (
-        gaxiosError.response.data as {
-          error?: ErrorShape;
-        }
-      ).error;
+    }
+
+    if (Array.isArray(data) && data.length > 0) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      data = data[0];
+    }
+
+    if (typeof data === 'object' && data !== null && 'error' in data) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+      const potentialError = (data as { error: unknown }).error;
+      if (isErrorShape(potentialError)) {
+        outerError = potentialError;
+      }
     }
   }
-  const responseStatus = gaxiosError.response?.status;
 
   if (!outerError) {
     // If the gaxios structure isn't there, check for a top-level `error` property.
     if (gaxiosError.error) {
       outerError = gaxiosError.error;
     } else {
-      return null;
+      return undefined;
     }
   }
+  return outerError;
+}
 
-  let currentError = outerError;
-  let depth = 0;
-  const maxDepth = 10;
-  // Handle cases where the actual error object is stringified inside the message
-  // by drilling down until we find an error that doesn't have a stringified message.
-  while (typeof currentError.message === 'string' && depth < maxDepth) {
-    try {
-      const parsedMessage = JSON.parse(currentError.message);
-      if (parsedMessage.error) {
-        currentError = parsedMessage.error;
-        depth++;
-      } else {
-        // The message is a JSON string, but not a nested error object.
-        break;
+function fromApiError(errorObj: object): ErrorShape | undefined {
+  const apiError = errorObj as {
+    message?:
+      | {
+          error?: ErrorShape;
+        }
+      | string;
+    code?: number;
+  };
+
+  let outerError: ErrorShape | undefined;
+  if (apiError.message) {
+    let data = apiError.message;
+
+    if (typeof data === 'string') {
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        data = JSON.parse(sanitizeJsonString(data));
+      } catch {
+        // Not a JSON string, can't parse.
+        // Try one more fallback: look for the first '{' and last '}'
+        if (typeof data === 'string') {
+          const firstBrace = data.indexOf('{');
+          const lastBrace = data.lastIndexOf('}');
+          if (firstBrace !== -1 && lastBrace !== -1 && lastBrace > firstBrace) {
+            try {
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+              data = JSON.parse(
+                // biome-ignore lint/style/noSubstr: keep original
+                sanitizeJsonString(data.substring(firstBrace, lastBrace + 1)),
+              );
+            } catch {
+              // Still failed
+            }
+          }
+        }
       }
-    } catch (_) {
-      // It wasn't a JSON string, so we've drilled down as far as we can.
-      break;
     }
-  }
 
-  const code = responseStatus ?? currentError.code ?? gaxiosError.code;
-  const message = currentError.message;
-  const errorDetails = currentError.details;
+    if (Array.isArray(data) && data.length > 0) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      data = data[0];
+    }
 
-  if (Array.isArray(errorDetails) && code && message) {
-    const details: GoogleApiErrorDetail[] = [];
-    for (const detail of errorDetails) {
-      if (detail && typeof detail === 'object' && '@type' in detail) {
-        // We can just cast it; the consumer will have to switch on @type
-        details.push(detail as GoogleApiErrorDetail);
+    if (typeof data === 'object' && data !== null && 'error' in data) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+      const potentialError = (data as { error: unknown }).error;
+      if (isErrorShape(potentialError)) {
+        outerError = potentialError;
       }
     }
-
-    if (details.length > 0) {
-      return {
-        code,
-        message,
-        details,
-      };
-    }
   }
-
-  return null;
+  return outerError;
 }

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -15,7 +15,8 @@
       "!**/.next",
       "!**/dist",
       "!**/build",
-      "!apps/web/components/ui"
+      "!apps/web/components/ui",
+      "!apps/web/app/globals.css"
     ]
   },
   "formatter": {


### PR DESCRIPTION
## Summary
- Filter low-signal React DOM, hydration, and RSC client errors from Sentry.
- Downgrade known auth callback flow-state failures and Gemini provider quota/transient failures to clearer, lower-noise handling.
- Clamp Tiptap selection state after external content changes so tag insertion stays stable.
- Treat expected fal.ai reference-audio failures as fallback cases and keep unexpected provider errors typed.
- Remove user-facing LiveKit disconnect/agent-unavailable messages from Sentry capture.

## Testing
- Added and updated unit tests for generate voice, auth callback, Sentry client filters, clone voice, and the Grok editor selection behavior.
- Focused Vitest suites passed, including the broader Sentry regression set.
- `pnpm type-check` passed.