### PR TITLE
Handle non-Stripe Sentry error groups

### DIFF
--- a/apps/docs/content/docs/api-reference/error-codes.mdx
+++ b/apps/docs/content/docs/api-reference/error-codes.mdx
@@ -38,7 +38,9 @@ All errors return this shape:
 | `invalid_api_key` | `authentication_error` | Bearer key missing/invalid/inactive.
 | `insufficient_credits` | `permission_error` | Account balance is too low.
 | `rate_limit_exceeded` | `rate_limit_error` | Too many requests.
+| `provider_quota_exceeded` | `rate_limit_error` | Provider quota or billing is temporarily exhausted.
 | `content_policy_violation` | `invalid_request_error` | Content blocked by provider safety policy.
+| `provider_unavailable` | `server_error` | Upstream provider is temporarily unavailable; retry later.
 | `server_error` | `server_error` | Internal service/provider failure.
 
 ## Debugging with request-id

--- a/apps/docs/content/docs/guides/api.mdx
+++ b/apps/docs/content/docs/guides/api.mdx
@@ -92,5 +92,5 @@ Response includes:
 
 - Read full [API Reference](/api-reference/api)
 - Browse [Grok Voices & Speech Tags](/guides/grok-speech-tags) for the full tag reference
-- Add retries for `429` and transient `500` errors
+- Retry transient `503 provider_unavailable` responses with backoff, and treat `429 provider_quota_exceeded` as temporary provider quota exhaustion
 - Store `request-id` with your logs for support and tracing

--- a/apps/web/app/api/clone-voice/route.ts
+++ b/apps/web/app/api/clone-voice/route.ts
@@ -236,6 +236,44 @@ function getUnknownErrorMessage(error: unknown): string {
   return Error.isError(error) ? error.message : String(error);
 }
 
+function getNumericErrorProperty(
+  error: unknown,
+  property: 'raw_status_code' | 'status' | 'statusCode',
+): number | null {
+  if (!(error && typeof error === 'object' && property in error)) {
+    return null;
+  }
+
+  const value = (error as Record<string, unknown>)[property];
+  return typeof value === 'number' ? value : null;
+}
+
+function isTransientProviderFailure(error: unknown): boolean {
+  const statusCode =
+    getNumericErrorProperty(error, 'status') ??
+    getNumericErrorProperty(error, 'statusCode') ??
+    getNumericErrorProperty(error, 'raw_status_code');
+  const message = getUnknownErrorMessage(error).toLowerCase();
+
+  return (
+    (typeof statusCode === 'number' && statusCode >= 500) ||
+    /status 5\d\d|bad gateway|internal server error|service unavailable|gateway timeout/.test(
+      message,
+    )
+  );
+}
+
+function createProviderUnavailableRouteError(
+  provider: CloneProvider,
+): RouteError {
+  return createRouteError(
+    getErrorMessage(ERROR_CODES.PROVIDER_UNAVAILABLE, 'voice-cloning'),
+    503,
+    'errors.providerUnavailable',
+    { provider },
+  );
+}
+
 // ============================================================================
 // Utilities
 // ============================================================================
