### PR TITLE
fix(stripe): detect reference conflicts in PostgREST details

### DIFF
--- a/apps/web/lib/supabase/queries.ts
+++ b/apps/web/lib/supabase/queries.ts
@@ -491,12 +491,18 @@ export const insertTopupCreditTransaction = async (
   await updateUserCredits(userId, creditAmount);
 };
 
-const isCreditTransactionReferenceConflict = (error: {
+export const isCreditTransactionReferenceConflict = (error: {
   code?: string;
+  details?: string;
   message?: string;
-}): boolean =>
-  error.code === '23505' &&
-  /unique_reference|reference_id/i.test(error.message ?? '');
+}): boolean => {
+  const conflictContext = `${error.message ?? ''} ${error.details ?? ''}`;
+
+  return (
+    error.code === '23505' &&
+    /unique_reference|reference_id/i.test(conflictContext)
+  );
+};
 
 const updateUserCredits = async (userId: string, creditAmount: number) => {
   const supabase = createAdminClient();

--- a/apps/web/tests/supabase-credit-transactions.test.ts
+++ b/apps/web/tests/supabase-credit-transactions.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+
+import { isCreditTransactionReferenceConflict } from '@/lib/supabase/queries';
+
+describe('credit transaction reference conflicts', () => {
+  it('recognizes reference conflicts reported in PostgREST details', () => {
+    expect(
+      isCreditTransactionReferenceConflict({
+        code: '23505',
+        message: 'duplicate key value violates unique constraint',
+        details: 'Key (reference_id)=(pi_123) already exists.',
+      }),
+    ).toBe(true);
+  });
+
+  it('ignores unrelated unique constraint violations', () => {
+    expect(
+      isCreditTransactionReferenceConflict({
+        code: '23505',
+        message:
+          'duplicate key value violates unique constraint users_email_key',
+        details: 'Key (email)=(person@example.com) already exists.',
+      }),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- include PostgREST `details` when classifying duplicate credit transaction references
- preserve unrelated `23505` errors as failures
- add focused coverage for both cases

Follow-up to the valid Claude review feedback on #415.

## Verification
- `pnpm --filter @sexyvoice/web exec vitest run tests/supabase-credit-transactions.test.ts`
- `pnpm type-check`
- targeted Biome check passes
- `pnpm fixall` remains blocked by pre-existing repository-wide Biome diagnostics outside this change