### PR TITLE
fix(generate-voice): disable Gemini 3.1 streaming and revert to char limits

### DIFF
--- a/apps/web/app/api/generate-voice/route.ts
+++ b/apps/web/app/api/generate-voice/route.ts
@@ -302,13 +302,29 @@ export async function POST(request: Request) {
     // return audio progressively. The 2.5 models emit the whole clip in a
     // single chunk, so streaming gives no benefit — they keep the JSON path,
     // as do Grok/Replicate voices.
+    const clientRequestedStream =
+      stream && isGeminiVoice && voiceObj.model === 'gpro31';
     // HOTFIX: gated behind GEMINI_STREAMING_ENABLED (currently false) because
     // progressive streaming corrupted some gpro31 generations.
-    const shouldStream =
-      GEMINI_STREAMING_ENABLED &&
-      stream &&
-      isGeminiVoice &&
-      voiceObj.model === 'gpro31';
+    const shouldStream = GEMINI_STREAMING_ENABLED && clientRequestedStream;
+
+    // HOTFIX: while streaming is disabled, a stale browser bundle from a
+    // previous deploy may still POST `stream: true` and wait for an SSE `done`
+    // event. The non-streaming JSON response never satisfies that contract, so
+    // the client would hang after audio was generated and credits debited.
+    // Fail fast with an explicit non-OK response — before any credit
+    // reservation — so the stale client surfaces an error and the user reloads
+    // to pick up the non-streaming bundle.
+    if (clientRequestedStream && !shouldStream) {
+      logger.warn('Rejected stream request while streaming is disabled', {
+        user: { id: user.id },
+        extra: { voice: voiceObj.name, model: voiceObj.model },
+      });
+      return APIErrorResponse(
+        'Streaming is temporarily disabled. Please refresh the page and try again.',
+        409,
+      );
+    }
 
     userHasPaid = await hasUserPaid(user.id);
 

--- a/apps/web/app/api/generate-voice/route.ts
+++ b/apps/web/app/api/generate-voice/route.ts
@@ -13,6 +13,7 @@ import Replicate, { type Prediction } from 'replicate';
 import {
   estimateTokenCount,
   extractInlineAudio,
+  GEMINI_STREAMING_ENABLED,
   getCharactersLimit,
   getGeminiCombinedTokenLimit,
   getGeminiStyleCharacterLimit,
@@ -301,14 +302,24 @@ export async function POST(request: Request) {
     // return audio progressively. The 2.5 models emit the whole clip in a
     // single chunk, so streaming gives no benefit — they keep the JSON path,
     // as do Grok/Replicate voices.
-    const shouldStream = stream && isGeminiVoice && voiceObj.model === 'gpro31';
+    // HOTFIX: gated behind GEMINI_STREAMING_ENABLED (currently false) because
+    // progressive streaming corrupted some gpro31 generations.
+    const shouldStream =
+      GEMINI_STREAMING_ENABLED &&
+      stream &&
+      isGeminiVoice &&
+      voiceObj.model === 'gpro31';
 
     userHasPaid = await hasUserPaid(user.id);
 
     // Enforce per-tier input limits on the RAW transcript and style before
     // combining them, so the attacker-controlled (and otherwise unbounded)
     // styleVariant cannot bypass the limits or under-estimate credits.
-    const isGemini31 = isGeminiVoice && voiceObj.model === 'gpro31';
+    // HOTFIX: while streaming is disabled (GEMINI_STREAMING_ENABLED === false)
+    // gpro31 falls back to the standard per-tier character limits below, like
+    // the Gemini 2.5 voices, instead of the larger combined token budget.
+    const isGemini31 =
+      GEMINI_STREAMING_ENABLED && isGeminiVoice && voiceObj.model === 'gpro31';
 
     if (isGemini31) {
       // Gemini 3.1 streams audio, so the transcript and style share one combined

--- a/apps/web/components/audio-generator.test.tsx
+++ b/apps/web/components/audio-generator.test.tsx
@@ -53,6 +53,7 @@ vi.mock('@/lib/ai', () => ({
   ),
   estimateTokenCount: vi.fn((text: string) => Math.ceil(text.length / 4)),
   GEMINI_CHARS_PER_TOKEN: 4,
+  GEMINI_STREAMING_ENABLED: false,
 }));
 
 vi.mock('@/lib/download', () => ({

--- a/apps/web/components/audio-generator.tsx
+++ b/apps/web/components/audio-generator.tsx
@@ -27,6 +27,7 @@ import { Textarea } from '@/components/ui/textarea';
 import {
   estimateTokenCount,
   GEMINI_CHARS_PER_TOKEN,
+  GEMINI_STREAMING_ENABLED,
   getCharactersLimit,
   getGeminiCombinedTokenLimit,
   getGeminiStyleCharacterLimit,
@@ -306,7 +307,10 @@ export function AudioGenerator({
   // Only gemini-3.1 (gpro31) returns audio progressively. The 2.5 models
   // synthesize the whole clip and return it in a single chunk, so streaming
   // there gives no time-to-first-audio benefit — keep them on the JSON path.
-  const isStreamingModel = selectedVoice?.model === 'gpro31';
+  // HOTFIX: gated behind GEMINI_STREAMING_ENABLED (currently false) because
+  // progressive streaming corrupted some gpro31 generations.
+  const isStreamingModel =
+    GEMINI_STREAMING_ENABLED && selectedVoice?.model === 'gpro31';
   // Rough speech-rate estimate (~15 chars/sec) so the streaming waveform fills
   // toward the expected total length before the exact duration is known.
   const estimatedStreamDurationSec = Math.max(1, Math.round(text.length / 15));
@@ -318,7 +322,13 @@ export function AudioGenerator({
   // Gemini 3.1 (gpro31) shares one combined token budget between the transcript
   // and the style, so its transcript "character limit" is that token budget
   // expressed in approximate characters. Other voices keep the per-tier cap.
-  const isGemini31 = isGeminiVoice && selectedVoice?.model === 'gpro31';
+  // HOTFIX: while streaming is disabled (GEMINI_STREAMING_ENABLED === false)
+  // gpro31 reverts to the standard per-tier character limits and the separate
+  // style-prompt cap, like the Gemini 2.5 voices.
+  const isGemini31 =
+    GEMINI_STREAMING_ENABLED &&
+    isGeminiVoice &&
+    selectedVoice?.model === 'gpro31';
   const styleText = isGeminiVoice ? (selectedStyle ?? '') : '';
   const charactersLimit = isGemini31
     ? getGeminiCombinedTokenLimit(isPaidUser) * GEMINI_CHARS_PER_TOKEN

--- a/apps/web/lib/ai.ts
+++ b/apps/web/lib/ai.ts
@@ -72,6 +72,15 @@ const GEMINI_31_TOKEN_LIMIT_PAID = 8192;
 // token is the conventional rough heuristic for English-like text.
 export const GEMINI_CHARS_PER_TOKEN = 4;
 
+// HOTFIX: Gemini 3.1 (gpro31) progressive streaming was corrupting some
+// generations, so streaming — and the larger combined input *token* budget that
+// shipped with it — are temporarily disabled. While this is `false`, gpro31 uses
+// the non-streaming JSON path and the standard per-tier *character* limits
+// (getCharactersLimit) with a separate style-prompt cap, exactly like the Gemini
+// 2.5 voices. Flip back to `true` to restore streaming + the combined token
+// budget once the streaming corruption is fixed.
+export const GEMINI_STREAMING_ENABLED = false;
+
 /** Character limit for the Gemini 2.5 style prompt, per tier. */
 export const getGeminiStyleCharacterLimit = (isPaidUser = false) =>
   isPaidUser ? GEMINI_25_STYLE_LIMIT_PAID : GEMINI_25_STYLE_LIMIT_FREE;

--- a/apps/web/tests/components/audio-generator.test.tsx
+++ b/apps/web/tests/components/audio-generator.test.tsx
@@ -138,6 +138,7 @@ vi.mock('@/lib/ai', () => ({
   ),
   estimateTokenCount: vi.fn((text: string) => Math.ceil(text.length / 4)),
   GEMINI_CHARS_PER_TOKEN: 4,
+  GEMINI_STREAMING_ENABLED: false,
 }));
 
 vi.mock('@/lib/download', () => ({
@@ -1566,7 +1567,9 @@ describe('AudioGenerator', () => {
     };
   }
 
-  it('sends stream: true when Gemini voice and text exceeds threshold', async () => {
+  // HOTFIX: streaming is disabled (GEMINI_STREAMING_ENABLED === false), so the
+  // client no longer requests the SSE path. Re-enable with the flag.
+  it.skip('sends stream: true when Gemini voice and text exceeds threshold', async () => {
     const user = userEvent.setup();
     const fetchMock = vi
       .fn()
@@ -1681,7 +1684,8 @@ describe('AudioGenerator', () => {
     expect(body.stream).toBeUndefined();
   });
 
-  it('schedules audio chunks via Web Audio and shows the streaming player', async () => {
+  // HOTFIX: streaming disabled — see GEMINI_STREAMING_ENABLED.
+  it.skip('schedules audio chunks via Web Audio and shows the streaming player', async () => {
     const user = userEvent.setup();
     const fetchMock = vi
       .fn()
@@ -1726,7 +1730,8 @@ describe('AudioGenerator', () => {
     expect(screen.queryByTestId('audio-player')).not.toBeInTheDocument();
   });
 
-  it('shows error toast on SSE error event', async () => {
+  // HOTFIX: streaming disabled — see GEMINI_STREAMING_ENABLED.
+  it.skip('shows error toast on SSE error event', async () => {
     const user = userEvent.setup();
     const fetchMock = vi
       .fn()

--- a/apps/web/tests/generate-voice.test.ts
+++ b/apps/web/tests/generate-voice.test.ts
@@ -2079,6 +2079,35 @@ describe('Generate Voice API Route', () => {
     });
   });
 
+  describe('Streaming disabled (hotfix)', () => {
+    it('rejects stream: true for gpro31 with 409 and does not debit credits', async () => {
+      const { reduceCredits } = await import('@/lib/supabase/queries');
+
+      const request = new Request('http://localhost/api/generate-voice', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          text: 'Hello world',
+          voiceId: 'voice-achernar-31-id',
+          stream: true,
+        }),
+      });
+
+      const response = await POST(request);
+      const json = await response.json();
+
+      // Stale bundles that still request the SSE path get a fast non-OK
+      // response instead of a JSON body that would hang their SSE parser.
+      expect(response.status).toBe(409);
+      expect(response.headers.get('content-type')).not.toContain(
+        'text/event-stream',
+      );
+      expect(json.error).toBeTruthy();
+      // Fail-fast happens before any credit reservation.
+      expect(reduceCredits).not.toHaveBeenCalled();
+    });
+  });
+
   // HOTFIX: Gemini 3.1 (gpro31) streaming is disabled via GEMINI_STREAMING_ENABLED
   // because progressive streaming corrupted some generations. The SSE path is
   // retained in the route for a future re-enable, so this suite is parked rather

--- a/apps/web/tests/generate-voice.test.ts
+++ b/apps/web/tests/generate-voice.test.ts
@@ -175,7 +175,7 @@ describe('Generate Voice API Route', () => {
       }
     });
 
-    it('should enforce the combined token limit for Gemini 3.1 (gpro31)', async () => {
+    it('should enforce the character limit for Gemini 3.1 (gpro31)', async () => {
       const { getVoiceById } = await import('@/lib/supabase/queries');
       vi.mocked(getVoiceById).mockResolvedValueOnce({
         id: 'voice-gpro31-id',
@@ -184,8 +184,9 @@ describe('Generate Voice API Route', () => {
         model: 'gpro31',
       });
 
-      // Free gpro31 budget is 400 tokens (~1600 chars); 32001 chars (~8001 tokens) exceeds it.
-      const longText = 'a'.repeat(32_001);
+      // HOTFIX: streaming is disabled, so gpro31 uses the standard per-tier
+      // character limits like the Gemini 2.5 voices (500 chars for free users).
+      const longText = 'a'.repeat(501);
 
       const request = new Request('http://localhost/api/generate-voice', {
         method: 'POST',
@@ -199,7 +200,7 @@ describe('Generate Voice API Route', () => {
       const json = await response.json();
 
       expect(response.status).toBe(400);
-      expect(json.error).toContain('tokens');
+      expect(json.error).toContain('maximum length');
     });
 
     it('should return 400 when paid Gemini text exceeds maximum length', async () => {
@@ -1250,7 +1251,9 @@ describe('Generate Voice API Route', () => {
       );
     });
 
-    it('uses Gemini 3.1 for free users streaming gpro31 voices', async () => {
+    // HOTFIX: streaming is disabled (GEMINI_STREAMING_ENABLED === false); gpro31
+    // now uses the non-streaming JSON path. Re-enable with the flag.
+    it.skip('uses Gemini 3.1 for free users streaming gpro31 voices', async () => {
       const generateContentStream = vi
         .fn()
         .mockImplementation(async function* () {
@@ -2076,7 +2079,11 @@ describe('Generate Voice API Route', () => {
     });
   });
 
-  describe('Streaming - Gemini SSE', () => {
+  // HOTFIX: Gemini 3.1 (gpro31) streaming is disabled via GEMINI_STREAMING_ENABLED
+  // because progressive streaming corrupted some generations. The SSE path is
+  // retained in the route for a future re-enable, so this suite is parked rather
+  // than removed — flip the flag back to `true` to restore it.
+  describe.skip('Streaming - Gemini SSE', () => {
     it('streams audio events and done event for Gemini voice', async () => {
       const {
         hasUserPaid,


### PR DESCRIPTION
Customers reported that progressive streaming was corrupting some Gemini
3.1 (gpro31) generations. Disable streaming as a hotfix and revert gpro31
to the pre-streaming input limits.

- Add GEMINI_STREAMING_ENABLED flag (currently false) in lib/ai.ts. It
  gates both the gpro31 SSE streaming path and the larger combined input
  *token* budget that shipped alongside it.
- While disabled, gpro31 uses the non-streaming JSON path and the standard
  per-tier *character* limits (getCharactersLimit, 500 free / 1000 paid)
  with a separate style-prompt cap, exactly like the Gemini 2.5 voices.
- Gate shouldStream/isStreamingModel and the combined-token validation in
  both the server route and the audio-generator client behind the flag.
- The SSE streaming helpers and player remain in place (dormant) so the
  feature can be re-enabled by flipping the flag once the corruption is
  fixed.
- Park the streaming + combined-token tests and add a char-limit test for
  gpro31 to match the reverted behavior.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013CXubV4yu284wi47hKxZkZ