### PR TITLE
sentry fixes june 9

### DIFF
--- a/apps/web/app/[lang]/(dashboard)/dashboard/clone/new.client.tsx
+++ b/apps/web/app/[lang]/(dashboard)/dashboard/clone/new.client.tsx
@@ -45,6 +45,10 @@ import {
   CLONE_TEXT_MAX_LENGTH_VOXTRAL_PAID,
   VOXTRAL_SUPPORTED_LOCALE_CODES,
 } from '@/lib/clone/constants';
+import {
+  createMicrophoneReferenceAudioFile,
+  isWebmAudioBlob,
+} from '@/lib/clone/microphone-reference-audio';
 import { getCloneTextMaxLength } from '@/lib/clone/text-limits';
 import { downloadUrl } from '@/lib/download';
 import { getTranslatedLanguages } from '@/lib/i18n/get-translated-languages';
@@ -414,42 +418,38 @@ function NewVoiceClientInner({
     try {
       abortController.current = new AbortController();
 
-      // Use micBlob if available, otherwise use file
       let audioToProcess = file;
       if (micBlob && !file) {
-        // Convert WebM to WAV for non-English locales
-        // Check locale at GENERATION time, not recording time
-        if (micBlob.type.includes('webm') && selectedLocale.code !== 'en') {
+        const shouldConvertMicAudio = isWebmAudioBlob(micBlob);
+
+        if (shouldConvertMicAudio) {
           setConvertingMicAudio(true);
-          try {
-            const wavBlob = await convertWithFFmpeg(micBlob, 'wav');
-            audioToProcess = new File([wavBlob], 'microphone-recording.wav', {
-              type: wavBlob.type,
-            });
-          } catch (convertError) {
-            console.error('WebM to WAV conversion error:', convertError);
-            // TODO send logs to Sentry
-            setErrorMessage(
-              convertError instanceof Error
-                ? formatCloneMessage(dict.audioConversionFailedWithMessage, {
-                    ERROR: convertError.message,
-                  })
-                : dict.audioConversionFailed,
-            );
-            setStatus('error');
-            setConvertingMicAudio(false);
-            return;
-          } finally {
+        }
+
+        try {
+          if (shouldConvertMicAudio) {
+            await ensureLoaded();
+          }
+
+          audioToProcess = await createMicrophoneReferenceAudioFile(
+            micBlob,
+            convertWithFFmpeg,
+          );
+        } catch (convertError) {
+          console.error('WebM to WAV conversion error:', convertError);
+          setErrorMessage(
+            convertError instanceof Error
+              ? formatCloneMessage(dict.audioConversionFailedWithMessage, {
+                  ERROR: convertError.message,
+                })
+              : dict.audioConversionFailed,
+          );
+          setStatus('error');
+          return;
+        } finally {
+          if (shouldConvertMicAudio) {
             setConvertingMicAudio(false);
           }
-        } else {
-          // For English or non-WebM formats, use blob directly
-          const mimeType = micBlob.type || 'audio/wav';
-          const isWebM = mimeType.includes('webm');
-          const filename = isWebM
-            ? 'microphone-recording.webm'
-            : 'microphone-recording.wav';
-          audioToProcess = new File([micBlob], filename, { type: mimeType });
         }
       }
 
@@ -532,6 +532,7 @@ function NewVoiceClientInner({
     clearErrors,
     convertWithFFmpeg,
     dict,
+    ensureLoaded,
     file,
     getCloneErrorMessage,
     micBlob,

--- a/apps/web/app/api/clone-voice/route.ts
+++ b/apps/web/app/api/clone-voice/route.ts
@@ -444,6 +444,10 @@ function validateFileSize(file: File): void {
   }
 }
 
+function isWebmMimeType(mimeType: string): boolean {
+  return mimeType === 'audio/webm' || mimeType === 'video/webm';
+}
+
 function validateAudioDuration(
   duration: number | null,
   provider: CloneProvider,
@@ -658,6 +662,26 @@ async function processAudioFile(
 
   // Convert to WAV for providers that need normalized reference audio
   if (shouldNormalizeToWav && needsConversion(normalizedMimeType)) {
+    if (isWebmMimeType(normalizedMimeType)) {
+      logger.info('Rejected WebM reference audio before server conversion', {
+        user: { id: userId },
+        extra: {
+          normalizedMimeType,
+          isMicAudio,
+          locale,
+          filename: file.name,
+          bufferSize: buffer.length,
+        },
+      });
+
+      throw createRouteError(
+        'WebM audio must be converted to WAV on the client before uploading. Please try recording again.',
+        400,
+        'errors.audioConversionRequiredWebm',
+        { mimeType: normalizedMimeType },
+      );
+    }
+
     if (!(isMicAudio || isConversionSupported(normalizedMimeType, file.name))) {
       throw createRouteError(
         'Unsupported audio format for voice cloning. Please use MP3, OGG/OPUS, WEBM, or WAV.',
@@ -724,20 +748,14 @@ async function processAudioFile(
         });
       }
 
-      const errorMsg =
-        normalizedMimeType === 'audio/webm' ||
-        normalizedMimeType === 'video/webm'
-          ? 'WebM audio must be converted to WAV on the client before uploading. Please try recording again.'
-          : 'Failed to convert audio format to WAV. Uploaded file must be MP3, OGG, Opus, or WAV';
-      const errorCode =
-        normalizedMimeType === 'audio/webm' ||
-        normalizedMimeType === 'video/webm'
-          ? 'errors.audioConversionRequiredWebm'
-          : 'errors.audioConversionFailed';
-
-      throw createRouteError(errorMsg, 400, errorCode, {
-        mimeType: normalizedMimeType,
-      });
+      throw createRouteError(
+        'Failed to convert audio format to WAV. Uploaded file must be MP3, OGG, Opus, or WAV',
+        400,
+        'errors.audioConversionFailed',
+        {
+          mimeType: normalizedMimeType,
+        },
+      );
     }
   }
 

--- a/apps/web/app/api/clone-voice/route.ts
+++ b/apps/web/app/api/clone-voice/route.ts
@@ -675,7 +675,7 @@ async function processAudioFile(
       });
 
       throw createRouteError(
-        'WebM audio must be converted to WAV on the client before uploading. Please try recording again.',
+        'WebM audio must be converted to WAV on the client before uploading. Please record again or upload a different audio format (MP3, OGG, Opus, or WAV).',
         400,
         'errors.audioConversionRequiredWebm',
         { mimeType: normalizedMimeType },

--- a/apps/web/app/auth/callback/route.ts
+++ b/apps/web/app/auth/callback/route.ts
@@ -8,6 +8,7 @@ import { OAUTH_CALLBACK_COOKIE_NAME } from '@/lib/supabase/constants';
 import {
   createOauthCallbackMarkerValue,
   OAUTH_CALLBACK_COOKIE_MAX_AGE_SECONDS,
+  verifyOauthCallbackMarkerValue,
 } from '@/lib/supabase/oauth-callback-marker';
 import { createClient } from '@/lib/supabase/server';
 import { routing } from '@/src/i18n/routing';
@@ -64,6 +65,20 @@ const getErrorMessage = (error: unknown) => {
 
   return String(error);
 };
+
+const parseCookieHeader = (cookieHeader: string) =>
+  cookieHeader
+    .split(';')
+    .map((cookie) => {
+      const [rawName, ...rawValueParts] = cookie.split('=');
+      const name = rawName?.trim();
+      const value = rawValueParts.join('=').trim();
+
+      return name ? { name, value } : null;
+    })
+    .filter((cookie): cookie is { name: string; value: string } =>
+      Boolean(cookie),
+    );
 
 const isPkceCodeVerifierMissingError = (error: unknown) => {
   const errorName = getErrorStringProperty(error, 'name');
@@ -131,14 +146,15 @@ function getKnownOauthCallbackFailure(error: unknown): {
 
 const getOauthCallbackCookieContext = (request: Request) => {
   const cookieHeader = request.headers.get('cookie') ?? '';
-  const cookieNames = cookieHeader
-    .split(';')
-    .map((cookie) => cookie.split('=')[0]?.trim())
-    .filter((name): name is string => Boolean(name));
+  const cookies = parseCookieHeader(cookieHeader);
+  const cookieNames = cookies.map(({ name }) => name);
   const supabaseCookieNames = cookieNames.filter((name) => {
     const lowerName = name.toLowerCase();
     return lowerName.startsWith('sb-') || lowerName.includes('supabase');
   });
+  const oauthCallbackMarkerCookie = cookies.find(
+    ({ name }) => name === OAUTH_CALLBACK_COOKIE_NAME,
+  );
 
   return {
     hasCookieHeader: Boolean(cookieHeader),
@@ -153,7 +169,24 @@ const getOauthCallbackCookieContext = (request: Request) => {
     hasOauthCallbackMarkerCookie: cookieNames.includes(
       OAUTH_CALLBACK_COOKIE_NAME,
     ),
+    hasValidOauthCallbackMarkerCookie: verifyOauthCallbackMarkerValue(
+      oauthCallbackMarkerCookie?.value,
+    ),
   };
+};
+
+const clearOauthCallbackMarkerCookie = (response: NextResponse) => {
+  response.cookies.set({
+    name: OAUTH_CALLBACK_COOKIE_NAME,
+    value: '',
+    httpOnly: true,
+    maxAge: 0,
+    path: '/',
+    sameSite: 'lax',
+    secure: process.env.NODE_ENV === 'production',
+  });
+
+  return response;
 };
 
 const createOauthRedirectResponse = (url: string) => {
@@ -175,6 +208,9 @@ const createOauthRedirectResponse = (url: string) => {
   return response;
 };
 
+const createOauthFailureRedirectResponse = (url: string) =>
+  clearOauthCallbackMarkerCookie(NextResponse.redirect(url));
+
 export async function GET(request: Request) {
   // The `/auth/callback` route is required for the server-side auth flow implemented
   // by the SSR package. It exchanges an auth code for the user's session.
@@ -187,32 +223,48 @@ export async function GET(request: Request) {
   const loginPath = `/${locale}/login`;
   const oauthCodeContext = getOauthCodeFingerprint(code);
   const oauthCookieContext = getOauthCallbackCookieContext(request);
+  const createSafePostAuthRedirectResponse = () =>
+    createOauthRedirectResponse(
+      isSafeRedirectPath(redirectTo)
+        ? `${origin}${redirectTo}`
+        : `${origin}/${routing.defaultLocale}/dashboard`,
+    );
   const reportKnownOauthCallbackFailure = (
     message: string,
     errorType: string,
     error: unknown,
   ) => {
-    console.warn(message, {
-      area: 'auth',
-      errorType,
-      flow: 'oauth-callback',
-      extra: {
-        redirectTo,
-        locale,
-        ...oauthCodeContext,
-        ...oauthCookieContext,
-        errorCode: getErrorStringProperty(error, 'code') || null,
-        errorMessage: getErrorMessage(error),
-        errorName: getErrorStringProperty(error, 'name') || null,
-      },
-    });
+    if (process.env.NODE_ENV !== 'production') {
+      console.warn(message, {
+        area: 'auth',
+        errorType,
+        flow: 'oauth-callback',
+        extra: {
+          redirectTo,
+          locale,
+          ...oauthCodeContext,
+          ...oauthCookieContext,
+          errorCode: getErrorStringProperty(error, 'code') || null,
+          errorMessage: getErrorMessage(error),
+          errorName: getErrorStringProperty(error, 'name') || null,
+        },
+      });
+    }
 
-    return NextResponse.redirect(`${origin}${loginPath}`);
+    return createOauthFailureRedirectResponse(`${origin}${loginPath}`);
   };
   try {
     if (!code) {
-      return NextResponse.redirect(`${origin}${loginPath}`);
+      return createOauthFailureRedirectResponse(`${origin}${loginPath}`);
     }
+
+    if (
+      oauthCookieContext.hasValidOauthCallbackMarkerCookie &&
+      !oauthCookieContext.hasSupabaseCodeVerifierCookie
+    ) {
+      return createSafePostAuthRedirectResponse();
+    }
+
     const supabase = await createClient();
     const {
       data: { user },
@@ -243,7 +295,7 @@ export async function GET(request: Request) {
         },
       });
 
-      return NextResponse.redirect(`${origin}${loginPath}`);
+      return createOauthFailureRedirectResponse(`${origin}${loginPath}`);
     }
 
     const email = user?.email;
@@ -261,7 +313,7 @@ export async function GET(request: Request) {
         },
       });
 
-      return NextResponse.redirect(`${origin}${loginPath}`);
+      return createOauthFailureRedirectResponse(`${origin}${loginPath}`);
     }
 
     // Add Stripe customer creation
@@ -322,6 +374,6 @@ export async function GET(request: Request) {
       },
     });
 
-    return NextResponse.redirect(`${origin}${loginPath}`);
+    return createOauthFailureRedirectResponse(`${origin}${loginPath}`);
   }
 }

--- a/apps/web/app/auth/callback/route.ts
+++ b/apps/web/app/auth/callback/route.ts
@@ -258,6 +258,13 @@ export async function GET(request: Request) {
       return createOauthFailureRedirectResponse(`${origin}${loginPath}`);
     }
 
+    // Short-circuit a replayed/refreshed callback: the HMAC-signed marker cookie
+    // (60s TTL) proves we already exchanged the one-time `code` successfully, while
+    // the missing code-verifier cookie confirms the PKCE flow is no longer active.
+    // Invariant: the Supabase auth-token cookie written by that first exchange is
+    // still present, so downstream middleware reuses the existing session. If that
+    // cookie was somehow cleared while the marker survived, the dashboard simply
+    // redirects back to login — safe either way.
     if (
       oauthCookieContext.hasValidOauthCallbackMarkerCookie &&
       !oauthCookieContext.hasSupabaseCodeVerifierCookie

--- a/apps/web/lib/clone/microphone-reference-audio.ts
+++ b/apps/web/lib/clone/microphone-reference-audio.ts
@@ -1,0 +1,24 @@
+'use client';
+
+type AudioConverter = (blob: Blob, format: 'wav') => Promise<Blob>;
+
+export function isWebmAudioBlob(blob: Blob): boolean {
+  return blob.type.toLowerCase().includes('webm');
+}
+
+export async function createMicrophoneReferenceAudioFile(
+  micBlob: Blob,
+  convert: AudioConverter,
+): Promise<File> {
+  if (isWebmAudioBlob(micBlob)) {
+    const wavBlob = await convert(micBlob, 'wav');
+    return new File([wavBlob], 'microphone-recording.wav', {
+      type: wavBlob.type || 'audio/wav',
+    });
+  }
+
+  const mimeType = micBlob.type || 'audio/wav';
+  return new File([micBlob], 'microphone-recording.wav', {
+    type: mimeType,
+  });
+}

--- a/apps/web/lib/clone/microphone-reference-audio.ts
+++ b/apps/web/lib/clone/microphone-reference-audio.ts
@@ -6,6 +6,19 @@ export function isWebmAudioBlob(blob: Blob): boolean {
   return blob.type.toLowerCase().includes('webm');
 }
 
+// Keep the file extension aligned with the blob's MIME type so name and type
+// don't disagree (e.g. avoid `microphone-recording.wav` with `type: audio/ogg`).
+function extensionForMimeType(mimeType: string): string {
+  const normalized = mimeType.toLowerCase();
+  if (normalized.includes('ogg') || normalized.includes('opus')) {
+    return 'ogg';
+  }
+  if (normalized.includes('mpeg') || normalized.includes('mp3')) {
+    return 'mp3';
+  }
+  return 'wav';
+}
+
 export async function createMicrophoneReferenceAudioFile(
   micBlob: Blob,
   convert: AudioConverter,
@@ -18,7 +31,8 @@ export async function createMicrophoneReferenceAudioFile(
   }
 
   const mimeType = micBlob.type || 'audio/wav';
-  return new File([micBlob], 'microphone-recording.wav', {
+  const extension = extensionForMimeType(mimeType);
+  return new File([micBlob], `microphone-recording.${extension}`, {
     type: mimeType,
   });
 }

--- a/apps/web/tests/auth-callback.test.ts
+++ b/apps/web/tests/auth-callback.test.ts
@@ -2,7 +2,16 @@ import { captureException, captureMessage } from '@sentry/nextjs';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { GET } from '@/app/auth/callback/route';
+import { OAUTH_CALLBACK_COOKIE_NAME } from '@/lib/supabase/constants';
+import {
+  createOauthCallbackMarkerValue,
+  OAUTH_CALLBACK_COOKIE_MAX_AGE_SECONDS,
+} from '@/lib/supabase/oauth-callback-marker';
 import { createClient } from '@/lib/supabase/server';
+
+const { responseCookieSetMock } = vi.hoisted(() => ({
+  responseCookieSetMock: vi.fn(),
+}));
 
 vi.mock('@/lib/stripe/stripe-admin', () => ({
   createOrRetrieveCustomer: vi.fn().mockResolvedValue('cus_test'),
@@ -19,13 +28,23 @@ vi.mock('next/server', () => ({
   NextResponse: {
     redirect: (url: string | URL, init?: ResponseInit | number) => {
       const responseInit = typeof init === 'object' ? init : undefined;
-      return new Response(null, {
+      const response = new Response(null, {
         ...responseInit,
         status: typeof init === 'number' ? init : (responseInit?.status ?? 307),
         headers: {
           location: String(url),
         },
-      });
+      }) as Response & {
+        cookies: {
+          set: typeof responseCookieSetMock;
+        };
+      };
+
+      response.cookies = {
+        set: responseCookieSetMock,
+      };
+
+      return response;
     },
   },
 }));
@@ -38,6 +57,7 @@ describe('OAuth callback route', () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.unstubAllEnvs();
   });
 
   it('handles missing PKCE verifier errors without Sentry telemetry', async () => {
@@ -91,6 +111,81 @@ describe('OAuth callback route', () => {
           errorMessage: 'PKCE code verifier not found in storage.',
         }),
       },
+    );
+    expect(responseCookieSetMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: OAUTH_CALLBACK_COOKIE_NAME,
+        maxAge: 0,
+      }),
+    );
+  });
+
+  it('does not emit production console warnings for expected PKCE verifier misses', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    const exchangeError = new Error('PKCE code verifier not found in storage.');
+    exchangeError.name = 'AuthPKCECodeVerifierMissingError';
+    const exchangeCodeForSession = vi.fn().mockResolvedValue({
+      data: { user: null },
+      error: exchangeError,
+    });
+
+    vi.mocked(createClient).mockResolvedValueOnce({
+      auth: { exchangeCodeForSession },
+    } as unknown as Awaited<ReturnType<typeof createClient>>);
+
+    const response = await GET(
+      new Request(
+        'https://sexyvoice.ai/auth/callback?code=abc123&redirect_to=%2Fen%2Fdashboard',
+        {
+          headers: {
+            cookie: 'sb-test-auth-token=token',
+          },
+        },
+      ),
+    );
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get('location')).toBe(
+      'https://sexyvoice.ai/en/login',
+    );
+    expect(exchangeCodeForSession).toHaveBeenCalledWith('abc123');
+    expect(console.warn).not.toHaveBeenCalled();
+    expect(captureException).not.toHaveBeenCalled();
+    expect(captureMessage).not.toHaveBeenCalled();
+    expect(responseCookieSetMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: OAUTH_CALLBACK_COOKIE_NAME,
+        maxAge: 0,
+        secure: true,
+      }),
+    );
+  });
+
+  it('treats valid marked callbacks without a verifier as already completed', async () => {
+    vi.stubEnv('API_KEY_HMAC_SECRET', 'test-secret');
+    const marker = createOauthCallbackMarkerValue();
+
+    const response = await GET(
+      new Request(
+        'https://sexyvoice.ai/auth/callback?code=abc123&redirect_to=%2Fen%2Fdashboard',
+        {
+          headers: {
+            cookie: `${OAUTH_CALLBACK_COOKIE_NAME}=${marker}; sb-test-auth-token=token`,
+          },
+        },
+      ),
+    );
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get('location')).toBe(
+      'https://sexyvoice.ai/en/dashboard',
+    );
+    expect(createClient).not.toHaveBeenCalled();
+    expect(responseCookieSetMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: OAUTH_CALLBACK_COOKIE_NAME,
+        maxAge: OAUTH_CALLBACK_COOKIE_MAX_AGE_SECONDS,
+      }),
     );
   });
 

