### PR TITLE
sentry june 15th

### DIFF
--- a/apps/web/app/actions.ts
+++ b/apps/web/app/actions.ts
@@ -9,6 +9,8 @@ import { deleteFileFromR2 } from '@/lib/storage/upload';
 import { createClient } from '@/lib/supabase/server';
 import { encodedRedirect } from '@/lib/utils';
 
+const { logger, captureException } = Sentry;
+
 const EMAIL_SCHEMA = z.email({ message: 'Invalid email' });
 
 export const forgotPasswordAction = async (formData: FormData) => {
@@ -139,7 +141,7 @@ export const handleDeleteAccountAction = async ({ lang }: { lang: Locale }) => {
     deletionResults.forEach((result, index) => {
       if (result.status === 'rejected') {
         const file = audio_files[index];
-        Sentry.captureException(
+        captureException(
           new Error(result.reason || 'Failed to delete file from R2 storage.'),
           {
             user: { id: user.id, email: user.email },
@@ -189,7 +191,7 @@ export const handleDeleteAccountAction = async ({ lang }: { lang: Locale }) => {
         .eq('user_id', user.id);
 
       if (deletePromptsError) {
-        Sentry.captureException(deletePromptsError, {
+        captureException(deletePromptsError, {
           user: { id: user.id, email: user.email },
           extra: {
             promptIds,
@@ -208,7 +210,7 @@ export const handleDeleteAccountAction = async ({ lang }: { lang: Locale }) => {
   if (error || deleteError || deleteUsageEventsError) {
     throw new Error('User deletion failed');
   }
-  Sentry.logger.info('User deleted', {
+  logger.info('User deleted', {
     userId: user.id,
     deleted: deleteData?.length,
     deletedCustomCharacters: customCharacters?.length ?? 0,

--- a/apps/web/app/api/generate-voice/route.ts
+++ b/apps/web/app/api/generate-voice/route.ts
@@ -390,6 +390,21 @@ export async function POST(request: Request) {
               finishReason,
             },
           });
+        } else if (isNoAudioData) {
+          logger.warn('Gemini voice generation returned no audio data', {
+            user: { id: user.id, email: user.email },
+            extra: {
+              voice,
+              styleVariant,
+              model: modelUsed,
+              provider,
+              textLength: text.length,
+              textPreview: text.slice(0, 500),
+              responseId: genAIResponse?.responseId,
+              finishReason,
+              blockReason,
+            },
+          });
         } else {
           logger.error('Gemini voice generation failed', {
             user: { id: user.id, email: user.email },
@@ -423,9 +438,9 @@ export async function POST(request: Request) {
             );
           }
         }
-        // Only capture non-PROHIBITED_CONTENT errors to Sentry.
-        // PROHIBITED_CONTENT is an expected user input block, not an error to report.
-        if (!isProhibitedContent) {
+        // Only capture unexpected Gemini blocks to Sentry. PROHIBITED_CONTENT
+        // and no-audio STOP responses are handled user/provider states.
+        if (!(isProhibitedContent || isNoAudioData)) {
           captureException(new Error('Gemini 200 — no audio data'), {
             extra: {
               finishReason,
@@ -446,10 +461,9 @@ export async function POST(request: Request) {
         } else if (isNoAudioData) {
           noAudioErrorCode = 'NO_AUDIO_DATA';
         }
-        throw new Error(
-          getErrorMessage(noAudioErrorCode, 'voice-generation'),
-          { cause: noAudioErrorCode },
-        );
+        throw new Error(getErrorMessage(noAudioErrorCode, 'voice-generation'), {
+          cause: noAudioErrorCode,
+        });
       }
       logger.info('Gemini voice generation succeeded', {
         user: {
@@ -694,6 +708,15 @@ export async function POST(request: Request) {
       );
     }
 
+    if (Error.isError(error) && error.cause === 'NO_AUDIO_DATA') {
+      return NextResponse.json(
+        {
+          error: error.message || 'Voice generation returned no audio',
+        },
+        { status: getErrorStatusCode(error.cause) },
+      );
+    }
+
     const googleApiError = parseGoogleApiError(error);
     if (googleApiError) {
       const googleStatus = getGoogleApiErrorStatus(googleApiError);
@@ -740,6 +763,28 @@ export async function POST(request: Request) {
             ),
           },
           { status: 503 },
+        );
+      }
+
+      if (googleStatus === 'INVALID_ARGUMENT') {
+        logger.warn('Gemini rejected TTS request', {
+          user: user ? { id: user.id, email: user.email } : undefined,
+          extra: {
+            textLength: text.length,
+            voice,
+            googleStatus,
+            googleCode: googleApiError.code,
+          },
+        });
+
+        return NextResponse.json(
+          {
+            error: getErrorMessage(
+              ERROR_CODES.OTHER_GEMINI_BLOCK,
+              'voice-generation',
+            ),
+          },
+          { status: 422 },
         );
       }
     }

--- a/apps/web/lib/sentry/client-filters.ts
+++ b/apps/web/lib/sentry/client-filters.ts
@@ -42,6 +42,14 @@ const browserMediaNoisePattern =
   /Track has ended|WASM_OR_WORKER_NOT_READY|Lock was stolen by another request/i;
 const opaqueBrowserEventRejectionPattern =
   /Event `Event` \(type=error\) captured as promise rejection/i;
+const injectedBrowserGlobalPattern =
+  /(?:Can't find variable: __firefox__|window\.__firefox__|window\.ethereum\.selectedAddress)/i;
+const externalWorkerImportPattern =
+  /Failed to execute 'importScripts' on 'WorkerGlobalScope': The script at 'https?:\/\/(?!([^/]+\.)?sexyvoice\.ai\/)[^']+' failed to load/i;
+const webViewBridgeNoisePattern =
+  /WKWebView API client did not respond to this postMessage/i;
+const transientBrowserNetworkPattern =
+  /(?:^|\s)(?:NetworkError:\s*)?Load failed$|(?:^|\s)network error$/i;
 const browserSecurityNoisePattern =
   /Permission to call 'get parentNode' denied|The request was denied/i;
 const nullTagNamePattern =
@@ -106,7 +114,11 @@ function isBrowserRuntimeNoiseException(exception: SentryException): boolean {
   if (
     !(
       browserMediaNoisePattern.test(exceptionText) ||
-      opaqueBrowserEventRejectionPattern.test(exceptionText)
+      opaqueBrowserEventRejectionPattern.test(exceptionText) ||
+      injectedBrowserGlobalPattern.test(exceptionText) ||
+      externalWorkerImportPattern.test(exceptionText) ||
+      webViewBridgeNoisePattern.test(exceptionText) ||
+      transientBrowserNetworkPattern.test(exceptionText)
     )
   ) {
     return false;
@@ -132,8 +144,12 @@ export function shouldDropClientSentryEvent(event: SentryClientEvent): boolean {
   }
 
   const message = event.message ?? '';
+  const isMessageOnlyReactDomNoise =
+    exceptions.length === 0 &&
+    reactDomMutationNoisePatterns.some((pattern) => pattern.test(message));
 
   return (
+    isMessageOnlyReactDomNoise ||
     reactHydrationRecoverablePattern.test(message) ||
     rscConnectionClosedPattern.test(message)
   );

--- a/apps/web/lib/stripe/stripe-admin.ts
+++ b/apps/web/lib/stripe/stripe-admin.ts
@@ -130,13 +130,11 @@ export async function createOrRetrieveCustomer(
     const error = new Error(
       `Multiple customers found for supabaseUUID ${userId}. Using the first one.`,
     );
-    console.error(`[STRIPE ADMIN] ${error.message}`);
-    Sentry.captureMessage(error.message, {
-      level: 'warning',
+    console.warn(`[STRIPE ADMIN] ${error.message}`);
+    Sentry.logger.warn('Multiple Stripe customers found for Supabase user', {
       user: { id: userId, email },
-      extra: {
-        customerCount: customersResults.data.length,
-      },
+      customerCount: customersResults.data.length,
+      customerIds: customersResults.data.map((customer) => customer.id),
     });
   }
 
@@ -154,10 +152,10 @@ export async function createOrRetrieveCustomer(
       `Multiple customers found for email ${email}. Using the first one.`,
     );
     console.warn(error.message);
-    Sentry.captureMessage(error.message, {
-      level: 'warning',
+    Sentry.logger.warn('Multiple Stripe customers found for email', {
       user: { id: userId, email },
-      extra: { customerCount: customers.data.length },
+      customerCount: customers.data.length,
+      customerIds: customers.data.map((customer) => customer.id),
     });
   }
 

--- a/apps/web/lib/stripe/stripe-admin.ts
+++ b/apps/web/lib/stripe/stripe-admin.ts
@@ -14,6 +14,8 @@ import { type CustomerData, setCustomerData } from '../redis/queries';
 import { getUserIdByStripeCustomerId } from '../supabase/queries';
 import { createClient } from '../supabase/server';
 
+const { logger, captureException } = Sentry;
+
 if (!process.env.STRIPE_SECRET_KEY) {
   throw new Error('STRIPE_SECRET_KEY is not set');
 }
@@ -41,7 +43,7 @@ export async function createOrRetrieveCustomer(
         `Stripe customer ${customer.id} already linked to Supabase user ${metadataUuid}.`,
       );
       console.error(`[STRIPE ADMIN] ${error.message}`);
-      Sentry.captureException(error, {
+      captureException(error, {
         user: { id: userId, email },
         extra: {
           customerId: customer.id,
@@ -71,7 +73,7 @@ export async function createOrRetrieveCustomer(
           `[STRIPE ADMIN] Failed to update metadata for Stripe customer ${customer.id}`,
           error,
         );
-        Sentry.captureException(error, {
+        captureException(error, {
           user: { id: userId, email },
           extra: {
             customerId: customer.id,
@@ -106,7 +108,7 @@ export async function createOrRetrieveCustomer(
         `[STRIPE ADMIN] Failed to retrieve Stripe customer with id ${customerId}`,
         error,
       );
-      Sentry.captureException(error, {
+      captureException(error, {
         user: { id: userId, email },
         extra: { customerId },
       });
@@ -131,7 +133,7 @@ export async function createOrRetrieveCustomer(
       `Multiple customers found for supabaseUUID ${userId}. Using the first one.`,
     );
     console.warn(`[STRIPE ADMIN] ${error.message}`);
-    Sentry.logger.warn('Multiple Stripe customers found for Supabase user', {
+    logger.warn('Multiple Stripe customers found for Supabase user', {
       user: { id: userId, email },
       customerCount: customersResults.data.length,
       customerIds: customersResults.data.map((customer) => customer.id),
@@ -152,7 +154,7 @@ export async function createOrRetrieveCustomer(
       `Multiple customers found for email ${email}. Using the first one.`,
     );
     console.warn(error.message);
-    Sentry.logger.warn('Multiple Stripe customers found for email', {
+    logger.warn('Multiple Stripe customers found for email', {
       user: { id: userId, email },
       customerCount: customers.data.length,
       customerIds: customers.data.map((customer) => customer.id),
@@ -177,7 +179,7 @@ export async function createOrRetrieveCustomer(
   console.info(
     `[STRIPE ADMIN] Created new Stripe customer with id ${stripeId} (${userId}) for email ${email}`,
   );
-  Sentry.logger.info('Created new Stripe customer', {
+  logger.info('Created new Stripe customer', {
     customerId: stripeId,
     email,
     userId,
@@ -252,7 +254,7 @@ export async function isStripeCouponUsable(couponId: string): Promise<boolean> {
 
     return coupon.valid;
   } catch (error) {
-    Sentry.captureException(error, {
+    captureException(error, {
       tags: {
         section: 'stripe_admin',
         event_type: 'coupon_validation_error',
@@ -309,7 +311,7 @@ export async function refreshCustomerSubscriptionData(
       error,
     );
     const userId = await getUserIdByStripeCustomerId(customerId);
-    Sentry.captureException(error, {
+    captureException(error, {
       user: userId ? { id: userId } : undefined,
       extra: { customerId },
     });

--- a/apps/web/lib/supabase/queries.ts
+++ b/apps/web/lib/supabase/queries.ts
@@ -381,6 +381,15 @@ export const insertSubscriptionCreditTransaction = async (
   });
 
   if (error) {
+    if (isCreditTransactionReferenceConflict(error)) {
+      console.log('Subscription transaction already exists', {
+        userId,
+        paymentIntentId,
+        subscriptionId,
+      });
+      return;
+    }
+
     console.error('Error inserting subscription transaction:', {
       userId,
       subscriptionId,
@@ -450,11 +459,28 @@ export const insertTopupCreditTransaction = async (
     },
   });
 
-  if (error) throw error;
+  if (error) {
+    if (isCreditTransactionReferenceConflict(error)) {
+      console.log('Topup transaction already exists', {
+        userId,
+        paymentIntentId,
+      });
+      return;
+    }
+
+    throw error;
+  }
 
   // Update user's credit balance using the database function
   await updateUserCredits(userId, creditAmount);
 };
+
+const isCreditTransactionReferenceConflict = (error: {
+  code?: string;
+  message?: string;
+}): boolean =>
+  error.code === '23505' &&
+  /unique_reference|reference_id/i.test(error.message ?? '');
 
 const updateUserCredits = async (userId: string, creditAmount: number) => {
   const supabase = createAdminClient();

--- a/apps/web/lib/utils.ts
+++ b/apps/web/lib/utils.ts
@@ -253,13 +253,13 @@ export const ERROR_CODES = {
  * Maps error codes to appropriate HTTP status codes.
  * - 422: Client input issues (content policy violations)
  * - 500: Server/upstream errors (third-party API failures)
- * - 503: Service temporarily unavailable (quota exceeded)
+ * - 503: Service temporarily unavailable (quota exceeded / transient upstream)
  */
 export const ERROR_STATUS_CODES: Record<keyof typeof ERROR_CODES, number> = {
   PROHIBITED_CONTENT: 422,
   FREE_QUOTA_EXCEEDED: 503,
   OTHER_GEMINI_BLOCK: 500,
-  NO_AUDIO_DATA: 500,
+  NO_AUDIO_DATA: 503,
   REPLICATE_ERROR: 500,
   XAI_TTS_ERROR: 500,
   GEMINI_PROVIDER_UNAVAILABLE: 503,

--- a/apps/web/tests/generate-voice.test.ts
+++ b/apps/web/tests/generate-voice.test.ts
@@ -1,4 +1,4 @@
-import type { GenerateContentResponse } from '@google/genai';
+import { FinishReason, type GenerateContentResponse } from '@google/genai';
 import * as Sentry from '@sentry/nextjs';
 import { HttpResponse, http } from 'msw';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -1074,6 +1074,56 @@ describe('Generate Voice API Route', () => {
       );
     });
 
+    it('should return 422 without Sentry capture when Gemini rejects a TTS request as invalid', async () => {
+      const invalidArgumentError: GoogleApiErrorWithStatus = {
+        code: 400,
+        message:
+          'Model tried to generate text, but it should only be used for TTS.',
+        status: 'INVALID_ARGUMENT',
+        details: [],
+      };
+
+      setMockGoogleGenAIFactory(() => ({
+        models: {
+          generateContent: vi.fn().mockImplementation(() => {
+            throw new Error(JSON.stringify({ error: invalidArgumentError }));
+          }),
+        },
+      }));
+
+      const request = new Request('http://localhost/api/generate-voice', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({ text: 'Hello world', voice: 'kore' }),
+      });
+
+      const response = await POST(request);
+      const json = await response.json();
+
+      expect(response.status).toBe(422);
+      expect(json.error).toBe(
+        getErrorMessage('OTHER_GEMINI_BLOCK', 'voice-generation'),
+      );
+      expect(Sentry.captureException).not.toHaveBeenCalled();
+      expect(Sentry.logger.warn).toHaveBeenCalledWith(
+        'Gemini rejected TTS request',
+        expect.objectContaining({
+          extra: expect.objectContaining({
+            googleCode: 400,
+            googleStatus: 'INVALID_ARGUMENT',
+            textLength: 'Hello world'.length,
+            voice: 'kore',
+          }),
+          user: {
+            id: 'test-user-id',
+            email: 'test@example.com',
+          },
+        }),
+      );
+    });
+
     it('should handle Google API quota exceeded error', async () => {
       // Mock Google API quota error - should fail on both pro and flash models
       setMockGoogleGenAIFactory(() => ({
@@ -1183,6 +1233,54 @@ describe('Generate Voice API Route', () => {
       expect(json.url).toContain('files.sexyvoice.ai');
       expect(queries.isFreemiumUserOverLimit).toHaveBeenCalledWith(
         'test-user-id',
+      );
+    });
+
+    it('should return 503 without Sentry capture when Gemini stops with no audio data', async () => {
+      setMockGoogleGenAIFactory(() => ({
+        models: {
+          generateContent: vi.fn().mockResolvedValue({
+            candidates: [
+              {
+                finishReason: FinishReason.STOP,
+                content: {
+                  parts: [],
+                },
+              },
+            ],
+          }),
+        },
+      }));
+
+      const request = new Request('http://localhost/api/generate-voice', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({ text: 'Hello world', voice: 'kore' }),
+      });
+
+      const response = await POST(request);
+      const json = await response.json();
+
+      expect(response.status).toBe(503);
+      expect(json.error).toBe(
+        getErrorMessage('NO_AUDIO_DATA', 'voice-generation'),
+      );
+      expect(Sentry.captureException).not.toHaveBeenCalled();
+      expect(Sentry.logger.warn).toHaveBeenCalledWith(
+        'Gemini voice generation returned no audio data',
+        expect.objectContaining({
+          extra: expect.objectContaining({
+            finishReason: FinishReason.STOP,
+            model: 'gemini-2.5-flash-preview-tts',
+            voice: 'kore',
+          }),
+          user: {
+            id: 'test-user-id',
+            email: 'test@example.com',
+          },
+        }),
       );
     });
 

--- a/apps/web/tests/sentry-client-filters.test.ts
+++ b/apps/web/tests/sentry-client-filters.test.ts
@@ -72,12 +72,12 @@ describe('shouldDropClientSentryEvent', () => {
     ).toBe(false);
   });
 
-  it('does not drop DOM mutation text without React frame evidence', () => {
+  it('drops message-only React DOM mutation noise', () => {
     expect(
       shouldDropClientSentryEvent({
         message: "Cannot read properties of null (reading 'removeChild')",
       }),
-    ).toBe(false);
+    ).toBe(true);
   });
 
   it('drops recoverable hydration and RSC connection messages', () => {
@@ -188,6 +188,109 @@ describe('shouldDropClientSentryEvent', () => {
             {
               type: 'Event',
               value: 'Event `Event` (type=error) captured as promise rejection',
+            },
+          ],
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it('drops injected browser globals and external worker imports without app frames', () => {
+    expect(
+      shouldDropClientSentryEvent({
+        exception: {
+          values: [
+            {
+              type: 'ReferenceError',
+              value: "Can't find variable: __firefox__",
+              stacktrace: {
+                frames: [{ filename: 'app:///en', function: 'global code' }],
+              },
+            },
+          ],
+        },
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldDropClientSentryEvent({
+        exception: {
+          values: [
+            {
+              type: 'TypeError',
+              value:
+                "undefined is not an object (evaluating 'window.ethereum.selectedAddress = undefined')",
+              stacktrace: {
+                frames: [{ filename: 'app:///en', function: 'global code' }],
+              },
+            },
+          ],
+        },
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldDropClientSentryEvent({
+        exception: {
+          values: [
+            {
+              value:
+                "Uncaught NetworkError: Failed to execute 'importScripts' on 'WorkerGlobalScope': The script at 'https://propertydealersinindia.org/tojy/elha.wasm.wasm' failed to load.",
+            },
+          ],
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it('does not drop injected browser global text with app frames', () => {
+    expect(
+      shouldDropClientSentryEvent({
+        exception: {
+          values: [
+            {
+              type: 'TypeError',
+              value:
+                "undefined is not an object (evaluating 'window.ethereum.selectedAddress = undefined')",
+              stacktrace: {
+                frames: [
+                  {
+                    filename: 'apps/web/components/wallet-button.tsx',
+                    function: 'connectWallet',
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it('drops WebView bridge and transient network noise without app frames', () => {
+    expect(
+      shouldDropClientSentryEvent({
+        exception: {
+          values: [
+            {
+              type: 'Error',
+              value: 'WKWebView API client did not respond to this postMessage',
+            },
+          ],
+        },
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldDropClientSentryEvent({
+        exception: {
+          values: [
+            {
+              type: 'TypeError',
+              value: 'network error',
+              stacktrace: {
+                frames: [{ filename: '[native code]', function: 'fetch' }],
+              },
             },
           ],
         },

--- a/apps/web/tests/stripe-admin.test.ts
+++ b/apps/web/tests/stripe-admin.test.ts
@@ -253,7 +253,15 @@ describe('createOrRetrieveCustomer()', () => {
       const result = await createOrRetrieveCustomer(userId, email);
 
       expect(result).toBe('cus_1');
-      expect(Sentry.captureMessage).toHaveBeenCalled();
+      expect(Sentry.captureMessage).not.toHaveBeenCalled();
+      expect(Sentry.logger.warn).toHaveBeenCalledWith(
+        'Multiple Stripe customers found for Supabase user',
+        expect.objectContaining({
+          customerCount: 2,
+          customerIds: ['cus_1', 'cus_2'],
+          user: { id: userId, email },
+        }),
+      );
     });
   });
 
@@ -330,7 +338,18 @@ describe('createOrRetrieveCustomer()', () => {
       const result = await createOrRetrieveCustomer(userId, email);
 
       expect(result).toBe('cus_email_1');
-      expect(Sentry.captureMessage).toHaveBeenCalled();
+      expect(Sentry.captureMessage).not.toHaveBeenCalledWith(
+        expect.stringContaining('Multiple customers found for email'),
+        expect.anything(),
+      );
+      expect(Sentry.logger.warn).toHaveBeenCalledWith(
+        'Multiple Stripe customers found for email',
+        expect.objectContaining({
+          customerCount: 2,
+          customerIds: ['cus_email_1', 'cus_email_2'],
+          user: { id: userId, email },
+        }),
+      );
     });
   });
 


### PR DESCRIPTION
- Gemini: handled no-audio STOP responses as warning + 503, without Sentry exception capture, and handled Gemini INVALID_ARGUMENT as warning + 422 in [route.ts (line 393)](/web/app/api/generate-voice/route.ts:393).
- Stripe webhook duplicates: duplicate reference_id/unique-index conflicts now return as idempotent no-ops before credit balance increments in [queries.ts (line 383)](apps/web/lib/supabase/queries.ts:383).
- Client noise: expanded Sentry filtering for React DOM mutation message-only payloads, injected browser globals, external worker imports, WKWebView bridge errors, and no-app-frame network failures in [client-filters.ts (line 45)](/apps/web/lib/sentry/client-filters.ts:45).
- Duplicate Stripe customers: changed handled duplicate-customer warnings from captureMessage issues to structured Sentry logs in [stripe-admin.ts (line 129)](/apps/web/lib/stripe/stripe-admin.ts:129).
