### PR TITLE
Add FAQ section to call dashboard page

### DIFF
--- a/apps/web/app/[lang]/(dashboard)/dashboard/call/page.tsx
+++ b/apps/web/app/[lang]/(dashboard)/dashboard/call/page.tsx
@@ -1,5 +1,6 @@
 import { getMessages } from 'next-intl/server';
 
+import { CallFaq } from '@/components/call/call-faq';
 import { Chat } from '@/components/call/chat';
 import { ConfigurationForm } from '@/components/call/configuration-form';
 import CreditsSection from '@/components/credits-section';
@@ -13,6 +14,10 @@ export default async function Call(props: {
 }) {
   const { lang } = await props.params;
   const dict = (await getMessages({ locale: lang })) as IntlMessages;
+
+  const callFaq = dict.landing.faq.groups.find(
+    (group) => group.id === 'liveCalling',
+  );
 
   const supabase = await createClient();
 
@@ -64,6 +69,12 @@ export default async function Call(props: {
             <br />
             {dict.call.notice2}
           </p>
+          {callFaq && (
+            <CallFaq
+              questions={callFaq.questions}
+              title={dict.landing.faq.title}
+            />
+          )}
         </div>
       </main>
     </div>

--- a/apps/web/app/[lang]/(dashboard)/dashboard/call/page.tsx
+++ b/apps/web/app/[lang]/(dashboard)/dashboard/call/page.tsx
@@ -15,7 +15,7 @@ export default async function Call(props: {
   const { lang } = await props.params;
   const dict = (await getMessages({ locale: lang })) as IntlMessages;
 
-  const callFaq = dict.landing.faq.groups.find(
+  const callFaq = dict.landing?.faq?.groups?.find(
     (group) => group.id === 'liveCalling',
   );
 

--- a/apps/web/app/[lang]/(dashboard)/dashboard/call/page.tsx
+++ b/apps/web/app/[lang]/(dashboard)/dashboard/call/page.tsx
@@ -72,7 +72,7 @@ export default async function Call(props: {
           {callFaq && (
             <CallFaq
               questions={callFaq.questions}
-              title={dict.landing.faq.title}
+              title={callFaq.category}
             />
           )}
         </div>

--- a/apps/web/components/call/call-faq.tsx
+++ b/apps/web/components/call/call-faq.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { useConnectionState } from '@livekit/components-react';
+import { ConnectionState } from 'livekit-client';
+
+import { CREDITS_PER_MINUTE } from '@/lib/supabase/constants';
+
+interface CallFaqQuestion {
+  question: string;
+  answer: string;
+}
+
+export function CallFaq({
+  title,
+  questions,
+}: {
+  title: string;
+  questions: CallFaqQuestion[];
+}) {
+  const connectionState = useConnectionState();
+
+  // Hide the FAQ while a call is connecting or in progress.
+  if (connectionState !== ConnectionState.Disconnected) {
+    return null;
+  }
+
+  return (
+    <section
+      className="mx-auto w-full max-w-2xl px-4 pb-8"
+      data-testid="call-faq"
+    >
+      <h2 className="mb-4 text-center font-semibold text-foreground text-lg">
+        {title}
+      </h2>
+      <dl className="flex flex-col gap-3">
+        {questions.map((faq, i) => (
+          <div
+            className="rounded-md border border-gray-500 bg-accent px-5 py-4"
+            key={i}
+          >
+            <dt className="font-medium text-foreground text-sm">
+              {faq.question}
+            </dt>
+            <dd className="mt-1 whitespace-pre-wrap text-muted-foreground text-sm">
+              {faq.answer.replace('{count}', String(CREDITS_PER_MINUTE))}
+            </dd>
+          </div>
+        ))}
+      </dl>
+    </section>
+  );
+}

--- a/apps/web/components/call/call-faq.tsx
+++ b/apps/web/components/call/call-faq.tsx
@@ -35,14 +35,14 @@ export function CallFaq({
       <dl className="flex flex-col gap-3">
         {questions.map((faq, i) => (
           <div
-            className="rounded-md border border-gray-500 bg-accent px-5 py-4"
+            className="rounded-md border border-border bg-accent px-5 py-4"
             key={i}
           >
             <dt className="font-medium text-foreground text-sm">
               {faq.question}
             </dt>
             <dd className="mt-1 whitespace-pre-wrap text-muted-foreground text-sm">
-              {faq.answer.replace('{count}', String(CREDITS_PER_MINUTE))}
+              {faq.answer.replaceAll('{count}', String(CREDITS_PER_MINUTE))}
             </dd>
           </div>
         ))}

--- a/apps/web/components/call/call-faq.tsx
+++ b/apps/web/components/call/call-faq.tsx
@@ -3,6 +3,12 @@
 import { useConnectionState } from '@livekit/components-react';
 import { ConnectionState } from 'livekit-client';
 
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from '@/components/ui/accordion';
 import { CREDITS_PER_MINUTE } from '@/lib/supabase/constants';
 
 interface CallFaqQuestion {
@@ -32,21 +38,27 @@ export function CallFaq({
       <h2 className="mb-4 text-center font-semibold text-foreground text-lg">
         {title}
       </h2>
-      <dl className="flex flex-col gap-3">
+      <Accordion
+        className="w-full rounded-md border border-border"
+        collapsible
+        defaultValue="item-0"
+        type="single"
+      >
         {questions.map((faq, i) => (
-          <div
-            className="rounded-md border border-border bg-accent px-5 py-4"
+          <AccordionItem
+            className="border-border px-5"
             key={i}
+            value={`item-${i}`}
           >
-            <dt className="font-medium text-foreground text-sm">
+            <AccordionTrigger className="text-foreground">
               {faq.question}
-            </dt>
-            <dd className="mt-1 whitespace-pre-wrap text-muted-foreground text-sm">
+            </AccordionTrigger>
+            <AccordionContent className="whitespace-pre-wrap text-muted-foreground">
               {faq.answer.replaceAll('{count}', String(CREDITS_PER_MINUTE))}
-            </dd>
-          </div>
+            </AccordionContent>
+          </AccordionItem>
         ))}
-      </dl>
+      </Accordion>
     </section>
   );
 }

--- a/apps/web/e2e/call-dashboard.spec.ts
+++ b/apps/web/e2e/call-dashboard.spec.ts
@@ -99,6 +99,10 @@ test.describe('Call Dashboard - Authenticated User', () => {
     await callPage.expectNoticeTextVisible();
   });
 
+  test('should display the FAQ section when disconnected', async () => {
+    await callPage.expectCallFaqVisible();
+  });
+
   test('should display configuration form with form element', async () => {
     await callPage.expectFormPresent();
   });

--- a/apps/web/e2e/pages/call.page.ts
+++ b/apps/web/e2e/pages/call.page.ts
@@ -36,6 +36,9 @@ export class CallPage {
   // Notice text
   readonly noticeText: Locator;
 
+  // FAQ section (shown only when no call is in progress)
+  readonly callFaq: Locator;
+
   constructor(page: Page) {
     this.page = page;
 
@@ -62,6 +65,9 @@ export class CallPage {
 
     // Notice text at the bottom of the page
     this.noticeText = page.getByTestId('call-notice-text');
+
+    // FAQ section — only rendered while disconnected
+    this.callFaq = page.getByTestId('call-faq');
   }
 
   /**
@@ -162,6 +168,13 @@ export class CallPage {
    */
   async expectNoticeTextVisible() {
     await expect(this.noticeText).toBeVisible();
+  }
+
+  /**
+   * Verify the FAQ section is visible (only when no call is in progress)
+   */
+  async expectCallFaqVisible() {
+    await expect(this.callFaq).toBeVisible();
   }
 
   /**


### PR DESCRIPTION
## Summary

Added a reusable `CallFaq` component that displays frequently asked questions on the call dashboard. The FAQ section is only visible when no call is in progress, and dynamically inserts credit cost information from configuration constants.

## Changes

- Created new `CallFaq` component (`apps/web/components/call/call-faq.tsx`) that displays FAQ items with dynamic credit cost substitution
- Integrated `CallFaq` into the call dashboard page to show live calling FAQs from internationalization messages
- Component hides automatically when a call is connecting or in progress using LiveKit connection state

## How to test

1. Navigate to the call dashboard page
2. Verify the FAQ section displays with the title and questions from the `landing.faq.groups.liveCalling` translation
3. Confirm the `{count}` placeholder in answers is replaced with the `CREDITS_PER_MINUTE` constant value
4. Initiate a call and verify the FAQ section disappears while the call is active
5. End the call and verify the FAQ section reappears

## Scope

- [x] Frontend

## Checklist

- [x] I self-reviewed this PR
- [x] I ran `pnpm run fixall`
- [x] I ran `pnpm run type-check`

## Notes for reviewers

The component relies on the `landing.faq.groups` translation structure having a group with `id === 'liveCalling'`. Ensure this translation key exists in all supported languages before merging.

https://claude.ai/code/session_01Kxqe2UbYj3xt4X2CXjz3jm