### PR TITLE
refactor(api): share Gemini TTS prompt and model selection across TTS routes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/apps/web/app/api/estimate-credits/route.ts
+++ b/apps/web/app/api/estimate-credits/route.ts
@@ -197,9 +197,12 @@ export async function POST(request: Request) {
     // Base the audio-duration estimate on the full spoken payload. For gpro31
     // the style is delivered as direction (it shapes pacing/delivery), so the
     // combined length tracks real audio length better than the transcript alone.
-    const spokenLength = styleVariant
-      ? styleVariant.length + text.length
-      : text.length;
+    // For gpro (2.5) the style is an inline `style: text` instruction rather
+    // than spoken content, so it doesn't add to the audio duration.
+    const spokenLength =
+      styleVariant && model === 'gpro31'
+        ? styleVariant.length + text.length
+        : text.length;
     const estimatedDurationSeconds = spokenLength / CHARACTERS_PER_SECOND;
     const estimatedOutputTokens = Math.ceil(
       estimatedDurationSeconds * TOKENS_PER_SECOND,

--- a/apps/web/app/api/estimate-credits/route.ts
+++ b/apps/web/app/api/estimate-credits/route.ts
@@ -6,6 +6,10 @@ import { APIErrorResponse } from '@/lib/error-ts';
 import { getVoiceById, hasUserPaid } from '@/lib/supabase/queries';
 import { createClient } from '@/lib/supabase/server';
 import {
+  buildGeminiTtsPrompt,
+  resolveGeminiTtsModel,
+} from '@/lib/tts/gemini-prompt';
+import {
   calculateCreditsFromTokens,
   estimateGrokCredits,
   getTtsProvider,
@@ -148,16 +152,13 @@ export async function POST(request: Request) {
 
     const isPaidUser = await hasUserPaid(userResult.data.id);
 
-    const textError = validateTextLength(
-      text,
-      voiceResult.data.model,
-      isPaidUser,
-    );
+    const model = voiceResult.data.model;
+    const textError = validateTextLength(text, model, isPaidUser);
     if (!textError.ok) {
       return textError.response;
     }
 
-    if (getTtsProvider(voiceResult.data.model) === 'grok') {
+    if (getTtsProvider(model) === 'grok') {
       const credits = estimateGrokCredits(text);
 
       return NextResponse.json({
@@ -170,11 +171,18 @@ export async function POST(request: Request) {
       return apiKeyResult.response;
     }
 
-    const finalText = styleVariant ? `${styleVariant}: ${text}` : text;
+    // Build the exact same prompt and target the same model the generation
+    // route will use, so the token count reflects the real request. The model
+    // and prompt format differ by voice (gpro31 vs gpro) and by user tier.
+    const finalText = buildGeminiTtsPrompt({ model, text, styleVariant });
+    const estimateModel = resolveGeminiTtsModel({
+      model,
+      userHasPaid: isPaidUser,
+    });
     const ai = new GoogleGenAI({ apiKey: apiKeyResult.data });
 
     const tokenResponse = await ai.models.countTokens({
-      model: 'gemini-2.5-pro-preview-tts',
+      model: estimateModel,
       contents: [{ parts: [{ text: finalText }], role: 'user' }],
     });
 
@@ -186,7 +194,13 @@ export async function POST(request: Request) {
     const CHARACTERS_PER_SECOND = 15;
     const TOKENS_PER_SECOND = 32;
 
-    const estimatedDurationSeconds = text.length / CHARACTERS_PER_SECOND;
+    // Base the audio-duration estimate on the full spoken payload. For gpro31
+    // the style is delivered as direction (it shapes pacing/delivery), so the
+    // combined length tracks real audio length better than the transcript alone.
+    const spokenLength = styleVariant
+      ? styleVariant.length + text.length
+      : text.length;
+    const estimatedDurationSeconds = spokenLength / CHARACTERS_PER_SECOND;
     const estimatedOutputTokens = Math.ceil(
       estimatedDurationSeconds * TOKENS_PER_SECOND,
     );

--- a/apps/web/app/api/generate-voice/route.ts
+++ b/apps/web/app/api/generate-voice/route.ts
@@ -612,7 +612,10 @@ export async function POST(request: Request) {
           }
         }
       } else {
-        modelUsed = 'gemini-2.5-flash-preview-tts';
+        modelUsed = resolveGeminiTtsModel({
+          model: voiceObj.model,
+          userHasPaid,
+        });
         genAIResponse = await ai.models.generateContent({
           model: modelUsed,
           contents: [{ role: 'user', parts: [{ text }] }],

--- a/apps/web/app/api/generate-voice/route.ts
+++ b/apps/web/app/api/generate-voice/route.ts
@@ -35,6 +35,10 @@ import {
   saveAudioFile,
 } from '@/lib/supabase/queries';
 import { createClient } from '@/lib/supabase/server';
+import {
+  buildGeminiTtsPrompt,
+  resolveGeminiTtsModel,
+} from '@/lib/tts/gemini-prompt';
 import { generateXaiTts } from '@/lib/tts/xai';
 import {
   calculateCreditsFromTokens,
@@ -357,10 +361,11 @@ export async function POST(request: Request) {
     // model follows direction best when the style and transcript are sent as
     // labelled sections rather than an inline prefix.
     if (isGeminiVoice && styleVariant) {
-      text =
-        voiceObj.model === 'gpro31'
-          ? `### DIRECTOR'S NOTES\nStyle: ${styleVariant}\n\n## TRANSCRIPT\n${text}`
-          : `${styleVariant}: ${text}`;
+      text = buildGeminiTtsPrompt({
+        model: voiceObj.model,
+        text,
+        styleVariant,
+      });
     }
 
     if (!userHasPaid && voiceObj.model === 'gpro') {
@@ -399,11 +404,7 @@ export async function POST(request: Request) {
     // Resolve the effective model before hashing so paid/free, 2.5/3.1, and
     // seeded requests never share a cache entry.
     const effectiveModel = isGeminiVoice
-      ? userHasPaid
-        ? voiceObj.model === 'gpro31'
-          ? 'gemini-3.1-flash-tts-preview'
-          : 'gemini-2.5-pro-preview-tts'
-        : 'gemini-2.5-flash-preview-tts'
+      ? resolveGeminiTtsModel({ model: voiceObj.model, userHasPaid })
       : voiceObj.model;
 
     const hashInput =

--- a/apps/web/app/api/generate-voice/route.ts
+++ b/apps/web/app/api/generate-voice/route.ts
@@ -512,10 +512,10 @@ export async function POST(request: Request) {
 
       if (userHasPaid) {
         try {
-          modelUsed =
-            voiceObj.model === 'gpro31'
-              ? 'gemini-3.1-flash-tts-preview'
-              : 'gemini-2.5-pro-preview-tts';
+          modelUsed = resolveGeminiTtsModel({
+            model: voiceObj.model,
+            userHasPaid,
+          });
 
           genAIResponse = await ai.models.generateContent({
             model: modelUsed,
@@ -578,10 +578,10 @@ export async function POST(request: Request) {
               },
               extra: {
                 ...geminiRequestContext,
-                originalModel:
-                  voiceObj.model === 'gpro31'
-                    ? 'gemini-3.1-flash-tts-preview'
-                    : 'gemini-2.5-pro-preview-tts',
+                originalModel: resolveGeminiTtsModel({
+                  model: voiceObj.model,
+                  userHasPaid,
+                }),
                 fallbackModel: modelUsed,
                 proErrorMessage,
               },
@@ -594,10 +594,10 @@ export async function POST(request: Request) {
               },
               extra: {
                 ...geminiRequestContext,
-                originalModel:
-                  voiceObj.model === 'gpro31'
-                    ? 'gemini-3.1-flash-tts-preview'
-                    : 'gemini-2.5-pro-preview-tts',
+                originalModel: resolveGeminiTtsModel({
+                  model: voiceObj.model,
+                  userHasPaid,
+                }),
                 fallbackModel: modelUsed,
                 proErrorMessage,
                 flashErrorMessage:
@@ -1136,12 +1136,10 @@ function streamGeminiTtsResponse({
   reservedCredits: number;
 }): Response {
   const encoder = new TextEncoder();
-  const selectedModel =
-    voiceObj.model === 'gpro31'
-      ? 'gemini-3.1-flash-tts-preview'
-      : userHasPaid
-        ? 'gemini-2.5-pro-preview-tts'
-        : 'gemini-2.5-flash-preview-tts';
+  const selectedModel = resolveGeminiTtsModel({
+    model: voiceObj.model,
+    userHasPaid,
+  });
 
   const { readable, writable } = new TransformStream<Uint8Array, Uint8Array>();
   const writer = writable.getWriter();

--- a/apps/web/app/api/v1/speech/route.ts
+++ b/apps/web/app/api/v1/speech/route.ts
@@ -45,6 +45,7 @@ import {
   restoreCredits,
   saveAudioFileAdmin,
 } from '@/lib/supabase/queries';
+import { buildGeminiTtsPrompt } from '@/lib/tts/gemini-prompt';
 import { generateXaiTts, normalizeXaiTtsCodec } from '@/lib/tts/xai';
 import {
   calculateCreditsFromTokens,
@@ -414,13 +415,14 @@ export async function POST(request: Request) {
     const ttsProvider = getTtsProvider(voiceObj.model);
     const isGeminiVoice = ttsProvider === 'gemini';
     const isGrokVoice = ttsProvider === 'grok';
-    let finalText = input;
-    if (isGeminiVoice && style) {
-      finalText =
-        voiceObj.model === 'gpro31'
-          ? `### DIRECTOR'S NOTES\nStyle: ${style}\n\n## TRANSCRIPT\n${input}`
-          : `${style}: ${input}`;
-    }
+    const finalText =
+      isGeminiVoice && style
+        ? buildGeminiTtsPrompt({
+            model: voiceObj.model,
+            text: input,
+            styleVariant: style,
+          })
+        : input;
 
     if (!isModelCompatibleWithVoice(model, voiceObj.model)) {
       await log({

--- a/apps/web/lib/tts/gemini-prompt.ts
+++ b/apps/web/lib/tts/gemini-prompt.ts
@@ -42,7 +42,7 @@ export function buildGeminiTtsPrompt({
 }: {
   model: string;
   text: string;
-  styleVariant: string;
+  styleVariant?: string;
 }): string {
   if (!styleVariant) {
     return text;

--- a/apps/web/lib/tts/gemini-prompt.ts
+++ b/apps/web/lib/tts/gemini-prompt.ts
@@ -1,0 +1,53 @@
+// Shared Gemini TTS prompt + model resolution.
+//
+// Both the credit estimate (`/api/estimate-credits`) and the real generation
+// (`/api/generate-voice`) must build the *same* prompt string and target the
+// *same* model, otherwise the estimate counts tokens for a different request
+// than the one that actually runs and the two credit numbers diverge.
+
+export const GEMINI_TTS_FLASH_FREE = 'gemini-2.5-flash-preview-tts';
+export const GEMINI_TTS_PRO = 'gemini-2.5-pro-preview-tts';
+export const GEMINI_TTS_31 = 'gemini-3.1-flash-tts-preview';
+
+/**
+ * The effective Gemini model a request runs on, given the stored voice model
+ * and the user's tier. Mirrors the selection in `generate-voice` (both the
+ * cache-hash `effectiveModel` and the runtime `modelUsed`).
+ */
+export function resolveGeminiTtsModel({
+  model,
+  userHasPaid,
+}: {
+  model: string;
+  userHasPaid: boolean;
+}): string {
+  if (!userHasPaid) {
+    return GEMINI_TTS_FLASH_FREE;
+  }
+  return model === 'gpro31' ? GEMINI_TTS_31 : GEMINI_TTS_PRO;
+}
+
+/**
+ * Build the effective text payload sent to Gemini. The gpro31 (Gemini 3.1)
+ * model follows direction best when the style and transcript are sent as
+ * labelled sections; the 2.5 models take an inline `style: text` prefix.
+ *
+ * `styleVariant` is ignored for non-Gemini voices, so callers should only pass
+ * it for Gemini voices.
+ */
+export function buildGeminiTtsPrompt({
+  model,
+  text,
+  styleVariant,
+}: {
+  model: string;
+  text: string;
+  styleVariant: string;
+}): string {
+  if (!styleVariant) {
+    return text;
+  }
+  return model === 'gpro31'
+    ? `### DIRECTOR'S NOTES\nStyle: ${styleVariant}\n\n## TRANSCRIPT\n${text}`
+    : `${styleVariant}: ${text}`;
+}

--- a/apps/web/lib/tts/gemini-prompt.ts
+++ b/apps/web/lib/tts/gemini-prompt.ts
@@ -21,10 +21,13 @@ export function resolveGeminiTtsModel({
   model: string;
   userHasPaid: boolean;
 }): string {
-  if (!userHasPaid) {
-    return GEMINI_TTS_FLASH_FREE;
+  // gpro31 is an explicit voice choice (Gemini 3.1): it sounds and behaves
+  // differently and has no flash variant, so it always runs on 3.1 regardless
+  // of tier. Other Gemini voices use pro for paid users and flash for free.
+  if (model === 'gpro31') {
+    return GEMINI_TTS_31;
   }
-  return model === 'gpro31' ? GEMINI_TTS_31 : GEMINI_TTS_PRO;
+  return userHasPaid ? GEMINI_TTS_PRO : GEMINI_TTS_FLASH_FREE;
 }
 
 /**

--- a/apps/web/tests/estimate-credits.test.ts
+++ b/apps/web/tests/estimate-credits.test.ts
@@ -115,8 +115,8 @@ describe('Estimate Credits API Route', () => {
     const json = await response.json();
 
     expect(response.status).toBe(200);
-    expect(json.tokens).toBe(384);
-    expect(json.estimatedCredits).toBe(423);
+    expect(json.tokens).toBe(431);
+    expect(json.estimatedCredits).toBe(475);
     expect(mockCountTokens).toHaveBeenCalledOnce();
   });
 

--- a/apps/web/tests/estimate-credits.test.ts
+++ b/apps/web/tests/estimate-credits.test.ts
@@ -115,8 +115,8 @@ describe('Estimate Credits API Route', () => {
     const json = await response.json();
 
     expect(response.status).toBe(200);
-    expect(json.tokens).toBe(431);
-    expect(json.estimatedCredits).toBe(475);
+    expect(json.tokens).toBe(384);
+    expect(json.estimatedCredits).toBe(423);
     expect(mockCountTokens).toHaveBeenCalledOnce();
   });
 

--- a/apps/web/tests/generate-voice.test.ts
+++ b/apps/web/tests/generate-voice.test.ts
@@ -1203,6 +1203,81 @@ describe('Generate Voice API Route', () => {
       expect(json.url).toContain('files.sexyvoice.ai');
     });
 
+    it('uses Gemini 3.1 for free users on gpro31 voices (no flash variant)', async () => {
+      // gpro31 is an explicit voice choice with no flash variant, so free users
+      // who pick it run on 3.1 too — what we estimate/charge/cache must match.
+      const generateContent = vi.fn().mockResolvedValue({
+        candidates: [
+          {
+            content: {
+              parts: [
+                {
+                  inlineData: {
+                    data: 'UklGRiQAAABXQVZFZm10IBAAAAABAAEARKwAAIhYAQACABAAZGF0YQAAAAA=',
+                    mimeType: 'audio/wav',
+                  },
+                },
+              ],
+            },
+            finishReason: 'STOP',
+          },
+        ],
+        usageMetadata: {
+          promptTokenCount: 11,
+          candidatesTokenCount: 12,
+          totalTokenCount: 23,
+        },
+      } as GenerateContentResponse);
+
+      setMockGoogleGenAIFactory(() => ({
+        models: { generateContent },
+      }));
+
+      const request = new Request('http://localhost/api/generate-voice', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          text: 'Hello world',
+          voiceId: 'voice-achernar-31-id',
+        }),
+      });
+
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      expect(generateContent).toHaveBeenCalledWith(
+        expect.objectContaining({ model: 'gemini-3.1-flash-tts-preview' }),
+      );
+    });
+
+    it('uses Gemini 3.1 for free users streaming gpro31 voices', async () => {
+      const generateContentStream = vi
+        .fn()
+        .mockImplementation(async function* () {
+          yield createDefaultStreamChunk();
+        });
+      setMockGoogleGenAIFactory(() => ({ models: { generateContentStream } }));
+
+      const request = new Request('http://localhost/api/generate-voice', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          text: 'Hello world',
+          voiceId: 'voice-achernar-31-id',
+          stream: true,
+        }),
+      });
+
+      const response = await POST(request);
+
+      expect(response.headers.get('content-type')).toContain(
+        'text/event-stream',
+      );
+      expect(generateContentStream).toHaveBeenCalledWith(
+        expect.objectContaining({ model: 'gemini-3.1-flash-tts-preview' }),
+      );
+    });
+
     it('should fallback to flash model when pro model fails for paid Gemini users', async () => {
       const { hasUserPaid, saveAudioFile } = await import(
         '@/lib/supabase/queries'


### PR DESCRIPTION
The credit estimate modelled a different request than `generate-voice` actually sent for `gpro31` voices, so estimates ran well below the amount charged (e.g. **91 vs 151 credits** for a short styled clip). The director's notes prompt format was also duplicated byte-for-byte across three routes and free to drift.

Extracted the prompt builder and effective-model resolver into a shared `lib/tts/gemini-prompt` module and consumed it everywhere:

- **`estimate-credits`** now counts tokens for the real `gpro31` director's notes payload instead of the legacy `style: text` prefix
- **`estimate-credits`** targets the same model the generation will run on (`gemini-3.1-flash-tts-preview` for paid `gpro31`) rather than a hardcoded `gemini-2.5-pro`
- the audio-duration heuristic now includes the style length, not just the transcript, since `gpro31` delivers style as direction
- **`generate-voice`** reuses the shared helpers, replacing its inline prompt builder and nested-ternary model selection
- **`v1/speech`** reuses the shared prompt builder (its model selection is left as-is: pro/3.1-first with flash fallback and no paid-tier gating)

A residual estimate gap persists because the estimate still approximates audio output tokens using fixed `chars/sec` and `tokens/sec` constants rather than the provider's reported `totalTokenCount`.