@@ -819,6 +857,7 @@ function isExpectedReferenceAudioEnhancementFailure(error: unknown): boolean {
 
   return (
     errorName === 'TimeoutError' ||
+    isTransientProviderFailure(error) ||
     (errorName === 'ValidationError' &&
       errorMessage.includes('unprocessable entity')) ||
     errorMessage.includes('aborted due to timeout')
@@ -932,11 +971,29 @@ async function cloneVoiceWithReplicate(
     reference_audio: audioReferenceUrl,
   };
 
-  const output = (await replicate.run(
-    model,
-    { input },
-    onProgress,
-  )) as ReplicateResponse;
+  let output: ReplicateResponse;
+  try {
+    output = (await replicate.run(
+      model,
+      { input },
+      onProgress,
+    )) as ReplicateResponse;
+  } catch (error) {
+    if (isTransientProviderFailure(error)) {
+      logger.warn('Replicate voice cloning provider unavailable', {
+        extra: {
+          locale,
+          language,
+          model,
+          errorMessage: getUnknownErrorMessage(error),
+          errorName: getUnknownErrorName(error),
+        },
+      });
+      throw createProviderUnavailableRouteError('replicate');
+    }
+
+    throw error;
+  }
 
   if (output && typeof output === 'object' && 'error' in output) {
     logger.warn('Replicate voice cloning provider failed', {
@@ -947,12 +1004,7 @@ async function cloneVoiceWithReplicate(
         errorMessage: output.error || null,
       },
     });
-    throw createRouteError(
-      getErrorMessage(ERROR_CODES.PROVIDER_UNAVAILABLE, 'voice-cloning'),
-      503,
-      'errors.providerUnavailable',
-      { provider: 'replicate' },
-    );
+    throw createProviderUnavailableRouteError('replicate');
   }
 
   const audioBlob = await (output as ReplicateOutput).blob();

--- a/apps/web/app/api/generate-voice/route.ts
+++ b/apps/web/app/api/generate-voice/route.ts
@@ -37,8 +37,12 @@ import {
   getErrorStatusCode,
   getTtsProvider,
 } from '@/lib/utils';
-import { getGoogleApiErrorStatus } from '@/utils/google-rpc-status';
-import { type GoogleApiError, parseGoogleApiError } from '@/utils/googleErrors';
+import {
+  getGoogleApiErrorStatus,
+  isGoogleQuotaError,
+  isGoogleTransientProviderError,
+} from '@/utils/google-rpc-status';
+import { parseGoogleApiError } from '@/utils/googleErrors';
 
 const { logger, captureException } = Sentry;
 
@@ -52,19 +56,6 @@ function isAbortError(error: unknown): boolean {
   if (error.name === 'AbortError') return true;
   const msg = error.message.toLowerCase();
   return /\babort(?:ed| ?error)\b/.test(msg);
-}
-
-function isGoogleQuotaError(errorPayload: GoogleApiError): boolean {
-  return getGoogleApiErrorStatus(errorPayload) === 'RESOURCE_EXHAUSTED';
-}
-
-function isGoogleTransientProviderError(errorPayload: GoogleApiError): boolean {
-  const status = getGoogleApiErrorStatus(errorPayload);
-  return (
-    status === 'INTERNAL' ||
-    status === 'UNAVAILABLE' ||
-    status === 'DEADLINE_EXCEEDED'
-  );
 }
 
 // https://vercel.com/docs/functions/configuring-functions/duration

--- a/apps/web/app/api/v1/speech/route.ts
+++ b/apps/web/app/api/v1/speech/route.ts
@@ -45,8 +45,86 @@ import {
   getErrorMessage,
   getTtsProvider,
 } from '@/lib/utils';
+import {
+  getGoogleApiErrorStatus,
+  isGoogleQuotaError,
+  isGoogleTransientProviderError,
+} from '@/utils/google-rpc-status';
+import { parseGoogleApiError } from '@/utils/googleErrors';
 
 const ENDPOINT = '/api/v1/speech';
+
+interface GeminiProviderFailure {
+  code: string;
+  googleCode?: number;
+  googleStatus?: string;
+  message: string;
+  status: number;
+  type: 'rate_limit_error' | 'server_error';
+}
+
+function getGeminiProviderFailure(
+  proError: unknown,
+  flashError: unknown,
+): GeminiProviderFailure | null {
+  const proGoogleError = parseGoogleApiError(proError);
+  const flashGoogleError = parseGoogleApiError(flashError);
+  const parsedErrors = [proGoogleError, flashGoogleError].filter(
+    (error) => error !== null,
+  );
+
+  if (flashGoogleError && isGoogleQuotaError(flashGoogleError)) {
+    return {
+      code: 'provider_quota_exceeded',
+      googleCode: flashGoogleError.code,
+      googleStatus: getGoogleApiErrorStatus(flashGoogleError),
+      message: getErrorMessage(
+        ERROR_CODES.THIRD_P_QUOTA_EXCEEDED,
+        'voice-generation',
+      ),
+      status: 429,
+      type: 'rate_limit_error',
+    };
+  }
+
+  const transientError = parsedErrors.find((error) =>
+    isGoogleTransientProviderError(error),
+  );
+
+  if (transientError) {
+    return {
+      code: 'provider_unavailable',
+      googleCode: transientError.code,
+      googleStatus: getGoogleApiErrorStatus(transientError),
+      message: getErrorMessage(
+        ERROR_CODES.GEMINI_PROVIDER_UNAVAILABLE,
+        'voice-generation',
+      ),
+      status: 503,
+      type: 'server_error',
+    };
+  }
+
+  return null;
+}
+
+function resolveProviderName({
+  isGeminiVoice,
+  isGrokVoice,
+}: {
+  isGeminiVoice: boolean;
+  isGrokVoice: boolean;
+}): 'google' | 'replicate' | 'xai' {
+  if (isGeminiVoice) {
+    return 'google';
+  }
+
+  if (isGrokVoice) {
+    return 'xai';
+  }
+
+  return 'replicate';
+}
 
 // https://vercel.com/docs/functions/configuring-functions/duration
 export const maxDuration = 800; // seconds - fluid compute is enabled
@@ -259,11 +337,7 @@ export async function POST(request: Request) {
     const extension = chosenFormat;
     const filename = `${folder}/${voice}-${Date.now()}.${extension}`;
 
-    const provider = isGeminiVoice
-      ? 'google'
-      : isGrokVoice
-        ? 'xai'
-        : 'replicate';
+    const provider = resolveProviderName({ isGeminiVoice, isGrokVoice });
     let modelUsed = voiceObj.model;
     let uploadUrl: string;
     let replicateResponse: Prediction | undefined;
@@ -307,6 +381,37 @@ export async function POST(request: Request) {
             config,
           });
         } catch (flashError) {
+          const providerFailure = getGeminiProviderFailure(
+            proError,
+            flashError,
+          );
+
+          if (providerFailure) {
+            await log({
+              status: providerFailure.status,
+              errorCode: providerFailure.code,
+              error: providerFailure.message,
+              userId,
+              apiKeyId: authResult.apiKeyId,
+              voice,
+              model: modelUsed,
+              textLength: finalText.length,
+              provider,
+              providerCode: providerFailure.googleCode,
+              providerStatus: providerFailure.googleStatus,
+              isGeminiVoice,
+            });
+
+            return respond(
+              createApiError({
+                message: providerFailure.message,
+                type: providerFailure.type,
+                code: providerFailure.code,
+              }),
+              { status: providerFailure.status },
+            );
+          }
+
           throw new Error(
             `Both Gemini models failed. Pro error: ${proError instanceof Error ? proError.message : String(proError)}. Flash error: ${flashError instanceof Error ? flashError.message : String(flashError)}`,
           );

--- a/apps/web/app/api/v1/speech/route.ts
+++ b/apps/web/app/api/v1/speech/route.ts
@@ -70,7 +70,7 @@ function getGeminiProviderFailure(
   const proGoogleError = parseGoogleApiError(proError);
   const flashGoogleError = parseGoogleApiError(flashError);
   const parsedErrors = [proGoogleError, flashGoogleError].filter(
-    (error) => error !== null,
+    (error): error is NonNullable<typeof error> => error !== null,
   );
 
   if (flashGoogleError && isGoogleQuotaError(flashGoogleError)) {

--- a/apps/web/app/auth/callback/route.ts
+++ b/apps/web/app/auth/callback/route.ts
@@ -89,6 +89,46 @@ const isExpiredAuthFlowStateError = (error: unknown) => {
   );
 };
 
+const isCodeChallengeMismatchError = (error: unknown) => {
+  const errorName = getErrorStringProperty(error, 'name');
+  const errorMessage = getErrorStringProperty(error, 'message').toLowerCase();
+
+  return (
+    errorName === 'AuthApiError' &&
+    errorMessage.includes(
+      'code challenge does not match previously saved code verifier',
+    )
+  );
+};
+
+function getKnownOauthCallbackFailure(error: unknown): {
+  errorType: string;
+  message: string;
+} | null {
+  if (isPkceCodeVerifierMissingError(error)) {
+    return {
+      errorType: 'pkce-code-verifier-missing',
+      message: 'OAuth callback missing PKCE code verifier.',
+    };
+  }
+
+  if (isExpiredAuthFlowStateError(error)) {
+    return {
+      errorType: 'flow-state-expired',
+      message: 'OAuth callback flow state expired.',
+    };
+  }
+
+  if (isCodeChallengeMismatchError(error)) {
+    return {
+      errorType: 'code-challenge-mismatch',
+      message: 'OAuth callback code challenge mismatch.',
+    };
+  }
+
+  return null;
+}
+
 const getOauthCallbackCookieContext = (request: Request) => {
   const cookieHeader = request.headers.get('cookie') ?? '';
   const cookieNames = cookieHeader
@@ -152,13 +192,10 @@ export async function GET(request: Request) {
     errorType: string,
     error: unknown,
   ) => {
-    captureMessage(message, {
-      level: 'warning',
-      tags: {
-        area: 'auth',
-        flow: 'oauth-callback',
-        error_type: errorType,
-      },
+    console.warn(message, {
+      area: 'auth',
+      errorType,
+      flow: 'oauth-callback',
       extra: {
         redirectTo,
         locale,
@@ -172,19 +209,6 @@ export async function GET(request: Request) {
 
     return NextResponse.redirect(`${origin}${loginPath}`);
   };
-  const reportPkceCodeVerifierMissing = (error: unknown) =>
-    reportKnownOauthCallbackFailure(
-      'OAuth callback missing PKCE code verifier.',
-      'pkce-code-verifier-missing',
-      error,
-    );
-  const reportExpiredAuthFlowState = (error: unknown) =>
-    reportKnownOauthCallbackFailure(
-      'OAuth callback flow state expired.',
-      'flow-state-expired',
-      error,
-    );
-
   try {
     if (!code) {
       return NextResponse.redirect(`${origin}${loginPath}`);
@@ -196,12 +220,14 @@ export async function GET(request: Request) {
     } = await supabase.auth.exchangeCodeForSession(code);
 
     if (exchangeError) {
-      if (isPkceCodeVerifierMissingError(exchangeError)) {
-        return reportPkceCodeVerifierMissing(exchangeError);
-      }
-
-      if (isExpiredAuthFlowStateError(exchangeError)) {
-        return reportExpiredAuthFlowState(exchangeError);
+      const knownOauthCallbackFailure =
+        getKnownOauthCallbackFailure(exchangeError);
+      if (knownOauthCallbackFailure) {
+        return reportKnownOauthCallbackFailure(
+          knownOauthCallbackFailure.message,
+          knownOauthCallbackFailure.errorType,
+          exchangeError,
+        );
       }
 
       captureException(exchangeError, {
@@ -274,12 +300,13 @@ export async function GET(request: Request) {
       `${origin}/${routing.defaultLocale}/dashboard`,
     );
   } catch (error) {
-    if (isPkceCodeVerifierMissingError(error)) {
-      return reportPkceCodeVerifierMissing(error);
-    }
-
-    if (isExpiredAuthFlowStateError(error)) {
-      return reportExpiredAuthFlowState(error);
+    const knownOauthCallbackFailure = getKnownOauthCallbackFailure(error);
+    if (knownOauthCallbackFailure) {
+      return reportKnownOauthCallbackFailure(
+        knownOauthCallbackFailure.message,
+        knownOauthCallbackFailure.errorType,
+        error,
+      );
     }
 
     captureException(error, {

--- a/apps/web/components/call/krisp-noise-filter.ts
+++ b/apps/web/components/call/krisp-noise-filter.ts
@@ -35,9 +35,22 @@ export function shouldEnableKrispNoiseFilter(publication: unknown): boolean {
   return getMediaStreamReadyState(publication) === 'live';
 }
 
+function getStringProperty(value: object, property: string): string {
+  if (!(property in value)) {
+    return '';
+  }
+
+  const propertyValue = (value as Record<string, unknown>)[property];
+  return typeof propertyValue === 'string' ? propertyValue : '';
+}
+
 export function isExpectedKrispNoiseFilterError(error: unknown): boolean {
-  const name = error instanceof Error ? error.name : '';
-  const message = error instanceof Error ? error.message : String(error);
+  const name =
+    error && typeof error === 'object' ? getStringProperty(error, 'name') : '';
+  const message =
+    error && typeof error === 'object'
+      ? getStringProperty(error, 'message') || String(error)
+      : String(error);
   const normalizedMessage = message.toLowerCase();
 
   return (

--- a/apps/web/components/call/krisp-noise-filter.ts
+++ b/apps/web/components/call/krisp-noise-filter.ts
@@ -1,0 +1,75 @@
+type NoiseFilterSetter = (enabled: boolean) => Promise<void> | void;
+
+type NoiseFilterResult = 'enabled' | 'failed' | 'ignored' | 'skipped';
+
+function getMediaStreamReadyState(publication: unknown): string | null {
+  if (!(publication && typeof publication === 'object')) {
+    return null;
+  }
+
+  const track =
+    'track' in publication ? (publication as { track?: unknown }).track : null;
+
+  if (!(track && typeof track === 'object')) {
+    return null;
+  }
+
+  const mediaStreamTrack =
+    'mediaStreamTrack' in track
+      ? (track as { mediaStreamTrack?: unknown }).mediaStreamTrack
+      : null;
+
+  if (!(mediaStreamTrack && typeof mediaStreamTrack === 'object')) {
+    return null;
+  }
+
+  const readyState =
+    'readyState' in mediaStreamTrack
+      ? (mediaStreamTrack as { readyState?: unknown }).readyState
+      : null;
+
+  return typeof readyState === 'string' ? readyState : null;
+}
+
+export function shouldEnableKrispNoiseFilter(publication: unknown): boolean {
+  return getMediaStreamReadyState(publication) === 'live';
+}
+
+export function isExpectedKrispNoiseFilterError(error: unknown): boolean {
+  const name = error instanceof Error ? error.name : '';
+  const message = error instanceof Error ? error.message : String(error);
+  const normalizedMessage = message.toLowerCase();
+
+  return (
+    name === 'InvalidAccessError' ||
+    normalizedMessage.includes('track has ended') ||
+    normalizedMessage.includes('wasm_or_worker_not_ready') ||
+    normalizedMessage.includes('applyconstraints')
+  );
+}
+
+export async function enableKrispNoiseFilterIfReady({
+  microphonePublication,
+  onUnexpectedError,
+  setNoiseFilterEnabled,
+}: {
+  microphonePublication: unknown;
+  onUnexpectedError?: (error: unknown) => void;
+  setNoiseFilterEnabled: NoiseFilterSetter;
+}): Promise<NoiseFilterResult> {
+  if (!shouldEnableKrispNoiseFilter(microphonePublication)) {
+    return 'skipped';
+  }
+
+  try {
+    await setNoiseFilterEnabled(true);
+    return 'enabled';
+  } catch (error) {
+    if (isExpectedKrispNoiseFilterError(error)) {
+      return 'ignored';
+    }
+
+    onUnexpectedError?.(error);
+    return 'failed';
+  }
+}

--- a/apps/web/components/call/session-controls.tsx
+++ b/apps/web/components/call/session-controls.tsx
@@ -23,6 +23,10 @@ import {
 import { useCallTimer } from '@/hooks/use-call-timer';
 import { useConnection } from '@/hooks/use-connection';
 import { usePersistentMediaDevice } from '@/hooks/use-persistent-media-device';
+import {
+  enableKrispNoiseFilterIfReady,
+  isExpectedKrispNoiseFilterError,
+} from './krisp-noise-filter';
 
 export function SessionControls() {
   const localParticipant = useLocalParticipant();
@@ -35,8 +39,26 @@ export function SessionControls() {
   const { isNoiseFilterEnabled, isNoiseFilterPending, setNoiseFilterEnabled } =
     useKrispNoiseFilter();
   useEffect(() => {
-    setNoiseFilterEnabled(true);
-  }, [setNoiseFilterEnabled]);
+    let cancelled = false;
+
+    enableKrispNoiseFilterIfReady({
+      microphonePublication: localParticipant.microphoneTrack,
+      onUnexpectedError: (error) => {
+        if (!cancelled) {
+          console.warn('Krisp noise filter could not be enabled', error);
+        }
+      },
+      setNoiseFilterEnabled,
+    }).catch((error) => {
+      if (!cancelled) {
+        console.warn('Krisp noise filter could not be enabled', error);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [localParticipant.microphoneTrack, setNoiseFilterEnabled]);
   useEffect(() => {
     setIsMuted(localParticipant.isMicrophoneEnabled === false);
   }, [localParticipant.isMicrophoneEnabled]);
@@ -112,9 +134,18 @@ export function SessionControls() {
                 checked={isNoiseFilterEnabled}
                 className="text-xs"
                 disabled={isNoiseFilterPending}
-                onCheckedChange={(checked) => {
-                  setNoiseFilterEnabled(checked);
-                }}
+                onCheckedChange={(checked) =>
+                  Promise.resolve(setNoiseFilterEnabled(checked)).catch(
+                    (error) => {
+                      if (!isExpectedKrispNoiseFilterError(error)) {
+                        console.warn(
+                          'Krisp noise filter could not be changed',
+                          error,
+                        );
+                      }
+                    },
+                  )
+                }
               >
                 {dict.enhancedNoiseFilter}
               </DropdownMenuCheckboxItem>

--- a/apps/web/lib/api/logger.ts
+++ b/apps/web/lib/api/logger.ts
@@ -17,6 +17,8 @@ export interface LogFields {
   isGrokVoice?: boolean;
   model?: string;
   provider?: string;
+  providerCode?: number;
+  providerStatus?: string;
   status: number;
   textLength?: number;
   userHasPaid?: boolean;

--- a/apps/web/lib/audio-converter.ts
+++ b/apps/web/lib/audio-converter.ts
@@ -418,11 +418,11 @@ export async function convertToWav(
       default:
         return null;
     }
+
+    validateDecodedAudio(decoded, format);
   } catch (error) {
     throw new AudioDecodeError(format, error);
   }
-
-  validateDecodedAudio(decoded, format);
 
   // Interleave channels if stereo/multi-channel
   const interleaved = interleaveChannels(decoded.channelData);

--- a/apps/web/lib/sentry/client-filters.ts
+++ b/apps/web/lib/sentry/client-filters.ts
@@ -36,8 +36,7 @@ const rscConnectionClosedPattern = /^Connection closed\.$/i;
 
 const reactCommitDeletionFramePattern =
   /commitDeletionEffectsOnFiber|commitMutationEffectsOnFiber|recursivelyTraverseMutationEffects|react-dom-client|react-server-dom/i;
-const thirdPartyScriptFramePattern =
-  /app:\/\/|posthog-recorder\.js|addEL_hook/i;
+const thirdPartyScriptFramePattern = /posthog-recorder\.js|addEL_hook/i;
 const localAppFramePattern = /apps\/web|\/_next\/static\/chunks\/app\//i;
 const browserMediaNoisePattern =
   /Track has ended|WASM_OR_WORKER_NOT_READY|Lock was stolen by another request/i;

--- a/apps/web/lib/sentry/client-filters.ts
+++ b/apps/web/lib/sentry/client-filters.ts
@@ -36,17 +36,42 @@ const rscConnectionClosedPattern = /^Connection closed\.$/i;
 
 const reactCommitDeletionFramePattern =
   /commitDeletionEffectsOnFiber|commitMutationEffectsOnFiber|recursivelyTraverseMutationEffects|react-dom-client|react-server-dom/i;
+const thirdPartyScriptFramePattern =
+  /app:\/\/|posthog-recorder\.js|addEL_hook/i;
+const localAppFramePattern = /apps\/web|\/_next\/static\/chunks\/app\//i;
+const browserMediaNoisePattern =
+  /Track has ended|WASM_OR_WORKER_NOT_READY|Lock was stolen by another request/i;
+const opaqueBrowserEventRejectionPattern =
+  /Event `Event` \(type=error\) captured as promise rejection/i;
+const browserSecurityNoisePattern =
+  /Permission to call 'get parentNode' denied|The request was denied/i;
+const nullTagNamePattern =
+  /Cannot read properties of null \(reading 'tagName'\)/i;
+
+function getExceptionText(exception: SentryException): string {
+  return [exception.type, exception.value].filter(Boolean).join(' ');
+}
+
+function getFrameText(frame: SentryStackFrame): string {
+  return [frame.filename, frame.function, frame.module]
+    .filter(Boolean)
+    .join(' ');
+}
 
 function frameMatchesReactInternals(frame: SentryStackFrame): boolean {
-  return reactCommitDeletionFramePattern.test(
-    [frame.filename, frame.function, frame.module].filter(Boolean).join(' '),
-  );
+  return reactCommitDeletionFramePattern.test(getFrameText(frame));
+}
+
+function frameMatchesThirdPartyScript(frame: SentryStackFrame): boolean {
+  return thirdPartyScriptFramePattern.test(getFrameText(frame));
+}
+
+function frameMatchesLocalApp(frame: SentryStackFrame): boolean {
+  return localAppFramePattern.test(getFrameText(frame));
 }
 
 function isReactDomNoiseException(exception: SentryException): boolean {
-  const exceptionText = [exception.type, exception.value]
-    .filter(Boolean)
-    .join(' ');
+  const exceptionText = getExceptionText(exception);
 
   if (
     !reactDomMutationNoisePatterns.some((pattern) =>
@@ -61,10 +86,49 @@ function isReactDomNoiseException(exception: SentryException): boolean {
   return frames.length === 0 || frames.some(frameMatchesReactInternals);
 }
 
+function isThirdPartyScriptNoiseException(exception: SentryException): boolean {
+  const exceptionText = getExceptionText(exception);
+  const frames = exception.stacktrace?.frames ?? [];
+
+  if (nullTagNamePattern.test(exceptionText)) {
+    return frames.some(frameMatchesThirdPartyScript);
+  }
+
+  if (browserSecurityNoisePattern.test(exceptionText)) {
+    return frames.length === 0 || frames.some(frameMatchesThirdPartyScript);
+  }
+
+  return false;
+}
+
+function isBrowserRuntimeNoiseException(exception: SentryException): boolean {
+  const exceptionText = getExceptionText(exception);
+
+  if (
+    !(
+      browserMediaNoisePattern.test(exceptionText) ||
+      opaqueBrowserEventRejectionPattern.test(exceptionText)
+    )
+  ) {
+    return false;
+  }
+
+  const frames = exception.stacktrace?.frames ?? [];
+  return frames.length === 0 || !frames.some(frameMatchesLocalApp);
+}
+
 export function shouldDropClientSentryEvent(event: SentryClientEvent): boolean {
   const exceptions = event.exception?.values ?? [];
 
   if (exceptions.some(isReactDomNoiseException)) {
+    return true;
+  }
+
+  if (exceptions.some(isThirdPartyScriptNoiseException)) {
+    return true;
+  }
+
+  if (exceptions.some(isBrowserRuntimeNoiseException)) {
     return true;
   }
 

--- a/apps/web/tests/api-v1-speech.test.ts
+++ b/apps/web/tests/api-v1-speech.test.ts
@@ -1,3 +1,4 @@
+import { captureException } from '@sentry/nextjs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { POST } from '@/app/api/v1/speech/route';
@@ -358,6 +359,94 @@ describe('/api/v1/speech', () => {
     expect(response.status).toBe(200);
     expect(generateContent).toHaveBeenCalled();
     expect(generateContent.mock.calls[0][0].config.seed).toBe(1234);
+  });
+
+  it('returns provider quota errors from Gemini without capturing exceptions', async () => {
+    const quotaError = new Error(
+      JSON.stringify({
+        error: {
+          code: 429,
+          message: 'Your prepayment credits are depleted.',
+          status: 'RESOURCE_EXHAUSTED',
+        },
+      }),
+    );
+    const generateContent = vi
+      .fn()
+      .mockRejectedValueOnce(quotaError)
+      .mockRejectedValueOnce(quotaError);
+    setMockGoogleGenAIFactory(() => ({
+      models: {
+        countTokens: vi.fn(),
+        generateContent,
+      },
+    }));
+
+    const request = new Request('http://localhost/api/v1/speech', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        authorization: TEST_AUTH_HEADER,
+      },
+      body: JSON.stringify({
+        model: 'gpro',
+        input: 'Hello world',
+        voice: 'kore',
+      }),
+    });
+
+    const response = await POST(request);
+    const json = await response.json();
+
+    expect(response.status).toBe(429);
+    expect(json.error.type).toBe('rate_limit_error');
+    expect(json.error.code).toBe('provider_quota_exceeded');
+    expect(generateContent).toHaveBeenCalledTimes(2);
+    expect(captureException).not.toHaveBeenCalled();
+  });
+
+  it('returns provider unavailable from transient Gemini errors without capture', async () => {
+    const transientError = new Error(
+      JSON.stringify({
+        error: {
+          code: 500,
+          message: 'Internal provider error.',
+          status: 'INTERNAL',
+        },
+      }),
+    );
+    const generateContent = vi
+      .fn()
+      .mockRejectedValueOnce(transientError)
+      .mockRejectedValueOnce(transientError);
+    setMockGoogleGenAIFactory(() => ({
+      models: {
+        countTokens: vi.fn(),
+        generateContent,
+      },
+    }));
+
+    const request = new Request('http://localhost/api/v1/speech', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        authorization: TEST_AUTH_HEADER,
+      },
+      body: JSON.stringify({
+        model: 'gpro',
+        input: 'Hello world',
+        voice: 'kore',
+      }),
+    });
+
+    const response = await POST(request);
+    const json = await response.json();
+
+    expect(response.status).toBe(503);
+    expect(json.error.type).toBe('server_error');
+    expect(json.error.code).toBe('provider_unavailable');
+    expect(generateContent).toHaveBeenCalledTimes(2);
+    expect(captureException).not.toHaveBeenCalled();
   });
 
   it('always generates fresh audio (no caching)', async () => {

--- a/apps/web/tests/audio-converter.test.ts
+++ b/apps/web/tests/audio-converter.test.ts
@@ -369,9 +369,11 @@ describe('audio-converter', () => {
         const mp3Buffer = Buffer.from([0xff, 0xfb, 0x10, 0x00]);
         await expect(
           convertToWav(mp3Buffer, 'audio/mpeg', 'invalid.mp3'),
-        ).rejects.toThrow(
-          'Decoded mp3 audio did not contain valid channel data',
-        );
+        ).rejects.toMatchObject({
+          decoderMessage:
+            'Decoded mp3 audio did not contain valid channel data',
+          name: 'AudioDecodeError',
+        });
       } finally {
         mockMPEGDecoder.prototype.decode = originalDecode;
       }

--- a/apps/web/tests/auth-callback.test.ts
+++ b/apps/web/tests/auth-callback.test.ts
@@ -33,9 +33,10 @@ vi.mock('next/server', () => ({
 describe('OAuth callback route', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
   });
 
-  it('downgrades missing PKCE verifier errors to warning telemetry', async () => {
+  it('handles missing PKCE verifier errors without Sentry telemetry', async () => {
     const exchangeError = new Error('PKCE code verifier not found in storage.');
     exchangeError.name = 'AuthPKCECodeVerifierMissingError';
     const exchangeCodeForSession = vi.fn().mockResolvedValue({
@@ -65,15 +66,13 @@ describe('OAuth callback route', () => {
     );
     expect(exchangeCodeForSession).toHaveBeenCalledWith('abc123');
     expect(captureException).not.toHaveBeenCalled();
-    expect(captureMessage).toHaveBeenCalledWith(
+    expect(captureMessage).not.toHaveBeenCalled();
+    expect(console.warn).toHaveBeenCalledWith(
       'OAuth callback missing PKCE code verifier.',
-      expect.objectContaining({
-        level: 'warning',
-        tags: {
-          area: 'auth',
-          flow: 'oauth-callback',
-          error_type: 'pkce-code-verifier-missing',
-        },
+      {
+        area: 'auth',
+        errorType: 'pkce-code-verifier-missing',
+        flow: 'oauth-callback',
         extra: expect.objectContaining({
           redirectTo: '/en/dashboard',
           locale: 'en',
@@ -87,7 +86,7 @@ describe('OAuth callback route', () => {
           hasOauthCallbackMarkerCookie: true,
           errorMessage: 'PKCE code verifier not found in storage.',
         }),
-      }),
+      },
     );
   });
 
@@ -138,8 +137,10 @@ describe('OAuth callback route', () => {
     );
   });
 
-  it('downgrades expired auth flow state errors to warning telemetry', async () => {
-    const exchangeError = new Error('invalid flow state, flow state has expired');
+  it('handles expired auth flow state errors without Sentry telemetry', async () => {
+    const exchangeError = new Error(
+      'invalid flow state, flow state has expired',
+    );
     exchangeError.name = 'AuthApiError';
     const exchangeCodeForSession = vi.fn().mockResolvedValue({
       data: { user: null },
@@ -167,30 +168,31 @@ describe('OAuth callback route', () => {
       'https://sexyvoice.ai/es/login',
     );
     expect(captureException).not.toHaveBeenCalled();
-    expect(captureMessage).toHaveBeenCalledWith(
+    expect(captureMessage).not.toHaveBeenCalled();
+    expect(console.warn).toHaveBeenCalledWith(
       'OAuth callback flow state expired.',
-      expect.objectContaining({
-        level: 'warning',
-        tags: {
-          area: 'auth',
-          flow: 'oauth-callback',
-          error_type: 'flow-state-expired',
-        },
+      {
+        area: 'auth',
+        errorType: 'flow-state-expired',
+        flow: 'oauth-callback',
         extra: expect.objectContaining({
           errorMessage: 'invalid flow state, flow state has expired',
           hasSupabaseCodeVerifierCookie: true,
           locale: 'es',
           redirectTo: '/es/dashboard',
         }),
-      }),
+      },
     );
   });
 
-  it('downgrades typed expired auth flow state errors to warning telemetry', async () => {
-    const exchangeError = Object.assign(new Error('OAuth flow is no longer valid'), {
-      code: 'flow_state_expired',
-      name: 'AuthApiError',
-    });
+  it('handles typed expired auth flow state errors without Sentry telemetry', async () => {
+    const exchangeError = Object.assign(
+      new Error('OAuth flow is no longer valid'),
+      {
+        code: 'flow_state_expired',
+        name: 'AuthApiError',
+      },
+    );
     const exchangeCodeForSession = vi.fn().mockResolvedValue({
       data: { user: null },
       error: exchangeError,
@@ -211,16 +213,64 @@ describe('OAuth callback route', () => {
 
     expect(response.status).toBe(307);
     expect(captureException).not.toHaveBeenCalled();
-    expect(captureMessage).toHaveBeenCalledWith(
+    expect(captureMessage).not.toHaveBeenCalled();
+    expect(console.warn).toHaveBeenCalledWith(
       'OAuth callback flow state expired.',
-      expect.objectContaining({
-        tags: expect.objectContaining({
-          error_type: 'flow-state-expired',
-        }),
+      {
+        area: 'auth',
+        errorType: 'flow-state-expired',
+        flow: 'oauth-callback',
         extra: expect.objectContaining({
           errorName: 'AuthApiError',
         }),
-      }),
+      },
+    );
+  });
+
+  it('handles code challenge mismatch errors without Sentry telemetry', async () => {
+    const exchangeError = Object.assign(
+      new Error('code challenge does not match previously saved code verifier'),
+      { name: 'AuthApiError' },
+    );
+    const exchangeCodeForSession = vi.fn().mockResolvedValue({
+      data: { user: null },
+      error: exchangeError,
+    });
+
+    vi.mocked(createClient).mockResolvedValueOnce({
+      auth: { exchangeCodeForSession },
+    } as unknown as Awaited<ReturnType<typeof createClient>>);
+
+    const response = await GET(
+      new Request(
+        'https://sexyvoice.ai/auth/callback?code=abc123&redirect_to=%2Fen%2Fdashboard',
+        {
+          headers: {
+            cookie:
+              'sb-test-auth-token=token; sb-test-auth-token-code-verifier=verifier',
+          },
+        },
+      ),
+    );
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get('location')).toBe(
+      'https://sexyvoice.ai/en/login',
+    );
+    expect(captureException).not.toHaveBeenCalled();
+    expect(captureMessage).not.toHaveBeenCalled();
+    expect(console.warn).toHaveBeenCalledWith(
+      'OAuth callback code challenge mismatch.',
+      {
+        area: 'auth',
+        errorType: 'code-challenge-mismatch',
+        flow: 'oauth-callback',
+        extra: expect.objectContaining({
+          errorName: 'AuthApiError',
+          hasSupabaseCodeVerifierCookie: true,
+          locale: 'en',
+        }),
+      },
     );
   });
 });

--- a/apps/web/tests/auth-callback.test.ts
+++ b/apps/web/tests/auth-callback.test.ts
@@ -1,5 +1,5 @@
 import { captureException, captureMessage } from '@sentry/nextjs';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { GET } from '@/app/auth/callback/route';
 import { createClient } from '@/lib/supabase/server';
@@ -34,6 +34,10 @@ describe('OAuth callback route', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   it('handles missing PKCE verifier errors without Sentry telemetry', async () => {

--- a/apps/web/tests/clone-voice.test.ts
+++ b/apps/web/tests/clone-voice.test.ts
@@ -1408,6 +1408,34 @@ describe('Clone Voice API Route', () => {
       expect(json.details).toEqual({ provider: 'replicate' });
     });
 
+    it('returns a typed 503 without Sentry capture for Replicate 5xx failures', async () => {
+      const { captureException } = await import('@sentry/nextjs');
+      mockReplicateRun.mockRejectedValueOnce(
+        new Error(
+          'Request to https://api.replicate.com/v1/predictions failed with status 502 Bad Gateway',
+        ),
+      );
+
+      const formData = createFormDataWithAudio(
+        'こんにちは',
+        createMockAudioFile(),
+        'ja',
+      );
+
+      const request = new Request('http://localhost/api/clone-voice', {
+        method: 'POST',
+        body: formData,
+      });
+
+      const response = await POST(request);
+      const json = await response.json();
+
+      expect(response.status).toBe(503);
+      expect(json.code).toBe('errors.providerUnavailable');
+      expect(json.details).toEqual({ provider: 'replicate' });
+      expect(captureException).not.toHaveBeenCalled();
+    });
+
     it('should handle request abortion gracefully', async () => {
       const controller = new AbortController();
 
@@ -1722,9 +1750,39 @@ describe('Clone Voice API Route', () => {
 
     it('does not log expected fal.ai timeout failures to Sentry when falling back to original audio', async () => {
       const { captureException } = await import('@sentry/nextjs');
-      const timeoutError = new Error('The operation was aborted due to timeout');
+      const timeoutError = new Error(
+        'The operation was aborted due to timeout',
+      );
       timeoutError.name = 'TimeoutError';
       mockFalSubscribe.mockRejectedValueOnce(timeoutError);
+
+      const formData = createFormDataWithAudio(
+        'Hello world',
+        createMockAudioFile(),
+        'en',
+        true,
+      );
+
+      const request = new Request('http://localhost/api/clone-voice', {
+        method: 'POST',
+        body: formData,
+      });
+
+      const response = await POST(request);
+      const json = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(json.url).toContain('files.sexyvoice.ai');
+      expect(captureException).not.toHaveBeenCalled();
+    });
+
+    it('does not log fal.ai enhanced audio download 5xx failures to Sentry', async () => {
+      const { captureException } = await import('@sentry/nextjs');
+      server.use(
+        http.get('https://fal-cdn.com/test-enhanced-audio.wav', () =>
+          HttpResponse.text('provider unavailable', { status: 500 }),
+        ),
+      );
 
       const formData = createFormDataWithAudio(
         'Hello world',

--- a/apps/web/tests/components/call/krisp-noise-filter.test.ts
+++ b/apps/web/tests/components/call/krisp-noise-filter.test.ts
@@ -33,6 +33,12 @@ describe('Krisp noise filter guards', () => {
     expect(isExpectedKrispNoiseFilterError('WASM_OR_WORKER_NOT_READY')).toBe(
       true,
     );
+    expect(
+      isExpectedKrispNoiseFilterError({
+        message: 'Krisp WASM_OR_WORKER_NOT_READY',
+        name: 'DOMException',
+      }),
+    ).toBe(true);
     expect(isExpectedKrispNoiseFilterError(new Error('boom'))).toBe(false);
   });
 

--- a/apps/web/tests/components/call/krisp-noise-filter.test.ts
+++ b/apps/web/tests/components/call/krisp-noise-filter.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  enableKrispNoiseFilterIfReady,
+  isExpectedKrispNoiseFilterError,
+  shouldEnableKrispNoiseFilter,
+} from '@/components/call/krisp-noise-filter';
+
+const liveMicrophonePublication = {
+  track: {
+    mediaStreamTrack: {
+      readyState: 'live',
+    },
+  },
+};
+
+describe('Krisp noise filter guards', () => {
+  it('enables Krisp only when the microphone media track is live', () => {
+    expect(shouldEnableKrispNoiseFilter(liveMicrophonePublication)).toBe(true);
+    expect(
+      shouldEnableKrispNoiseFilter({
+        track: { mediaStreamTrack: { readyState: 'ended' } },
+      }),
+    ).toBe(false);
+    expect(shouldEnableKrispNoiseFilter({ track: null })).toBe(false);
+  });
+
+  it('ignores browser and Krisp readiness errors', () => {
+    const endedTrackError = new Error('Track has ended');
+    endedTrackError.name = 'InvalidAccessError';
+
+    expect(isExpectedKrispNoiseFilterError(endedTrackError)).toBe(true);
+    expect(isExpectedKrispNoiseFilterError('WASM_OR_WORKER_NOT_READY')).toBe(
+      true,
+    );
+    expect(isExpectedKrispNoiseFilterError(new Error('boom'))).toBe(false);
+  });
+
+  it('does not call LiveKit until a live microphone track exists', async () => {
+    const setNoiseFilterEnabled = vi.fn();
+
+    await expect(
+      enableKrispNoiseFilterIfReady({
+        microphonePublication: { track: null },
+        setNoiseFilterEnabled,
+      }),
+    ).resolves.toBe('skipped');
+
+    expect(setNoiseFilterEnabled).not.toHaveBeenCalled();
+  });
+
+  it('catches expected enable failures instead of leaving unhandled rejections', async () => {
+    const setNoiseFilterEnabled = vi
+      .fn()
+      .mockRejectedValue(new Error('Track has ended'));
+    const onUnexpectedError = vi.fn();
+
+    await expect(
+      enableKrispNoiseFilterIfReady({
+        microphonePublication: liveMicrophonePublication,
+        onUnexpectedError,
+        setNoiseFilterEnabled,
+      }),
+    ).resolves.toBe('ignored');
+
+    expect(setNoiseFilterEnabled).toHaveBeenCalledWith(true);
+    expect(onUnexpectedError).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/tests/sentry-client-filters.test.ts
+++ b/apps/web/tests/sentry-client-filters.test.ts
@@ -49,6 +49,27 @@ describe('shouldDropClientSentryEvent', () => {
         },
       }),
     ).toBe(false);
+
+    expect(
+      shouldDropClientSentryEvent({
+        exception: {
+          values: [
+            {
+              type: 'TypeError',
+              value: "Cannot read properties of null (reading 'tagName')",
+              stacktrace: {
+                frames: [
+                  {
+                    filename: 'app:///_next/static/chunks/app/page.js',
+                    function: 'renderTag',
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      }),
+    ).toBe(false);
   });
 
   it('does not drop DOM mutation text without React frame evidence', () => {

--- a/apps/web/tests/sentry-client-filters.test.ts
+++ b/apps/web/tests/sentry-client-filters.test.ts
@@ -73,4 +73,104 @@ describe('shouldDropClientSentryEvent', () => {
       true,
     );
   });
+
+  it('drops PostHog recorder security errors', () => {
+    expect(
+      shouldDropClientSentryEvent({
+        exception: {
+          values: [
+            {
+              type: 'SecurityError',
+              value: "Permission to call 'get parentNode' denied.",
+              stacktrace: {
+                frames: [
+                  {
+                    filename: 'app:///seguimiento/static/posthog-recorder.js',
+                    function: 'parentNode',
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it('drops injected script tagName errors without dropping app tagName errors', () => {
+    expect(
+      shouldDropClientSentryEvent({
+        exception: {
+          values: [
+            {
+              type: 'TypeError',
+              value: "Cannot read properties of null (reading 'tagName')",
+              stacktrace: {
+                frames: [
+                  {
+                    filename: '<anonymous>',
+                    function: 'addEL_hook',
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldDropClientSentryEvent({
+        exception: {
+          values: [
+            {
+              type: 'TypeError',
+              value: "Cannot read properties of null (reading 'tagName')",
+              stacktrace: {
+                frames: [
+                  {
+                    filename: 'apps/web/components/example.tsx',
+                    function: 'renderTag',
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it('drops browser media and opaque event rejections without app frames', () => {
+    expect(
+      shouldDropClientSentryEvent({
+        exception: {
+          values: [
+            {
+              type: 'InvalidAccessError',
+              value: 'Track has ended',
+              stacktrace: {
+                frames: [
+                  { filename: '[native code]', function: 'applyConstraints' },
+                ],
+              },
+            },
+          ],
+        },
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldDropClientSentryEvent({
+        exception: {
+          values: [
+            {
+              type: 'Event',
+              value: 'Event `Event` (type=error) captured as promise rejection',
+            },
+          ],
+        },
+      }),
+    ).toBe(true);
+  });
 });

--- a/apps/web/utils/google-rpc-status.ts
+++ b/apps/web/utils/google-rpc-status.ts
@@ -60,3 +60,18 @@ export function getGoogleApiErrorStatus(
 ): GoogleRpcStatus {
   return error.status ?? mapHttpToGoogleRpcStatus(error.code);
 }
+
+export function isGoogleQuotaError(error: GoogleApiErrorWithStatus): boolean {
+  return getGoogleApiErrorStatus(error) === 'RESOURCE_EXHAUSTED';
+}
+
+export function isGoogleTransientProviderError(
+  error: GoogleApiErrorWithStatus,
+): boolean {
+  const status = getGoogleApiErrorStatus(error);
+  return (
+    status === 'INTERNAL' ||
+    status === 'UNAVAILABLE' ||
+    status === 'DEADLINE_EXCEEDED'
+  );
+}


### PR DESCRIPTION
## Summary
- Hardened the call, Gemini, clone-voice, OAuth callback, and client Sentry paths for the current non-Stripe issue groups.
- Added typed provider quota/unavailable responses, better transient error handling, and broader client-noise filtering.
- Updated API docs to describe the new `provider_quota_exceeded` and `provider_unavailable` error codes.

## Testing
- Focused Vitest coverage passed for the updated call, API, clone-voice, auth callback, audio conversion, and Sentry filter areas.