--- a/apps/web/tests/clone-voice.test.ts
+++ b/apps/web/tests/clone-voice.test.ts
@@ -1612,6 +1612,33 @@ describe('Clone Voice API Route', () => {
   });
 
   describe('Error Handling', () => {
+    it('returns a typed 400 without Sentry capture for direct WebM uploads', async () => {
+      const { captureException } = await import('@sentry/nextjs');
+      const convertToWavModule = await import('@/lib/audio-converter');
+      const convertSpy = vi.spyOn(convertToWavModule, 'convertToWav');
+      const webmFile = new File(['webm'], 'microphone-recording.webm', {
+        type: 'video/webm',
+      });
+
+      const formData = createFormDataWithAudio('Hello world', webmFile, 'en');
+
+      const request = new Request('http://localhost/api/clone-voice', {
+        method: 'POST',
+        body: formData,
+      });
+
+      const response = await POST(request);
+      const json = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(json.code).toBe('errors.audioConversionRequiredWebm');
+      expect(json.serverMessage).toBe(
+        'WebM audio must be converted to WAV on the client before uploading. Please try recording again.',
+      );
+      expect(convertSpy).not.toHaveBeenCalled();
+      expect(captureException).not.toHaveBeenCalled();
+    });
+
     it('should return 400 without logging to Sentry when audio decoding fails for non-English', async () => {
       const { captureException } = await import('@sentry/nextjs');
       // Mock convertToWav to throw an error for multilingual

--- a/apps/web/tests/microphone-reference-audio.test.ts
+++ b/apps/web/tests/microphone-reference-audio.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  createMicrophoneReferenceAudioFile,
+  isWebmAudioBlob,
+} from '@/lib/clone/microphone-reference-audio';
+
+describe('microphone reference audio', () => {
+  it('detects WebM microphone blobs with codec parameters', () => {
+    expect(
+      isWebmAudioBlob(new Blob(['webm'], { type: 'video/webm;codecs=opus' })),
+    ).toBe(true);
+    expect(isWebmAudioBlob(new Blob(['wav'], { type: 'audio/wav' }))).toBe(
+      false,
+    );
+  });
+
+  it('converts WebM microphone audio to a WAV file before upload', async () => {
+    const source = new Blob(['webm'], { type: 'video/webm;codecs=opus' });
+    const wavBlob = new Blob(['wav'], { type: 'audio/wav' });
+    const convert = vi.fn().mockResolvedValue(wavBlob);
+
+    const file = await createMicrophoneReferenceAudioFile(source, convert);
+
+    expect(convert).toHaveBeenCalledWith(source, 'wav');
+    expect(file.name).toBe('microphone-recording.wav');
+    expect(file.type).toBe('audio/wav');
+    expect(await file.text()).toBe('wav');
+  });
+
+  it('keeps non-WebM microphone audio without invoking conversion', async () => {
+    const source = new Blob(['wav'], { type: 'audio/wav' });
+    const convert = vi.fn();
+
+    const file = await createMicrophoneReferenceAudioFile(source, convert);
+
+    expect(convert).not.toHaveBeenCalled();
+    expect(file.name).toBe('microphone-recording.wav');
+    expect(file.type).toBe('audio/wav');
+    expect(await file.text()).toBe('wav');
+  });
+});


### PR DESCRIPTION
Changed:
- WebM mic recordings now always convert to WAV before clone upload via `microphone-reference-audio.ts`.
- Direct/stale WebM uploads now return the typed errors.audioConversionRequiredWebm 400 without Sentry capture in `clone-voice/route.ts`. -OAuth callback expected PKCE/flow-state failures no longer console.warn in production, clear the callback marker on failure, and skip re-exchanging already completed marked callbacks in `auth/callback/route.ts`.

## 2026-06-09T20:59:44+02:00

Implemented requested fixes for WebM upload and OAuth PKCE on branch
`automation/fix-sentry-webm-pkce-jun-09`.

Changes:
- Added `apps/web/lib/clone/microphone-reference-audio.ts` and wired the clone
  client to convert every microphone WebM blob to WAV before submitting,
  regardless of selected locale. The client now calls `ensureLoaded()` before
  lazy FFmpeg conversion.
- Updated `apps/web/app/api/clone-voice/route.ts` to reject direct WebM uploads
  before calling server-side conversion, returning existing
  `errors.audioConversionRequiredWebm` 400 without Sentry capture.
- Updated `apps/web/app/auth/callback/route.ts` to avoid production
  `console.warn` for expected PKCE/flow-state failures, clear the OAuth marker
  cookie on failure redirects, and treat valid recently marked callbacks without
  a verifier as already completed instead of re-exchanging a single-use code.
