### PR TITLE
feat(db): expose relevance scores from match_agent_memories_hybrid

### DIFF
--- a/apps/web/supabase/migrations/20260626130000_match_agent_memories_hybrid_scores.sql
+++ b/apps/web/supabase/migrations/20260626130000_match_agent_memories_hybrid_scores.sql
@@ -103,5 +103,5 @@ $$;
 
 -- Re-grant: DROP removed the privileges, so restore the original posture.
 GRANT EXECUTE ON FUNCTION public.match_agent_memories_hybrid(
-  vector, text, uuid, text, int
+  extensions.vector, text, uuid, text, int
 ) TO authenticated, service_role;

--- a/apps/web/supabase/migrations/20260626130000_match_agent_memories_hybrid_scores.sql
+++ b/apps/web/supabase/migrations/20260626130000_match_agent_memories_hybrid_scores.sql
@@ -31,7 +31,7 @@ DROP FUNCTION IF EXISTS public.match_agent_memories_hybrid(
 );
 
 CREATE OR REPLACE FUNCTION public.match_agent_memories_hybrid(
-  query_embedding vector(1536),
+  query_embedding extensions.vector(1536),
   query_text      text,
   p_user_id       uuid,
   p_character_id  text DEFAULT '__shared__',

--- a/apps/web/supabase/migrations/20260626130000_match_agent_memories_hybrid_scores.sql
+++ b/apps/web/supabase/migrations/20260626130000_match_agent_memories_hybrid_scores.sql
@@ -1,0 +1,107 @@
+-- Migration: 20260626130000_match_agent_memories_hybrid_scores.sql
+-- Surface relevance scores from public.match_agent_memories_hybrid so the voice
+-- agent (sexycall, src/observability.py) can log retrieval quality.
+--
+-- Today the RPC already computes the cosine distance, the per-branch RRF ranks,
+-- and the fused score, but discards them in the final SELECT. Reciprocal Rank
+-- Fusion is purely rank-based, so retrieval is currently unobservable: every
+-- turn returns the top-N regardless of how poor the match is. This change
+-- exposes those already-computed values.
+--
+-- ADDITIVE / BACKWARD COMPATIBLE: the first two output columns (memory_type,
+-- content) keep their position and meaning, the argument signature is unchanged,
+-- and ranking behaviour is identical (same RRF weights 0.7 vector / 0.3 text,
+-- k=60, same ORDER BY / LIMIT). Only four trailing columns are added. Callers
+-- that read memory_type / content (e.g. sexycall's format_memories) are
+-- unaffected.
+--
+-- Why DROP and not a plain CREATE OR REPLACE: adding columns to a RETURNS TABLE
+-- changes the function's result type, and PostgreSQL refuses to do that via
+-- CREATE OR REPLACE FUNCTION ("cannot change return type of existing function").
+-- We therefore DROP and recreate ONLY the function, keyed on its exact argument
+-- signature. The agent_memories table and its rows are never touched, and the
+-- recreated function keeps the same arguments, so this is not a breaking change.
+--
+-- Depends on 20260626110000_create_agent_memories.sql, which creates the table
+-- and the original two-column function. The DROP is therefore the existing
+-- two-column definition.
+
+DROP FUNCTION IF EXISTS public.match_agent_memories_hybrid(
+  vector, text, uuid, text, int
+);
+
+CREATE OR REPLACE FUNCTION public.match_agent_memories_hybrid(
+  query_embedding vector(1536),
+  query_text      text,
+  p_user_id       uuid,
+  p_character_id  text DEFAULT '__shared__',
+  match_count     int  DEFAULT 5
+)
+RETURNS TABLE (
+  memory_type     text,
+  content         text,
+  cosine_distance double precision,  -- m.embedding <=> query_embedding; lower = nearer/better; NULL if no embedding
+  rrf_score       double precision,  -- the fused score this row was ranked by
+  vector_rank     int,               -- rank in the vector branch (NULL if not matched there)
+  text_rank       int                -- rank in the full-text branch (NULL if not matched there)
+)
+LANGUAGE sql
+SECURITY INVOKER
+SET search_path = public, extensions
+AS $$
+  WITH vector_ranked AS (
+    SELECT m.id,
+           row_number() OVER (ORDER BY m.embedding <=> query_embedding ASC) AS rank
+    FROM public.agent_memories m
+    WHERE m.user_id = p_user_id
+      AND m.character_id = p_character_id
+      AND m.embedding IS NOT NULL
+      -- Guard: with a NULL query_embedding, `embedding <=> NULL` is NULL and the
+      -- ORDER BY would rank arbitrary rows, polluting the fused result. Returning
+      -- 0 rows here lets the hybrid search fall back to pure full-text.
+      AND query_embedding IS NOT NULL
+    ORDER BY m.embedding <=> query_embedding ASC
+    LIMIT least(greatest(match_count, 1) * 4, 50)
+  ),
+  text_ranked AS (
+    SELECT m.id,
+           row_number() OVER (
+             ORDER BY ts_rank_cd(m.fts, websearch_to_tsquery('simple', query_text)) DESC
+           ) AS rank
+    FROM public.agent_memories m
+    WHERE m.user_id = p_user_id
+      AND m.character_id = p_character_id
+      AND query_text IS NOT NULL
+      AND query_text <> ''
+      AND m.fts @@ websearch_to_tsquery('simple', query_text)
+    ORDER BY ts_rank_cd(m.fts, websearch_to_tsquery('simple', query_text)) DESC
+    LIMIT least(greatest(match_count, 1) * 4, 50)
+  ),
+  fused AS (
+    SELECT coalesce(v.id, t.id) AS id,
+           v.rank               AS vector_rank,
+           t.rank               AS text_rank,
+           coalesce(0.7 / (60 + v.rank), 0.0)
+             + coalesce(0.3 / (60 + t.rank), 0.0) AS score
+    FROM vector_ranked v
+    FULL OUTER JOIN text_ranked t ON v.id = t.id
+  )
+  SELECT m.memory_type,
+         m.content,
+         -- Recompute the cosine distance for the surviving row. `<=>` yields NULL
+         -- when m.embedding is NULL (or query_embedding is NULL), so null-embedding
+         -- rows that only matched the text branch report NULL here.
+         (m.embedding <=> query_embedding)::double precision AS cosine_distance,
+         f.score::double precision                           AS rrf_score,
+         f.vector_rank::int                                  AS vector_rank,
+         f.text_rank::int                                    AS text_rank
+  FROM fused f
+  JOIN public.agent_memories m ON m.id = f.id
+  ORDER BY f.score DESC
+  LIMIT greatest(match_count, 1);
+$$;
+
+-- Re-grant: DROP removed the privileges, so restore the original posture.
+GRANT EXECUTE ON FUNCTION public.match_agent_memories_hybrid(
+  vector, text, uuid, text, int
+) TO authenticated, service_role;

--- a/apps/web/supabase/migrations/20260626130000_match_agent_memories_hybrid_scores.sql
+++ b/apps/web/supabase/migrations/20260626130000_match_agent_memories_hybrid_scores.sql
@@ -27,7 +27,7 @@
 -- two-column definition.
 
 DROP FUNCTION IF EXISTS public.match_agent_memories_hybrid(
-  vector, text, uuid, text, int
+  extensions.vector, text, uuid, text, int
 );
 
 CREATE OR REPLACE FUNCTION public.match_agent_memories_hybrid(

--- a/apps/web/supabase/tests/match_agent_memories_hybrid_scores.test.sql
+++ b/apps/web/supabase/tests/match_agent_memories_hybrid_scores.test.sql
@@ -1,0 +1,149 @@
+-- pgTAP test for public.match_agent_memories_hybrid relevance scores.
+--
+-- Run with the Supabase CLI against a local DB that has the agent_memories
+-- migrations applied (this test is NOT wired into the Vitest CI, which has no
+-- Postgres):
+--
+--   supabase test db
+--
+-- It seeds one user with three memories — two embedded (one identical to the
+-- query vector, one orthogonal) and one with a NULL embedding that only matches
+-- the full-text branch — then asserts the additive score columns behave as
+-- documented while ranking stays byte-for-byte the same (memory_type / content
+-- first, RRF order preserved).
+
+begin;
+
+select plan(11);
+
+-- ── Seed ───────────────────────────────────────────────────────────────────
+-- Minimal auth.users row so the agent_memories.user_id FK is satisfied.
+insert into auth.users (instance_id, id, aud, role, email, created_at, updated_at)
+values (
+  '00000000-0000-0000-0000-000000000000',
+  '11111111-1111-4111-8111-111111111111',
+  'authenticated',
+  'authenticated',
+  'pgtap-memory@example.com',
+  now(),
+  now()
+);
+
+-- Three memories under the default '__shared__' scope.
+--   preferred_name : embedding == query vector            → cosine distance 0
+--   hobby          : embedding orthogonal to query vector → cosine distance 1
+--   fav_color      : NULL embedding, only matches text 'blue'
+insert into public.agent_memories (user_id, character_id, memory_type, content, embedding)
+values
+  (
+    '11111111-1111-4111-8111-111111111111',
+    '__shared__',
+    'preferred_name',
+    'Call me Alex',
+    ('[1' || repeat(',0', 1535) || ']')::extensions.vector
+  ),
+  (
+    '11111111-1111-4111-8111-111111111111',
+    '__shared__',
+    'hobby',
+    'Enjoys hiking',
+    ('[0,1' || repeat(',0', 1534) || ']')::extensions.vector
+  ),
+  (
+    '11111111-1111-4111-8111-111111111111',
+    '__shared__',
+    'fav_color',
+    'blue',
+    null
+  );
+
+-- ── Call the RPC ─────────────────────────────────────────────────────────────
+-- query_embedding == the preferred_name vector; query_text 'blue' matches only
+-- the NULL-embedding fav_color row in the full-text branch.
+create temporary table _res on commit drop as
+select *, row_number() over () as ord
+from public.match_agent_memories_hybrid(
+  ('[1' || repeat(',0', 1535) || ']')::extensions.vector,
+  'blue',
+  '11111111-1111-4111-8111-111111111111'::uuid,
+  '__shared__',
+  5
+);
+
+-- ── (a) Same rows, same order, first two columns intact ─────────────────────
+select is(
+  (select count(*) from _res)::int, 3,
+  'returns all three seeded memories'
+);
+
+select is(
+  (select array_agg(memory_type order by ord) from _res),
+  array['preferred_name', 'hobby', 'fav_color']::text[],
+  'rows preserved in RRF order: preferred_name, hobby, fav_color'
+);
+
+select is(
+  (select content from _res where memory_type = 'preferred_name'),
+  'Call me Alex',
+  'content stays the second column'
+);
+
+-- ── (b) cosine_distance: non-null & ascending for embedded rows, NULL else ──
+select isnt(
+  (select cosine_distance from _res where memory_type = 'preferred_name'),
+  null,
+  'embedded row exposes a non-null cosine_distance'
+);
+
+select is(
+  (select cosine_distance from _res where memory_type = 'fav_color'),
+  null,
+  'null-embedding row reports NULL cosine_distance'
+);
+
+select ok(
+  (select cosine_distance from _res where memory_type = 'preferred_name')
+    <= (select cosine_distance from _res where memory_type = 'hobby'),
+  'cosine_distance ascends with vector rank (nearer row is smaller)'
+);
+
+-- ── (c) rrf_score: non-null and monotonically non-increasing ────────────────
+select ok(
+  (select bool_and(rrf_score is not null) from _res),
+  'every row exposes a non-null rrf_score'
+);
+
+select ok(
+  (
+    select bool_and(prev_score >= rrf_score)
+    from (
+      select rrf_score, lag(rrf_score) over (order by ord) as prev_score
+      from _res
+    ) ranked
+    where prev_score is not null
+  ),
+  'rrf_score is monotonically non-increasing across the result set'
+);
+
+-- ── (d) per-branch ranks: text-only vs vector-only ──────────────────────────
+select ok(
+  (select vector_rank is null and text_rank is not null
+   from _res where memory_type = 'fav_color'),
+  'text-only match has vector_rank NULL and a text_rank'
+);
+
+select ok(
+  (select vector_rank is not null and text_rank is null
+   from _res where memory_type = 'preferred_name'),
+  'vector-only match has text_rank NULL and a vector_rank'
+);
+
+select is(
+  (select vector_rank from _res where memory_type = 'preferred_name')::int,
+  1,
+  'nearest embedded row is vector_rank 1'
+);
+
+select * from finish();
+
+rollback;


### PR DESCRIPTION
## What

Adds a migration that surfaces relevance scores from the existing Postgres RPC `public.match_agent_memories_hybrid`, plus a pgTAP test. This is **additive and backward compatible**: the RPC keeps `memory_type` and `content` as its first two columns and the same argument signature, ranking behaviour is unchanged (same RRF weights 0.7 vector / 0.3 text, k=60, same `ORDER BY f.score DESC` / `LIMIT`), and four trailing columns are added — `cosine_distance`, `rrf_score`, `vector_rank`, `text_rank`. It only *exposes* values the function already computed and discarded, so it unblocks retrieval-quality monitoring in sexycall (`src/observability.py`) without re-ranking anything. Callers that read `memory_type` / `content` (e.g. sexycall's `format_memories`) are unaffected.

## Files

- `apps/web/supabase/migrations/20260626130000_match_agent_memories_hybrid_scores.sql`
- `apps/web/supabase/tests/match_agent_memories_hybrid_scores.test.sql`

## Note on `DROP` vs `CREATE OR REPLACE`

The task asked for `CREATE OR REPLACE`, but adding columns to a `RETURNS TABLE` changes the function's result type, and Postgres rejects that via `CREATE OR REPLACE FUNCTION` (`ERROR: cannot change return type of existing function`). The migration therefore `DROP`s and recreates **only the function**, keyed on its exact argument signature — the `agent_memories` table and its rows are never touched, the arguments stay identical, and `EXECUTE` is re-granted to `authenticated, service_role`. Security posture is unchanged (`language sql`, `security invoker`, `set search_path = public, extensions`).

## Dependency / stacking

⚠️ This is **stacked on #437** (`claude/supabase-memory`), which introduces `agent_memories` and the original two-column function. The new migration's timestamp (`20260626130000`) sorts after #437's `…110000_create_agent_memories.sql` and `…120000_prune_agent_memories.sql`, so it applies in the correct order once both are merged. It will not apply on `main` until #437 lands.

## Testing

CI (Vitest + Redis) has no Postgres, so the test is a standalone pgTAP script run via `supabase test db`. Validated locally on Postgres 16 + pgvector + pgTAP by applying #437's migration then this one: the migration applies cleanly and **all 11 pgTAP assertions pass**. Coverage:

- (a) same rows in the same RRF order; `content` stays the second column
- (b) `cosine_distance` non-null & ascending for embedded rows, `NULL` for the null-embedding row
- (c) `rrf_score` non-null and monotonically non-increasing across the result set
- (d) a text-only match has `vector_rank IS NULL` (with a `text_rank`) and a vector-only match has `text_rank IS NULL` (with a `vector_rank`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XcFmiddpzKxYxkPbDnYfYv)_