### PR TITLE
Use sort order for featured voices

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,6 +147,8 @@ Use package filters when you only want one app, e.g.
 - Database functions should default to `SECURITY INVOKER`, set
   `search_path = ''`, and use fully qualified names.
 - Migration files use `YYYYMMDDHHmmss_description.sql`.
+- Do not add migrations for one-off data backfills or production data fixes unless
+  explicitly requested; provide the SQL for the user to run instead.
 - Enable RLS on new tables and add granular policies.
 
 ## External API v1

--- a/apps/web/app/[lang]/(dashboard)/dashboard/generate/generateui.client.test.tsx
+++ b/apps/web/app/[lang]/(dashboard)/dashboard/generate/generateui.client.test.tsx
@@ -94,7 +94,7 @@ function createVoice(
       'lucataco/orpheus-3b-0.1-ft:79f2a473e6a9720716a473d9b2f2951437dbf91dc02ccb7079fb3d89b881207f',
     description: null,
     type: null,
-    sort_order: 0,
+    sort_order: 1,
     feature: 'tts',
     sample_url: null,
     sample_prompt: null,
@@ -205,6 +205,7 @@ describe('GenerateUI', () => {
       id: 'voice-featured',
       name: 'eve',
       model: 'grok',
+      sort_order: 0,
     });
     const thirdVoice = createVoice({
       id: 'voice-third',

--- a/apps/web/app/[lang]/(dashboard)/dashboard/generate/page.tsx
+++ b/apps/web/app/[lang]/(dashboard)/dashboard/generate/page.tsx
@@ -50,7 +50,8 @@ export default async function GeneratePage(props: {
         .from('voices')
         .select('*')
         .eq('feature', 'tts')
-        .eq('is_public', true),
+        .eq('is_public', true)
+        .order('sort_order'),
     ]);
 
   if (!publicVoices) {

--- a/apps/web/app/[lang]/(dashboard)/dashboard/generate/page.tsx
+++ b/apps/web/app/[lang]/(dashboard)/dashboard/generate/page.tsx
@@ -51,7 +51,8 @@ export default async function GeneratePage(props: {
         .select('*')
         .eq('feature', 'tts')
         .eq('is_public', true)
-        .order('sort_order'),
+        .order('sort_order')
+        .order('name'),
     ]);
 
   if (!publicVoices) {

--- a/apps/web/app/api/v1/voices/route.ts
+++ b/apps/web/app/api/v1/voices/route.ts
@@ -45,7 +45,8 @@ export async function GET(request: Request) {
       .select('id, name, language, model, feature, is_public')
       .eq('feature', 'tts')
       .eq('is_public', true)
-      .order('sort_order');
+      .order('sort_order')
+      .order('name');
 
     if (error) {
       throw error;

--- a/apps/web/components/voice-selector.tsx
+++ b/apps/web/components/voice-selector.tsx
@@ -58,15 +58,9 @@ function isGrokVoice(voice: Tables<'voices'>) {
 }
 
 function sortVoices(voices: Tables<'voices'>[]) {
-  return [...voices].sort((voiceA, voiceB) => {
-    const isFeaturedA = isFeaturedVoice(voiceA);
-    const isFeaturedB = isFeaturedVoice(voiceB);
-
-    if (isFeaturedA && !isFeaturedB) return -1;
-    if (!isFeaturedA && isFeaturedB) return 1;
-
-    return voiceA.name.localeCompare(voiceB.name);
-  });
+  return [...voices].sort(
+    (voiceA, voiceB) => voiceA.sort_order - voiceB.sort_order,
+  );
 }
 
 function getGroupLabel(voice: Tables<'voices'>): string {

--- a/apps/web/components/voice-selector.tsx
+++ b/apps/web/components/voice-selector.tsx
@@ -47,8 +47,9 @@ interface VoiceGroup {
   voices: Tables<'voices'>[];
 }
 
-const featuredGroupLabel = 'Grok ✨';
-const geminiGroupLabel = 'Gemini 🌍';
+const defaultFeaturedGroupLabel = 'Featured';
+const defaultGeminiGroupLabel = 'Gemini 🌍';
+const grokGroupLabel = 'Grok ✨';
 
 function isMultilingualVoice(voice: Tables<'voices'>) {
   return voice.model === 'gpro';
@@ -59,13 +60,18 @@ function isGrokVoice(voice: Tables<'voices'>) {
 
 function sortVoices(voices: Tables<'voices'>[]) {
   return [...voices].sort(
-    (voiceA, voiceB) => voiceA.sort_order - voiceB.sort_order,
+    (voiceA, voiceB) =>
+      voiceA.sort_order - voiceB.sort_order ||
+      voiceA.name.localeCompare(voiceB.name),
   );
 }
 
-function getGroupLabel(voice: Tables<'voices'>): string {
+function getGroupLabel(
+  voice: Tables<'voices'>,
+  geminiGroupLabel: string,
+): string {
   if (isMultilingualVoice(voice)) return geminiGroupLabel;
-  if (isGrokVoice(voice)) return featuredGroupLabel;
+  if (isGrokVoice(voice)) return grokGroupLabel;
   return voice.language;
 }
 
@@ -93,7 +99,13 @@ export function VoiceSelector({
   const voiceSelectorLabels =
     dict.voiceSelector as typeof dict.voiceSelector & {
       featuredBadge?: string;
+      featuredGroupLabel?: string;
+      multilingualGroupLabel?: string;
     };
+  const featuredGroupLabel =
+    voiceSelectorLabels.featuredGroupLabel ?? defaultFeaturedGroupLabel;
+  const geminiGroupLabel =
+    voiceSelectorLabels.multilingualGroupLabel ?? defaultGeminiGroupLabel;
   const featuredBadgeLabel =
     voiceSelectorLabels.featuredBadge ?? featuredGroupLabel;
   const [isFullscreen, setIsFullscreen] = useState(false);
@@ -119,7 +131,7 @@ export function VoiceSelector({
     const groupedVoices = Object.entries(
       nonFeaturedVoices.reduce(
         (acc, voice) => {
-          const group = getGroupLabel(voice);
+          const group = getGroupLabel(voice, geminiGroupLabel);
 
           if (!acc[group]) {
             acc[group] = [];
@@ -154,7 +166,7 @@ export function VoiceSelector({
     }
 
     return [...groups, ...groupedVoices];
-  }, [publicVoices]);
+  }, [featuredGroupLabel, geminiGroupLabel, publicVoices]);
 
   return (
     <Card>

--- a/apps/web/components/voice-selector.tsx
+++ b/apps/web/components/voice-selector.tsx
@@ -42,9 +42,14 @@ import {
   TooltipTrigger,
 } from './ui/tooltip';
 
-interface VoiceGroup {
+export interface VoiceGroup {
   label: string;
   voices: Tables<'voices'>[];
+}
+
+interface VoiceGroupLabels {
+  featuredGroupLabel: string;
+  geminiGroupLabel: string;
 }
 
 const defaultFeaturedGroupLabel = 'Featured';
@@ -73,6 +78,52 @@ function getGroupLabel(
   if (isMultilingualVoice(voice)) return geminiGroupLabel;
   if (isGrokVoice(voice)) return grokGroupLabel;
   return voice.language;
+}
+
+export function getVoiceGroups(
+  publicVoices: Tables<'voices'>[],
+  { featuredGroupLabel, geminiGroupLabel }: VoiceGroupLabels,
+): VoiceGroup[] {
+  const featuredVoices = sortVoices(
+    publicVoices.filter((voice) => isFeaturedVoice(voice)),
+  );
+
+  const nonFeaturedVoices = publicVoices.filter(
+    (voice) => !isFeaturedVoice(voice),
+  );
+
+  const groupedVoices = Object.entries(
+    nonFeaturedVoices.reduce(
+      (acc, voice) => {
+        const group = getGroupLabel(voice, geminiGroupLabel);
+
+        if (!acc[group]) {
+          acc[group] = [];
+        }
+
+        acc[group].push(voice);
+        return acc;
+      },
+      {} as Record<string, Tables<'voices'>[]>,
+    ),
+  ).map(
+    ([label, voices]) =>
+      ({
+        label,
+        voices: sortVoices(voices),
+      }) satisfies VoiceGroup,
+  );
+
+  const groups: VoiceGroup[] = [];
+
+  if (featuredVoices.length > 0) {
+    groups.push({
+      label: featuredGroupLabel,
+      voices: featuredVoices,
+    });
+  }
+
+  return [...groups, ...groupedVoices];
 }
 
 export function VoiceSelector({
@@ -119,54 +170,14 @@ export function VoiceSelector({
     }
   }, [selectedStyle]);
 
-  const voiceGroups = useMemo(() => {
-    const featuredVoices = sortVoices(
-      publicVoices.filter((voice) => isFeaturedVoice(voice)),
-    );
-
-    const nonFeaturedVoices = publicVoices.filter(
-      (voice) => !isFeaturedVoice(voice),
-    );
-
-    const groupedVoices = Object.entries(
-      nonFeaturedVoices.reduce(
-        (acc, voice) => {
-          const group = getGroupLabel(voice, geminiGroupLabel);
-
-          if (!acc[group]) {
-            acc[group] = [];
-          }
-
-          acc[group].push(voice);
-          return acc;
-        },
-        {} as Record<string, Tables<'voices'>[]>,
-      ),
-    )
-      .map(
-        ([label, voices]) =>
-          ({
-            label,
-            voices: sortVoices(voices),
-          }) satisfies VoiceGroup,
-      )
-      .sort((groupA, groupB) => {
-        if (groupA.label === geminiGroupLabel) return -1;
-        if (groupB.label === geminiGroupLabel) return 1;
-        return groupA.label.localeCompare(groupB.label);
-      });
-
-    const groups: VoiceGroup[] = [];
-
-    if (featuredVoices.length > 0) {
-      groups.push({
-        label: featuredGroupLabel,
-        voices: featuredVoices,
-      });
-    }
-
-    return [...groups, ...groupedVoices];
-  }, [featuredGroupLabel, geminiGroupLabel, publicVoices]);
+  const voiceGroups = useMemo(
+    () =>
+      getVoiceGroups(publicVoices, {
+        featuredGroupLabel,
+        geminiGroupLabel,
+      }),
+    [featuredGroupLabel, geminiGroupLabel, publicVoices],
+  );
 
   return (
     <Card>

--- a/apps/web/lib/supabase/queries.ts
+++ b/apps/web/lib/supabase/queries.ts
@@ -26,7 +26,8 @@ export async function getCallVoices() {
     )
     .eq('feature', 'call')
     .eq('is_public', true)
-    .order('sort_order');
+    .order('sort_order')
+    .order('name');
   if (error) throw error;
   return data;
 }

--- a/apps/web/lib/voices.ts
+++ b/apps/web/lib/voices.ts
@@ -1,27 +1,13 @@
-export interface FeaturedVoiceMatcher {
-  model?: string;
-  name: string;
-}
-
-export const FEATURED_TTS_VOICE: FeaturedVoiceMatcher = {
-  model: 'xai',
-  name: 'eve',
-};
+export const FEATURED_VOICE_SORT_ORDER = 0;
 
 export function isFeaturedVoice(
-  voice: Pick<Tables<'voices'>, 'name' | 'model'>,
-  matcher: FeaturedVoiceMatcher = FEATURED_TTS_VOICE,
+  voice: Pick<Tables<'voices'>, 'sort_order'>,
 ): boolean {
-  return (
-    voice.name.toLowerCase() === matcher.name.toLowerCase() ||
-    matcher.model === undefined ||
-    voice.model === matcher.model
-  );
+  return voice.sort_order === FEATURED_VOICE_SORT_ORDER;
 }
 
 export function getFeaturedVoice(
   voices: Tables<'voices'>[],
-  matcher: FeaturedVoiceMatcher = FEATURED_TTS_VOICE,
 ): Tables<'voices'> | undefined {
-  return voices.find((voice) => isFeaturedVoice(voice, matcher));
+  return voices.find(isFeaturedVoice);
 }

--- a/apps/web/tests/api-v1-meta.test.ts
+++ b/apps/web/tests/api-v1-meta.test.ts
@@ -26,41 +26,45 @@ describe('/api/v1 metadata endpoints', () => {
   });
 
   it('returns voices list', async () => {
+    const voicesQuery = {
+      data: [
+        {
+          id: 'voice-kore-id',
+          name: 'kore',
+          language: 'en',
+          model: 'gpro',
+          feature: 'tts',
+          is_public: true,
+        },
+        {
+          id: 'voice-tara-id',
+          name: 'tara',
+          language: 'en',
+          model:
+            'lucataco/orpheus-3b-0.1-ft:79f2a473e6a9720716a473d9b2f2951437dbf91dc02ccb7079fb3d89b881207f',
+          feature: 'tts',
+          is_public: true,
+        },
+        {
+          id: 'voice-eve-id',
+          name: 'eve',
+          language: 'en',
+          model: 'xai',
+          feature: 'tts',
+          is_public: true,
+        },
+      ],
+      eq: vi.fn(),
+      error: null,
+      order: vi.fn(),
+      select: vi.fn(),
+    };
+    voicesQuery.select.mockReturnValue(voicesQuery);
+    voicesQuery.eq.mockReturnValue(voicesQuery);
+    voicesQuery.order.mockReturnValue(voicesQuery);
+
     vi.mocked(createClient).mockResolvedValueOnce({
-      from: vi.fn(() => ({
-        select: vi.fn().mockReturnThis(),
-        eq: vi.fn().mockReturnThis(),
-        order: vi.fn().mockResolvedValue({
-          data: [
-            {
-              id: 'voice-kore-id',
-              name: 'kore',
-              language: 'en',
-              model: 'gpro',
-              feature: 'tts',
-              is_public: true,
-            },
-            {
-              id: 'voice-tara-id',
-              name: 'tara',
-              language: 'en',
-              model:
-                'lucataco/orpheus-3b-0.1-ft:79f2a473e6a9720716a473d9b2f2951437dbf91dc02ccb7079fb3d89b881207f',
-              feature: 'tts',
-              is_public: true,
-            },
-            {
-              id: 'voice-eve-id',
-              name: 'eve',
-              language: 'en',
-              model: 'xai',
-              feature: 'tts',
-              is_public: true,
-            },
-          ],
-          error: null,
-        }),
-      })),
+      from: vi.fn(() => voicesQuery),
     } as never);
 
     const request = new Request('http://localhost/api/v1/voices', {
@@ -82,6 +86,8 @@ describe('/api/v1 metadata endpoints', () => {
       formats: ['mp3', 'wav'],
       supports_style: false,
     });
+    expect(voicesQuery.order).toHaveBeenNthCalledWith(1, 'sort_order');
+    expect(voicesQuery.order).toHaveBeenNthCalledWith(2, 'name');
     expect(response.headers.get('request-id')).toBeTruthy();
   });
 

--- a/apps/web/tests/components/voice-selector.test.tsx
+++ b/apps/web/tests/components/voice-selector.test.tsx
@@ -4,7 +4,7 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 
-import { VoiceSelector } from '@/components/voice-selector';
+import { getVoiceGroups, VoiceSelector } from '@/components/voice-selector';
 
 vi.mock('@/app/[lang]/(dashboard)/dashboard/clone/audio-provider', () => ({
   AudioProvider: ({ children }: { children: React.ReactNode }) => (
@@ -34,7 +34,7 @@ const baseDict = {
     toolTipEmotionTags: 'Emotion tags',
     selectStyleTextareaPlaceholder: 'Describe the speaking style',
     featuredBadge: 'Featured',
-    featuredGroupLabel: 'Grok',
+    featuredGroupLabel: 'Featured',
     multilingualGroupLabel: 'Gemini',
   },
 } as const;
@@ -231,6 +231,71 @@ describe('VoiceSelector', () => {
 
     expect(screen.getByRole('combobox')).toHaveTextContent(/eve/i);
     expect(screen.getByRole('combobox')).toHaveTextContent(/featured/i);
+  });
+
+  it('keeps featured voices first and preserves query order for non-featured groups', () => {
+    const voiceGroups = getVoiceGroups(
+      [
+        createVoice({
+          id: 'voice-featured-zephyr',
+          name: 'zephyr',
+          language: 'multiple',
+          model: 'gpro',
+          sort_order: 0,
+        }),
+        createVoice({
+          id: 'voice-featured-achernar',
+          name: 'achernar',
+          language: 'multiple',
+          model: 'gpro',
+          sort_order: 0,
+        }),
+        createVoice({
+          id: 'voice-grok-sal',
+          name: 'sal',
+          language: 'multiple',
+          model: 'xai',
+          sort_order: 1,
+        }),
+        createVoice({
+          id: 'voice-grok-ara',
+          name: 'ara',
+          language: 'multiple',
+          model: 'xai',
+          sort_order: 1,
+        }),
+        createVoice({
+          id: 'voice-replicate-dan',
+          name: 'dan',
+          language: 'en-GB 🇬🇧',
+          model:
+            'lucataco/orpheus-3b-0.1-ft:79f2a473e6a9720716a473d9b2f2951437dbf91dc02ccb7079fb3d89b881207f',
+          sort_order: 2,
+        }),
+        createVoice({
+          id: 'voice-replicate-emma',
+          name: 'emma',
+          language: 'en-US 🇺🇸',
+          model:
+            'lucataco/orpheus-3b-0.1-ft:79f2a473e6a9720716a473d9b2f2951437dbf91dc02ccb7079fb3d89b881207f',
+          sort_order: 2,
+        }),
+      ],
+      {
+        featuredGroupLabel: baseDict.voiceSelector.featuredGroupLabel,
+        geminiGroupLabel: baseDict.voiceSelector.multilingualGroupLabel,
+      },
+    );
+
+    expect(voiceGroups.map((group) => group.label)).toEqual([
+      'Featured',
+      'Grok ✨',
+      'en-GB 🇬🇧',
+      'en-US 🇺🇸',
+    ]);
+    expect(
+      voiceGroups.map((group) => group.voices.map((voice) => voice.name)),
+    ).toEqual([['achernar', 'zephyr'], ['ara', 'sal'], ['dan'], ['emma']]);
   });
 
   it('keeps the featured grok voice selected while using multilingual grouping copy', () => {

--- a/apps/web/tests/components/voice-selector.test.tsx
+++ b/apps/web/tests/components/voice-selector.test.tsx
@@ -50,7 +50,7 @@ function createVoice(
       'lucataco/orpheus-3b-0.1-ft:79f2a473e6a9720716a473d9b2f2951437dbf91dc02ccb7079fb3d89b881207f',
     description: null,
     type: null,
-    sort_order: 0,
+    sort_order: 1,
     feature: 'tts',
     sample_url: null,
     sample_prompt: null,
@@ -225,6 +225,7 @@ describe('VoiceSelector', () => {
         id: 'voice-grok',
         name: 'eve',
         model: 'xai',
+        sort_order: 0,
       }),
     });
 
@@ -247,6 +248,7 @@ describe('VoiceSelector', () => {
           name: 'eve',
           language: 'en',
           model: 'xai',
+          sort_order: 0,
         }),
       ],
       selectedVoice: createVoice({
@@ -254,6 +256,7 @@ describe('VoiceSelector', () => {
         name: 'eve',
         language: 'en',
         model: 'xai',
+        sort_order: 0,
       }),
     });
 


### PR DESCRIPTION
Summary:
- Treat voices with sort_order 0 as featured.
- Order the dashboard Generate page voices by sort_order before passing them to the client UI.
- Preserve database sort_order when displaying voices instead of alphabetizing within groups.

Tests:
- pnpm --filter @sexyvoice/web exec biome check --write app/[lang]/(dashboard)/dashboard/generate/page.tsx app/[lang]/(dashboard)/dashboard/generate/generateui.client.test.tsx components/voice-selector.tsx lib/voices.ts tests/components/voice-selector.test.tsx
- pnpm type-check
- CI=1 pnpm --filter @sexyvoice/web exec vitest --run tests/components/voice-selector.test.tsx

Notes:
- pnpm fixall was attempted but fails on existing lint issues outside this change.
- pnpm test passed its configured test files in watch mode, then timed out waiting for file changes; CI=1 pnpm test currently fails in tests/stripe-webhook.test.ts with Redis Connection is closed.