### PR TITLE
feat(tts): free taste of Gemini 3.1 for gpro31 voices + freemium cap

### DIFF
--- a/apps/web/app/api/generate-voice/route.ts
+++ b/apps/web/app/api/generate-voice/route.ts
@@ -162,7 +162,10 @@ export async function POST(request: Request) {
       );
     }
 
-    if (!userHasPaid && voiceObj.model === 'gpro') {
+    if (
+      !userHasPaid &&
+      (voiceObj.model === 'gpro' || voiceObj.model === 'gpro31')
+    ) {
       const isOverLimit = await isFreemiumUserOverLimit(user.id);
       if (isOverLimit) {
         return NextResponse.json(

--- a/apps/web/app/api/generate-voice/route.ts
+++ b/apps/web/app/api/generate-voice/route.ts
@@ -162,10 +162,7 @@ export async function POST(request: Request) {
       );
     }
 
-    if (
-      !userHasPaid &&
-      (voiceObj.model === 'gpro' || voiceObj.model === 'gpro31')
-    ) {
+    if (!userHasPaid && ['gpro', 'gpro31'].includes(voiceObj.model)) {
       const isOverLimit = await isFreemiumUserOverLimit(user.id);
       if (isOverLimit) {
         return NextResponse.json(

--- a/apps/web/lib/supabase/queries.ts
+++ b/apps/web/lib/supabase/queries.ts
@@ -708,12 +708,13 @@ export const isFreemiumUserOverLimit = async (
 ): Promise<boolean> => {
   const supabase = await createClient();
   // TODO: use redis instead
-  // If the user is a freemium user, count their voice model 'gpro' audio files.
+  // Count the freemium user's Gemini audio files (2.5 'gpro' and 3.1 'gpro31')
+  // against a single shared free-generation cap.
   const { count, error } = await supabase
     .from('audio_files')
     .select('id, voices!inner(model)', { count: 'exact', head: true })
     .eq('user_id', userId)
-    .eq('voices.model', 'gpro');
+    .in('voices.model', ['gpro', 'gpro31']);
 
   if (error) {
     throw error;

--- a/apps/web/lib/tts/gemini.ts
+++ b/apps/web/lib/tts/gemini.ts
@@ -66,11 +66,16 @@ export function buildGeminiTtsConfig({
 
 /**
  * Resolve the effective Gemini model id for a request.
- * - paid: gpro31 → gemini-3.1-flash-tts-preview, else gemini-2.5-pro-preview-tts
- * - free: gemini-2.5-flash-preview-tts
+ * - gpro31 (any tier): gemini-3.1-flash-tts-preview
+ * - gpro paid: gemini-2.5-pro-preview-tts
+ * - gpro free: gemini-2.5-flash-preview-tts
  *
- * The external API always generates at the "paid" tier (pass userHasPaid:true)
- * and relies on the flash fallback in `generateGeminiAudio`.
+ * gpro31 always synthesizes with Gemini 3.1 so free users get a consistent
+ * "taste" of 3.1 (matching the streaming path) as an upgrade funnel, rather
+ * than a 2.5-flash fallback that varied by request path and text length.
+ * `generateGeminiAudio` still falls back to flash if the 3.1 call fails.
+ *
+ * The external API always generates at the "paid" tier (pass userHasPaid:true).
  */
 export function selectGeminiModel({
   dbModel,
@@ -79,12 +84,13 @@ export function selectGeminiModel({
   dbModel: string;
   userHasPaid: boolean;
 }): string {
+  if (dbModel === 'gpro31') {
+    return 'gemini-3.1-flash-tts-preview';
+  }
   if (!userHasPaid) {
     return GEMINI_FLASH_MODEL;
   }
-  return dbModel === 'gpro31'
-    ? 'gemini-3.1-flash-tts-preview'
-    : 'gemini-2.5-pro-preview-tts';
+  return 'gemini-2.5-pro-preview-tts';
 }
 
 export interface GeminiAudioClassification {

--- a/apps/web/tests/generate-voice.test.ts
+++ b/apps/web/tests/generate-voice.test.ts
@@ -1314,6 +1314,33 @@ describe('Generate Voice API Route', () => {
       );
     });
 
+    it('should return 403 when freemium user exceeds the gpro31 voice limit', async () => {
+      const queries = await import('@/lib/supabase/queries');
+
+      vi.mocked(queries.hasUserPaid).mockResolvedValueOnce(false);
+      vi.mocked(queries.isFreemiumUserOverLimit).mockResolvedValueOnce(true);
+
+      const request = new Request('http://localhost/api/generate-voice', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          text: 'Hello world',
+          voiceId: 'voice-achernar-31-id',
+        }),
+      });
+
+      const response = await POST(request);
+      const json = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(json.errorCode).toBe('gproLimitExceeded');
+      expect(queries.isFreemiumUserOverLimit).toHaveBeenCalledWith(
+        'test-user-id',
+      );
+    });
+
     it('should allow voice generation when freemium user is under limit', async () => {
       const queries = await import('@/lib/supabase/queries');
 

--- a/apps/web/tests/tts-core.test.ts
+++ b/apps/web/tests/tts-core.test.ts
@@ -88,16 +88,16 @@ describe('buildStyledText', () => {
 });
 
 describe('selectGeminiModel', () => {
-  it('returns flash for free users', () => {
+  it('returns 2.5 flash for free gpro users', () => {
     expect(selectGeminiModel({ dbModel: 'gpro', userHasPaid: false })).toBe(
-      GEMINI_FLASH_MODEL,
-    );
-    expect(selectGeminiModel({ dbModel: 'gpro31', userHasPaid: false })).toBe(
       GEMINI_FLASH_MODEL,
     );
   });
 
-  it('returns the 3.1 model for paid gpro31', () => {
+  it('returns 3.1 for gpro31 regardless of tier (free taste of 3.1)', () => {
+    expect(selectGeminiModel({ dbModel: 'gpro31', userHasPaid: false })).toBe(
+      'gemini-3.1-flash-tts-preview',
+    );
     expect(selectGeminiModel({ dbModel: 'gpro31', userHasPaid: true })).toBe(
       'gemini-3.1-flash-tts-preview',
     );


### PR DESCRIPTION
Stacked on #432 (`refactor/tts-shared-core`). Retarget to `main` once #432 merges.

## Why
Free users selecting a **Gemini 3.1 (`gpro31`)** voice got real 3.1 only on the streaming path (text > 300 chars) and a 2.5-flash fallback on the JSON path — so the model they heard varied by request path and length. Product decision: keep 3.1 selectable for everyone as an upgrade funnel ("taste of 3.1"), but make it **consistent** and **metered**.

## What
1. **Consistent model** — `selectGeminiModel` now returns `gemini-3.1-flash-tts-preview` for any `gpro31` request regardless of tier (matching the streaming path). `generateGeminiAudio` still falls back to 2.5-flash if the 3.1 call fails. Paid `gpro` (2.5-pro) and the external `/v1/speech` tier are unchanged.
2. **Freemium cap extended to gpro31** — `isFreemiumUserOverLimit` previously counted only `gpro` (2.5) audio files; it now counts `gpro` **and** `gpro31` against a single shared free-generation cap (`MAX_FREE_GENERATIONS`). The `generate-voice` route gate applies to `gpro31` too, returning the same `gproLimitExceeded` 403.

Net effect: free users get a real, consistent taste of 3.1, but it counts toward their free quota instead of being unlimited.

## Not changed
- `voice-select.tsx` — 3.1 voices stay selectable for everyone (the picker already labels them "Gemini 3.1"). No UI gating, per the funnel intent.
- External `/v1/speech` API — unaffected (no freemium concept there).

## Tests
- `selectGeminiModel` unit tests updated (gpro31 → 3.1 for both tiers).
- New route test: free user over limit on a `gpro31` voice → 403 `gproLimitExceeded`.
- Full suite green; `tsgo` clean; biome introduces no new findings.