### PR TITLE
Track free vs paid calls in daily stats report

### DIFF
--- a/apps/web/app/api/daily-stats/route.ts
+++ b/apps/web/app/api/daily-stats/route.ts
@@ -274,7 +274,9 @@ export async function GET(request: NextRequest) {
       // (callSessions14dResult) Call sessions last 14 days with duration info
       supabase
         .from('call_sessions')
-        .select('id, started_at, duration_seconds, credits_used, status')
+        .select(
+          'id, started_at, duration_seconds, credits_used, status, free_call',
+        )
         .gte('started_at', fourteenDaysAgo.toISOString())
         .lt('started_at', today.toISOString()),
 
@@ -512,6 +514,27 @@ export async function GET(request: NextRequest) {
         ? callsDurationAllTime / callSessionsTotalCount
         : 0,
     ) || 0;
+
+  // Split yesterday and the rolling 14-day window into free vs paid calls
+  const isFreeCall = (call: Tables<'call_sessions'>) => call.free_call === true;
+  const freeCallsYesterday = callSessionsYesterdayData.filter(isFreeCall);
+  const paidCallsYesterday = callSessionsYesterdayData.filter(
+    (call) => !isFreeCall(call),
+  );
+  const freeCalls14d = callSessions14dData.filter(isFreeCall);
+  const paidCalls14d = callSessions14dData.filter((call) => !isFreeCall(call));
+  const freeCallsYesterdayCount = freeCallsYesterday.length;
+  const paidCallsYesterdayCount = paidCallsYesterday.length;
+  const freeCallsDurationYesterday = freeCallsYesterday.reduce(
+    (sum, call) => sum + call.duration_seconds,
+    0,
+  );
+  const paidCallsDurationYesterday = paidCallsYesterday.reduce(
+    (sum, call) => sum + call.duration_seconds,
+    0,
+  );
+  const freeCalls14dCount = freeCalls14d.length;
+  const paidCalls14dCount = paidCalls14d.length;
 
   // Call costs at $0.05 per minute
   const CALL_COST_PER_MINUTE = 0.05;
@@ -1292,6 +1315,7 @@ export async function GET(request: NextRequest) {
     '',
     `📞 Calls: ${callsYesterdayCount} (${formatChange(callsYesterdayCount, calls14dCount / ROLLING_WINDOW_DAYS)})`,
     `  - ${ROLLING_WINDOW_LABEL}: ${calls14dCount} (avg ${(calls14dCount / ROLLING_WINDOW_DAYS).toFixed(1)})`,
+    `  - Free: ${freeCallsYesterdayCount} (${formatDuration(freeCallsDurationYesterday)}) | Paid: ${paidCallsYesterdayCount} (${formatDuration(paidCallsDurationYesterday)}) | ${ROLLING_WINDOW_LABEL}: ${freeCalls14dCount} free, ${paidCalls14dCount} paid`,
     `  - Duration: ${formatDuration(callsDurationYesterday)} (avg ${formatDuration(callsAvgDurationYesterday)}, ${formatDurationChange(callsAvgDurationYesterday, callsAvgDuration14d)} vs ${ROLLING_WINDOW_LABEL}) | ${ROLLING_WINDOW_LABEL}: ${formatDuration(callsDuration14d)} (avg ${formatDuration(callsAvgDuration14d)})`,
     `  - Cost: $${callCostYesterday.toFixed(2)} yesterday | ${ROLLING_WINDOW_LABEL}: $${callCost14d.toFixed(2)} (avg $${(callCost14d / ROLLING_WINDOW_DAYS).toFixed(2)}/day)`,
     `  - All-time: ${callSessionsTotalCount.toLocaleString()} (avg ${formatDuration(callsAvgDurationAllTime)})`,

--- a/apps/web/app/api/daily-stats/route.ts
+++ b/apps/web/app/api/daily-stats/route.ts
@@ -518,23 +518,16 @@ export async function GET(request: NextRequest) {
   // Split yesterday and the rolling 14-day window into free vs paid calls
   const isFreeCall = (call: Tables<'call_sessions'>) => call.free_call === true;
   const freeCallsYesterday = callSessionsYesterdayData.filter(isFreeCall);
-  const paidCallsYesterday = callSessionsYesterdayData.filter(
-    (call) => !isFreeCall(call),
-  );
-  const freeCalls14d = callSessions14dData.filter(isFreeCall);
-  const paidCalls14d = callSessions14dData.filter((call) => !isFreeCall(call));
   const freeCallsYesterdayCount = freeCallsYesterday.length;
-  const paidCallsYesterdayCount = paidCallsYesterday.length;
   const freeCallsDurationYesterday = freeCallsYesterday.reduce(
     (sum, call) => sum + call.duration_seconds,
     0,
   );
-  const paidCallsDurationYesterday = paidCallsYesterday.reduce(
-    (sum, call) => sum + call.duration_seconds,
-    0,
-  );
-  const freeCalls14dCount = freeCalls14d.length;
-  const paidCalls14dCount = paidCalls14d.length;
+  const paidCallsYesterdayCount = callsYesterdayCount - freeCallsYesterdayCount;
+  const paidCallsDurationYesterday =
+    callsDurationYesterday - freeCallsDurationYesterday;
+  const freeCalls14dCount = callSessions14dData.filter(isFreeCall).length;
+  const paidCalls14dCount = calls14dCount - freeCalls14dCount;
 
   // Call costs at $0.05 per minute
   const CALL_COST_PER_MINUTE = 0.05;

--- a/apps/web/app/api/daily-stats/route.ts
+++ b/apps/web/app/api/daily-stats/route.ts
@@ -7,6 +7,9 @@ import { NextResponse } from 'next/server';
 
 // Debug cache file path (temporary for debugging)
 const CACHE_FILE = join(process.cwd(), '.daily-stats-cache.json');
+// Bump when the cached query shape changes so stale fixtures are ignored.
+// v2: call_sessions now include free_call for the free/paid split.
+const CACHE_VERSION = 2;
 const ROLLING_WINDOW_DAYS = 14;
 const ROLLING_WINDOW_LABEL = `${ROLLING_WINDOW_DAYS}d`;
 
@@ -168,6 +171,12 @@ export async function GET(request: NextRequest) {
         '♻️ Ignoring legacy cache without reportDate:',
         CACHE_FILE,
         '(forcing refresh)',
+      );
+    } else if (cached.cacheVersion !== CACHE_VERSION) {
+      console.log(
+        '♻️ Ignoring cache from a different version:',
+        CACHE_FILE,
+        `(cached: ${cached.cacheVersion}, expected: ${CACHE_VERSION})`,
       );
     } else if (cached.reportDate === cacheReportDate) {
       console.log(
@@ -403,6 +412,7 @@ export async function GET(request: NextRequest) {
   // checks so we never persist a partial/failed response to disk
   if (!(isProd || loadedFromValidCache)) {
     const cacheData = {
+      cacheVersion: CACHE_VERSION,
       reportDate: cacheReportDate,
       audioYesterdayResult,
       audio14dResult,
@@ -526,10 +536,17 @@ export async function GET(request: NextRequest) {
   const paidCallsYesterdayCount = callsYesterdayCount - freeCallsYesterdayCount;
   const paidCallsDurationYesterday =
     callsDurationYesterday - freeCallsDurationYesterday;
-  const freeCalls14dCount = callSessions14dData.filter(isFreeCall).length;
+  const freeCalls14d = callSessions14dData.filter(isFreeCall);
+  const freeCalls14dCount = freeCalls14d.length;
+  const freeCallsDuration14d = freeCalls14d.reduce(
+    (sum, call) => sum + call.duration_seconds,
+    0,
+  );
   const paidCalls14dCount = calls14dCount - freeCalls14dCount;
+  const paidCallsDuration14d = callsDuration14d - freeCallsDuration14d;
 
-  // Call costs at $0.05 per minute
+  // Platform infra cost at $0.05 per minute — covers all calls (free included),
+  // not billable revenue, so free-call duration is intentionally part of this.
   const CALL_COST_PER_MINUTE = 0.05;
   const callCostYesterday =
     (callsDurationYesterday / 60) * CALL_COST_PER_MINUTE;
@@ -1308,7 +1325,8 @@ export async function GET(request: NextRequest) {
     '',
     `📞 Calls: ${callsYesterdayCount} (${formatChange(callsYesterdayCount, calls14dCount / ROLLING_WINDOW_DAYS)})`,
     `  - ${ROLLING_WINDOW_LABEL}: ${calls14dCount} (avg ${(calls14dCount / ROLLING_WINDOW_DAYS).toFixed(1)})`,
-    `  - Free: ${freeCallsYesterdayCount} (${formatDuration(freeCallsDurationYesterday)}) | Paid: ${paidCallsYesterdayCount} (${formatDuration(paidCallsDurationYesterday)}) | ${ROLLING_WINDOW_LABEL}: ${freeCalls14dCount} free, ${paidCalls14dCount} paid`,
+    `  - Free: ${freeCallsYesterdayCount} (${formatDuration(freeCallsDurationYesterday)}) | Paid: ${paidCallsYesterdayCount} (${formatDuration(paidCallsDurationYesterday)})`,
+    `  - ${ROLLING_WINDOW_LABEL}: ${freeCalls14dCount} free (${formatDuration(freeCallsDuration14d)}), ${paidCalls14dCount} paid (${formatDuration(paidCallsDuration14d)})`,
     `  - Duration: ${formatDuration(callsDurationYesterday)} (avg ${formatDuration(callsAvgDurationYesterday)}, ${formatDurationChange(callsAvgDurationYesterday, callsAvgDuration14d)} vs ${ROLLING_WINDOW_LABEL}) | ${ROLLING_WINDOW_LABEL}: ${formatDuration(callsDuration14d)} (avg ${formatDuration(callsAvgDuration14d)})`,
     `  - Cost: $${callCostYesterday.toFixed(2)} yesterday | ${ROLLING_WINDOW_LABEL}: $${callCost14d.toFixed(2)} (avg $${(callCost14d / ROLLING_WINDOW_DAYS).toFixed(2)}/day)`,
     `  - All-time: ${callSessionsTotalCount.toLocaleString()} (avg ${formatDuration(callsAvgDurationAllTime)})`,


### PR DESCRIPTION
## Summary

Added tracking and reporting of free vs paid calls in the daily statistics API endpoint. The `free_call` field is now fetched from the database and used to split call metrics into free and paid categories, providing better visibility into call usage patterns.

## Changes

- Added `free_call` field to the call_sessions query to fetch free/paid call classification
- Implemented filtering logic to separate yesterday's and 14-day rolling window calls into free vs paid categories
- Added new metrics: free/paid call counts and durations for yesterday, plus free/paid call counts for the 14-day window
- Updated the daily stats report output to display free vs paid call breakdown alongside existing call metrics

## How to test

1. Verify the `/api/daily-stats` endpoint returns successfully without errors
2. Check that the response includes the new free/paid call breakdown line in the report output
3. Confirm the free and paid call counts and durations are calculated correctly by spot-checking against the database

## Scope

- [x] Backend
- [x] Database

## Checklist

- [x] I self-reviewed this PR
- [ ] I ran `pnpm run fixall`
- [ ] I ran `pnpm run type-check`
- [ ] I added or updated tests where needed
- [ ] I updated translations for any user-facing text
- [ ] I updated docs/comments where needed
- [ ] I included screenshots/video for UI changes
- [ ] I documented env vars, migrations, or rollout notes if needed

## Notes for reviewers

This change assumes the `free_call` column already exists in the `call_sessions` table. If the migration hasn't been applied yet, the query will fail. Verify the database schema includes this field before deploying.

https://claude.ai/code/session_016jCUR8C8vzd2jE6Bb7BLmn