### PR TITLE
fix(history): make audio download work for cross-origin R2 files

### DIFF
--- a/apps/web/app/[lang]/(dashboard)/dashboard/history/columns.tsx
+++ b/apps/web/app/[lang]/(dashboard)/dashboard/history/columns.tsx
@@ -16,20 +16,24 @@ import {
 import { downloadUrl } from '@/lib/download';
 import type { AudioFileAndVoicesRes } from '@/lib/supabase/queries.client';
 import { formatDate } from '@/lib/utils';
+import type langDict from '@/messages/en.json';
 import { DeleteButton } from './delete-button';
 
-const downloadFile = async (url: string) => {
+type HistoryDict = (typeof langDict)['history'];
+
+const downloadFile = async (url: string, errorMessage: string) => {
+  if (!url) return;
+
   const anchorElement = document.createElement('a');
   anchorElement.href = url;
   const filename = url.split('/').pop()?.split('?')[0];
   anchorElement.download = filename || 'generated_audio.mp3';
   anchorElement.target = '_blank';
-  if (!url) return;
 
   try {
     await downloadUrl(url, anchorElement);
   } catch {
-    toast.error('errorCloning'); // TODO: translate - passing
+    toast.error(errorMessage);
   }
 };
 
@@ -64,8 +68,10 @@ function getUsageData(value: unknown): AudioUsageData | null {
 
 export function createColumns({
   showApiColumns,
+  dict,
 }: {
   showApiColumns: boolean;
+  dict: HistoryDict;
 }): ColumnDef<AudioFileAndVoicesRes>[] {
   const baseColumns: ColumnDef<AudioFileAndVoicesRes>[] = [
     {
@@ -139,7 +145,7 @@ export function createColumns({
       cell: ({ row }) => (
         <Button
           className="ml-2"
-          onClick={() => downloadFile(row.original.url)}
+          onClick={() => downloadFile(row.original.url, dict.downloadError)}
           size="icon"
           title="Download"
           variant="outline"

--- a/apps/web/app/[lang]/(dashboard)/dashboard/history/data-table.tsx
+++ b/apps/web/app/[lang]/(dashboard)/dashboard/history/data-table.tsx
@@ -56,7 +56,7 @@ export function DataTable({ userId, dict, showApiColumns }: DataTableProps) {
     queryFn: () => getMyAudioFiles(supabase, userId),
     enabled: !!userId,
   });
-  const columns = createColumns({ showApiColumns });
+  const columns = createColumns({ showApiColumns, dict });
 
   const table = useReactTable<AudioFileAndVoicesRes>({
     data: (data as AudioFileAndVoicesRes[]) ?? [],

--- a/apps/web/app/api/download/route.ts
+++ b/apps/web/app/api/download/route.ts
@@ -1,14 +1,6 @@
 import { type NextRequest, NextResponse } from 'next/server';
 
-// Hosts we are willing to proxy downloads from. The audio files live on
-// Cloudflare R2 (served from files.sexyvoice.ai) which does not return CORS
-// headers, so a client-side `fetch()` of those URLs is blocked by the browser.
-// Proxying the request through this same-origin route avoids the CORS issue
-// while keeping us from becoming an open proxy for arbitrary URLs (SSRF).
-const ALLOWED_HOSTS = new Set([
-  'files.sexyvoice.ai',
-  'uxjubqdyhv4aowsi.public.blob.vercel-storage.com',
-]);
+import { getFileFromR2, R2_PUBLIC_HOST } from '@/lib/storage/upload';
 
 const getFilename = (pathname: string) => {
   const last = pathname.split('/').pop() || '';
@@ -36,14 +28,33 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: 'Invalid URL' }, { status: 400 });
   }
 
-  if (target.protocol !== 'https:' || !ALLOWED_HOSTS.has(target.hostname)) {
+  // Only proxy files we know live in our own R2 bucket (avoids SSRF).
+  if (target.protocol !== 'https:' || target.host !== R2_PUBLIC_HOST) {
     return NextResponse.json({ error: 'URL not allowed' }, { status: 400 });
   }
 
-  let upstream: Response;
+  // The public URL is `${R2_PUBLIC_URL}/${key}`, so the object key is the
+  // pathname without its leading slash.
+  let key = target.pathname.replace(/^\/+/, '');
   try {
-    upstream = await fetch(target.toString());
+    key = decodeURIComponent(key);
+  } catch {
+    // keep the raw key if it isn't valid percent-encoding
+  }
+
+  if (!key) {
+    return NextResponse.json({ error: 'Invalid URL' }, { status: 400 });
+  }
+
+  let object: Awaited<ReturnType<typeof getFileFromR2>>;
+  try {
+    object = await getFileFromR2(key);
   } catch (error) {
+    const status = (error as { $metadata?: { httpStatusCode?: number } })
+      .$metadata?.httpStatusCode;
+    if (status === 404) {
+      return NextResponse.json({ error: 'File not found' }, { status: 404 });
+    }
     console.error('Failed to fetch file for download', error);
     return NextResponse.json(
       { error: 'Failed to fetch file' },
@@ -51,29 +62,26 @@ export async function GET(request: NextRequest) {
     );
   }
 
-  if (!(upstream.ok && upstream.body)) {
-    return NextResponse.json(
-      { error: 'File not found' },
-      { status: upstream.status === 404 ? 404 : 502 },
-    );
+  if (!object.Body) {
+    return NextResponse.json({ error: 'File not found' }, { status: 404 });
   }
 
   const filename = getFilename(target.pathname);
-  const contentType =
-    upstream.headers.get('content-type') || 'application/octet-stream';
+  const contentType = object.ContentType || 'application/octet-stream';
 
   const headers = new Headers({
     'Content-Type': contentType,
-    // Use the RFC 5987 encoded form so any characters in the filename are
-    // safely percent-encoded and cannot break the header value.
+    // RFC 5987 encoded form keeps any characters in the filename safe.
     'Content-Disposition': `attachment; filename*=UTF-8''${encodeURIComponent(filename)}`,
     'Cache-Control': 'private, max-age=0, no-store',
   });
 
-  const contentLength = upstream.headers.get('content-length');
-  if (contentLength) {
-    headers.set('Content-Length', contentLength);
+  if (typeof object.ContentLength === 'number') {
+    headers.set('Content-Length', String(object.ContentLength));
   }
 
-  return new NextResponse(upstream.body, { status: 200, headers });
+  return new NextResponse(object.Body.transformToWebStream(), {
+    status: 200,
+    headers,
+  });
 }

--- a/apps/web/app/api/download/route.ts
+++ b/apps/web/app/api/download/route.ts
@@ -1,0 +1,79 @@
+import { type NextRequest, NextResponse } from 'next/server';
+
+// Hosts we are willing to proxy downloads from. The audio files live on
+// Cloudflare R2 (served from files.sexyvoice.ai) which does not return CORS
+// headers, so a client-side `fetch()` of those URLs is blocked by the browser.
+// Proxying the request through this same-origin route avoids the CORS issue
+// while keeping us from becoming an open proxy for arbitrary URLs (SSRF).
+const ALLOWED_HOSTS = new Set([
+  'files.sexyvoice.ai',
+  'uxjubqdyhv4aowsi.public.blob.vercel-storage.com',
+]);
+
+const getFilename = (pathname: string) => {
+  const last = pathname.split('/').pop() || '';
+  try {
+    return decodeURIComponent(last) || 'generated_audio.mp3';
+  } catch {
+    return last || 'generated_audio.mp3';
+  }
+};
+
+export async function GET(request: NextRequest) {
+  const rawUrl = request.nextUrl.searchParams.get('url');
+
+  if (!rawUrl) {
+    return NextResponse.json(
+      { error: 'Missing "url" query parameter' },
+      { status: 400 },
+    );
+  }
+
+  let target: URL;
+  try {
+    target = new URL(rawUrl);
+  } catch {
+    return NextResponse.json({ error: 'Invalid URL' }, { status: 400 });
+  }
+
+  if (target.protocol !== 'https:' || !ALLOWED_HOSTS.has(target.hostname)) {
+    return NextResponse.json({ error: 'URL not allowed' }, { status: 400 });
+  }
+
+  let upstream: Response;
+  try {
+    upstream = await fetch(target.toString());
+  } catch (error) {
+    console.error('Failed to fetch file for download', error);
+    return NextResponse.json(
+      { error: 'Failed to fetch file' },
+      { status: 502 },
+    );
+  }
+
+  if (!(upstream.ok && upstream.body)) {
+    return NextResponse.json(
+      { error: 'File not found' },
+      { status: upstream.status === 404 ? 404 : 502 },
+    );
+  }
+
+  const filename = getFilename(target.pathname);
+  const contentType =
+    upstream.headers.get('content-type') || 'application/octet-stream';
+
+  const headers = new Headers({
+    'Content-Type': contentType,
+    // Use the RFC 5987 encoded form so any characters in the filename are
+    // safely percent-encoded and cannot break the header value.
+    'Content-Disposition': `attachment; filename*=UTF-8''${encodeURIComponent(filename)}`,
+    'Cache-Control': 'private, max-age=0, no-store',
+  });
+
+  const contentLength = upstream.headers.get('content-length');
+  if (contentLength) {
+    headers.set('Content-Length', contentLength);
+  }
+
+  return new NextResponse(upstream.body, { status: 200, headers });
+}

--- a/apps/web/lib/download.ts
+++ b/apps/web/lib/download.ts
@@ -1,17 +1,41 @@
+// Cross-origin files (e.g. the audio stored on Cloudflare R2 at
+// files.sexyvoice.ai) cannot be fetched directly from the browser because the
+// storage origin does not send CORS headers. Routing those requests through
+// our same-origin `/api/download` proxy avoids the CORS failure while still
+// forcing a real "Save As" download with the correct filename.
+const toFetchableUrl = (url: string) => {
+  try {
+    const parsed = new URL(url, window.location.href);
+    const isHttp = parsed.protocol === 'http:' || parsed.protocol === 'https:';
+    if (isHttp && parsed.origin !== window.location.origin) {
+      return `/api/download?url=${encodeURIComponent(parsed.toString())}`;
+    }
+  } catch {
+    // Not an absolute URL (e.g. a blob: or object URL) — fetch it directly.
+  }
+  return url;
+};
+
 export const downloadUrl = async (
   url: string,
   anchorElement: HTMLAnchorElement,
 ) => {
   try {
     // Create a Blob from the audio source
-    const response = await fetch(url);
+    const response = await fetch(toFetchableUrl(url));
+
+    if (!response.ok) {
+      throw new Error(`Failed to download audio: ${response.status}`);
+    }
+
     const audioBlob = await response.blob();
 
     // Create a temporary object URL for the Blob
     const objectUrl = window.URL.createObjectURL(audioBlob);
 
     const filename =
-      url.split('/').pop() || `generated_audio_${Date.now()}.mp3`;
+      url.split('/').pop()?.split('?')[0] ||
+      `generated_audio_${Date.now()}.mp3`;
     anchorElement.href = objectUrl;
     anchorElement.download = filename;
 

--- a/apps/web/lib/storage/upload.ts
+++ b/apps/web/lib/storage/upload.ts
@@ -1,5 +1,6 @@
 import {
   DeleteObjectCommand,
+  GetObjectCommand,
   PutObjectCommand,
   type PutObjectCommandInput,
   S3Client,
@@ -48,6 +49,23 @@ export const uploadFileToR2 = async (
 
   await s3Client.send(new PutObjectCommand(params));
   return `${publicBaseUrl}/${filename}`;
+};
+
+export const R2_PUBLIC_HOST = new URL(DEFAULT_PUBLIC_URL).host;
+
+/**
+ * Fetch an object directly from R2 via the S3 API (authenticated).
+ *
+ * The public Cloudflare URL (files.sexyvoice.ai) cannot be fetched
+ * server-side because Cloudflare's bot protection blocks datacenter requests,
+ * and it cannot be fetched client-side because the origin sends no CORS
+ * headers. Reading straight from the bucket sidesteps both.
+ */
+export const getFileFromR2 = (
+  key: string,
+  bucketName: string = R2_BUCKET_NAME,
+) => {
+  return s3Client.send(new GetObjectCommand({ Bucket: bucketName, Key: key }));
 };
 
 export const deleteFileFromR2 = async (filename: string) => {

--- a/apps/web/messages/da.json
+++ b/apps/web/messages/da.json
@@ -768,6 +768,7 @@
   "history": {
     "header": "Genereringshistorik",
     "empty": "Ingen historik endnu",
+    "downloadError": "Kunne ikke downloade lyd",
     "ui": {
       "filterText": "Filtrer tekst...",
       "customizeColumns": "Tilpas kolonner",

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -768,6 +768,7 @@
   "history": {
     "header": "Generierungsverlauf",
     "empty": "Noch kein Verlauf",
+    "downloadError": "Audio konnte nicht heruntergeladen werden",
     "ui": {
       "filterText": "Text filtern...",
       "customizeColumns": "Spalten anpassen",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -768,6 +768,7 @@
   "history": {
     "header": "Generation History",
     "empty": "No history yet",
+    "downloadError": "Failed to download audio",
     "ui": {
       "filterText": "Filter text...",
       "customizeColumns": "Customize Columns",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -768,6 +768,7 @@
   "history": {
     "header": "Historial de Generación",
     "empty": "Sin historial aún",
+    "downloadError": "Error al descargar el audio",
     "ui": {
       "filterText": "Filtrar texto...",
       "customizeColumns": "Personalizar Columnas",

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -768,6 +768,7 @@
   "history": {
     "header": "Historique des générations",
     "empty": "Aucun historique pour le moment",
+    "downloadError": "Échec du téléchargement de l'audio",
     "ui": {
       "filterText": "Filtrer le texte...",
       "customizeColumns": "Personnaliser les colonnes",

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -768,6 +768,7 @@
   "history": {
     "header": "Cronologia generazioni",
     "empty": "Nessuna cronologia ancora",
+    "downloadError": "Impossibile scaricare l'audio",
     "ui": {
       "filterText": "Filtra testo...",
       "customizeColumns": "Personalizza colonne",


### PR DESCRIPTION
The download button failed instantly with a misleading "errorCloning"
toast while the play button worked. Play uses `new Audio(url)`, which is
not subject to CORS, whereas the download used a client-side `fetch()` of
the R2 file (files.sexyvoice.ai). R2's custom domain doesn't send CORS
headers, so the fetch was blocked and the catch surfaced the wrong,
untranslated literal string.

- Add a same-origin `/api/download` proxy route that streams the file
  server-side (no CORS) with `Content-Disposition: attachment`, host-
  restricted to avoid SSRF.
- Route cross-origin downloads through the proxy in `downloadUrl`, and
  treat non-OK responses as failures. This also fixes clone and generator
  downloads.
- Replace the hardcoded `errorCloning` toast with a proper, translated
  `history.downloadError` message in all locales.