### PR TITLE
docs: add Cursor Cloud dev environment setup notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -235,3 +235,33 @@ Routes under `apps/web/app/api/v1/*` are API-key authenticated except
   `apps/docs/content/`, `AGENTS.md`).
 - Call out impact on credits, billing, generation, storage, or API contracts
   when relevant.
+
+## Cursor Cloud specific instructions
+
+These notes cover non-obvious gotchas for running this repo inside a Cursor
+Cloud VM (the startup update script already runs `pnpm install`). Standard
+commands live in `## Common Commands` above; only the caveats are here.
+
+- Node version: the project requires Node `24.x`, but the base VM's default
+  `node` (at `/exec-daemon/node`) is `v22` and takes PATH precedence over nvm.
+  Before running dev/build/test, select Node 24 and put it first on PATH, e.g.
+  `nvm install 24.9.0 && export PATH="$HOME/.nvm/versions/node/v24.9.0/bin:$PATH"`
+  (then `corepack enable` so `pnpm@10.20.0` is available). `pnpm install` itself
+  works under either Node version.
+- Dev server: `pnpm dev` wraps `next dev` with the external `portless` CLI
+  (serves `https://sv.dev`), which is NOT installed in the cloud VM. Run plain
+  Next.js instead: `pnpm --filter @sexyvoice/web exec next dev -p 3000` and use
+  `http://localhost:3000` (locale root is `/en`). Contentlayer builds
+  automatically on dev start.
+- Secrets: no secrets are required to boot the dev server, load the marketing
+  pages, or use the free in-browser tools under `/[lang]/tools/*` (transcribe,
+  audio-converter, audio-joiner). Auth/dashboard, voice generation/cloning,
+  LiveKit calls, Stripe, and the external API v1 need real provider credentials
+  from `apps/web/.env.example` (copy to `apps/web/.env.local`).
+- Full test suite: `apps/web/tests/stripe-webhook.test.ts` uses
+  `redis-memory-server`, which downloads a Redis 7.2.4 binary on first run
+  (needs network) or reuses a system `redis-server`. If that download is not
+  available, point it at a system binary:
+  `REDISMS_SYSTEM_BINARY=/usr/bin/redis-server pnpm test` (install via
+  `apt-get install -y redis-server`). Without a Redis binary, only that one
+  test file times out; the other 43 files (590+ tests) pass.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What & why

Sets up and verifies the development environment for the SexyVoice.ai monorepo inside a Cursor Cloud VM, and records durable, non-obvious startup caveats for future agents in `AGENTS.md`.

No application/source code was changed — this only adds a `## Cursor Cloud specific instructions` section to `AGENTS.md`.

## Environment setup performed

- Installed Node `24.9.0` via nvm (base VM default `node` at `/exec-daemon/node` is `v22` and takes PATH precedence, so Node 24 must be put first on PATH).
- `pnpm install` (pnpm `10.20.0` via corepack) — set as the startup update script.
- Created a local-dev `apps/web/.env.local` (gitignored) — no secrets needed for the dev server, marketing pages, or in-browser tools.

## Verification

| Check | Command | Result |
| --- | --- | --- |
| Type-check | `pnpm type-check` | ✅ pass (3/3 tasks, Contentlayer built 35 docs) |
| Tests | `REDISMS_SYSTEM_BINARY=/usr/bin/redis-server pnpm test` | ✅ 44 files, 591 passed / 1 skipped |
| Lint | `pnpm lint` | ⚠️ Biome runs (282 files) but reports pre-existing findings on a clean checkout |
| Dev server | `pnpm --filter @sexyvoice/web exec next dev -p 3000` | ✅ Ready; `/en` → HTTP 200 |

Note: `pnpm test` without a Redis binary times out only on `stripe-webhook.test.ts` (uses `redis-memory-server`); the other 43 files pass. Documented in AGENTS.md.

## Hello-world action

Converted a WAV file to MP3 end-to-end using the free in-browser Audio Converter (`/en/tools/audio-converter`, ffmpeg.wasm, no login).

[audio_converter_wav_to_mp3_demo.mp4](https://cursor.com/agents/bc-b9a00b2b-2851-4121-a639-fd6a4e691d70/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Faudio_converter_wav_to_mp3_demo.mp4)

[Conversion complete](https://cursor.com/agents/bc-b9a00b2b-2851-4121-a639-fd6a4e691d70/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Faudio_converter_conversion_complete.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b9a00b2b-2851-4121-a639-fd6a4e691d70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b9a00b2b-2851-4121-a639-fd6a4e691d70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

