### PR TITLE
fix(billing): charge free users double credits for Gemini 3.1 voices

### DIFF
--- a/apps/web/app/api/estimate-credits/route.ts
+++ b/apps/web/app/api/estimate-credits/route.ts
@@ -210,7 +210,10 @@ export async function POST(request: Request) {
 
     const totalEstimatedTokens = inputTokens + estimatedOutputTokens;
 
-    const credits = calculateCreditsFromTokens(totalEstimatedTokens);
+    const credits = calculateCreditsFromTokens(totalEstimatedTokens, {
+      model,
+      userHasPaid: isPaidUser,
+    });
 
     return NextResponse.json({
       tokens: totalEstimatedTokens,

--- a/apps/web/app/api/generate-voice/route.ts
+++ b/apps/web/app/api/generate-voice/route.ts
@@ -38,6 +38,7 @@ import {
 import { createClient } from '@/lib/supabase/server';
 import {
   buildGeminiTtsPrompt,
+  GEMINI_TTS_31,
   resolveGeminiTtsModel,
 } from '@/lib/tts/gemini-prompt';
 import { generateXaiTts } from '@/lib/tts/xai';
@@ -879,9 +880,12 @@ export async function POST(request: Request) {
     );
 
     if (isGeminiVoice && usage) {
+      // Bill against the model that actually ran (`modelUsed`), not the stored
+      // voice model: a 3.1 request that fell back to 2.5 Flash must not incur
+      // the 3.1 free-user surcharge.
       creditsUsed = calculateCreditsFromTokens(
         Number.parseInt(usage.totalTokenCount, 10),
-        { model: voiceObj.model, userHasPaid },
+        { model: modelUsed, userHasPaid },
       );
     }
 
@@ -1296,9 +1300,12 @@ function streamGeminiTtsResponse({
       // Billing — calculate credits from stream tokens when available.
       let creditsUsed = estimate;
       if (streamUsageMetadata?.totalTokenCount) {
+        // Bill against the model that actually ran (`modelUsed`), which the
+        // stream sets to 2.5 Flash on fallback — so a downgraded 3.1 request
+        // is not charged the 3.1 free-user surcharge.
         creditsUsed = calculateCreditsFromTokens(
           streamUsageMetadata.totalTokenCount,
-          { model: voiceObj.model, userHasPaid },
+          { model: modelUsed, userHasPaid },
         );
       }
       const creditsDebited = await reconcileReservedCredits({

--- a/apps/web/app/api/generate-voice/route.ts
+++ b/apps/web/app/api/generate-voice/route.ts
@@ -407,7 +407,12 @@ export async function POST(request: Request) {
 
     const currentAmount = await getCredits(user.id);
 
-    const estimate = estimateCredits(text, voiceObj.name, voiceObj.model);
+    const estimate = estimateCredits(
+      text,
+      voiceObj.name,
+      voiceObj.model,
+      userHasPaid,
+    );
 
     // console.log({
     //   estimate,
@@ -876,6 +881,7 @@ export async function POST(request: Request) {
     if (isGeminiVoice && usage) {
       creditsUsed = calculateCreditsFromTokens(
         Number.parseInt(usage.totalTokenCount, 10),
+        { model: voiceObj.model, userHasPaid },
       );
     }
 
@@ -1292,6 +1298,7 @@ function streamGeminiTtsResponse({
       if (streamUsageMetadata?.totalTokenCount) {
         creditsUsed = calculateCreditsFromTokens(
           streamUsageMetadata.totalTokenCount,
+          { model: voiceObj.model, userHasPaid },
         );
       }
       const creditsDebited = await reconcileReservedCredits({

--- a/apps/web/lib/utils.ts
+++ b/apps/web/lib/utils.ts
@@ -40,6 +40,24 @@ const GROK_CHAR_BUCKET = 100;
 const GROK_CREDITS_PER_BUCKET = 100;
 const GROK_TTS_DOLLARS_PER_MILLION_CHARS = 4.2;
 
+// Gemini 3.1 (`gpro31`) voices always run on the full Gemini 3.1 model, which
+// costs the provider twice as much per token ($1/$20 per 1M in/out) as the
+// Gemini 2.5 Flash model ($0.5/$10) that free users are downgraded to for
+// `gpro` (2.5) voices. Our base credit rates are calibrated to that 2.5 cost,
+// so free users get 3.1 audio for the price of 2.5. Charge them double for 3.1
+// voices to compensate. Paid users run 2.5 Pro for `gpro` (same cost as 3.1),
+// so they are not affected.
+const GEMINI_31_FREE_CREDIT_MULTIPLIER = 2;
+
+function getGemini31FreeMultiplier(
+  model?: string,
+  userHasPaid?: boolean,
+): number {
+  return model === 'gpro31' && userHasPaid === false
+    ? GEMINI_31_FREE_CREDIT_MULTIPLIER
+    : 1;
+}
+
 export function getTtsProvider(model?: string): TtsProvider {
   if (model === 'gpro' || model === 'gpro31') {
     return 'gemini';
@@ -77,7 +95,11 @@ export function calculateReadingTime(
   return Math.ceil(wordCount / wordsPerMinute);
 }
 
-function getCreditMultiplier(voice: string, model?: string): number {
+function getCreditMultiplier(
+  voice: string,
+  model?: string,
+  userHasPaid?: boolean,
+): number {
   let multiplier: number;
   switch (voice) {
     case 'pietro':
@@ -100,13 +122,14 @@ function getCreditMultiplier(voice: string, model?: string): number {
     multiplier = GEMINI_CREDIT_MULTIPLIER;
   }
 
-  return multiplier;
+  return multiplier * getGemini31FreeMultiplier(model, userHasPaid);
 }
 
 function calculateCredits(
   words: number,
   voice: string,
   model?: string,
+  userHasPaid?: boolean,
 ): number {
   if (!voice) {
     throw new Error('Voice is required');
@@ -118,7 +141,7 @@ function calculateCredits(
 
   // Using average speaking rate of 100 words per minute (middle of 120-150 range)
   const wordsPerSecond = 100 / 60; // 2.25 words per second
-  const multiplier = getCreditMultiplier(voice, model);
+  const multiplier = getCreditMultiplier(voice, model, userHasPaid);
 
   return Math.ceil((words / wordsPerSecond) * 10 * multiplier);
 }
@@ -184,6 +207,7 @@ export function estimateCredits(
   text: string,
   voice: string,
   model?: string,
+  userHasPaid?: boolean,
 ): number {
   const words = countWords(text);
 
@@ -195,7 +219,7 @@ export function estimateCredits(
     return estimateGrokCredits(text);
   }
 
-  return calculateCredits(words, voice, model);
+  return calculateCredits(words, voice, model, userHasPaid);
 }
 
 // Credit calculation constants for gpro voices
@@ -203,14 +227,19 @@ const CREDITS_PER_TOKEN = 1.1;
 
 export function calculateCreditsFromTokens(
   tokenCount: number,
-  // voice?: string,
-  // model?: string,
+  options?: { model?: string; userHasPaid?: boolean },
 ): number {
   const normalizedTokens = Math.max(0, tokenCount);
 
   // Calculate estimated credits based on tokens
-  // Using a ratio that approximates the actual credit consumption
-  return Math.ceil(normalizedTokens * CREDITS_PER_TOKEN);
+  // Using a ratio that approximates the actual credit consumption. Free users
+  // on a Gemini 3.1 voice pay double (see GEMINI_31_FREE_CREDIT_MULTIPLIER).
+  const multiplier = getGemini31FreeMultiplier(
+    options?.model,
+    options?.userHasPaid,
+  );
+
+  return Math.ceil(normalizedTokens * CREDITS_PER_TOKEN * multiplier);
 }
 
 export function capitalizeFirstLetter(str: string) {

--- a/apps/web/lib/utils.ts
+++ b/apps/web/lib/utils.ts
@@ -6,6 +6,7 @@ import type { Prediction } from 'replicate';
 import { twMerge } from 'tailwind-merge';
 
 import type { CloneProvider } from '@/lib/clone/constants';
+import { GEMINI_TTS_31 } from '@/lib/tts/gemini-prompt';
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
@@ -49,11 +50,17 @@ const GROK_TTS_DOLLARS_PER_MILLION_CHARS = 4.2;
 // so they are not affected.
 const GEMINI_31_FREE_CREDIT_MULTIPLIER = 2;
 
+// `model` may be the stored voice token (`gpro31`), used by the estimate and the
+// upfront reservation, or the resolved provider model id, used when billing the
+// actual generation. Keying on both means the surcharge follows the audio that
+// was really produced: a free 3.1 request that errors out and falls back to
+// 2.5 Flash bills at 1×, not 2×.
 function getGemini31FreeMultiplier(
   model?: string,
   userHasPaid?: boolean,
 ): number {
-  return model === 'gpro31' && userHasPaid === false
+  const isGemini31 = model === 'gpro31' || model === GEMINI_TTS_31;
+  return isGemini31 && userHasPaid === false
     ? GEMINI_31_FREE_CREDIT_MULTIPLIER
     : 1;
 }

--- a/apps/web/tests/utils.test.ts
+++ b/apps/web/tests/utils.test.ts
@@ -126,6 +126,26 @@ describe('calculateCreditsFromTokens', () => {
       calculateCreditsFromTokens(100, { model: 'gpro', userHasPaid: false }),
     ).toBe(calculateCreditsFromTokens(100));
   });
+
+  test('should double credits when billed against the resolved 3.1 model id', () => {
+    expect(
+      calculateCreditsFromTokens(100, {
+        model: 'gemini-3.1-flash-tts-preview',
+        userHasPaid: false,
+      }),
+    ).toBe(Math.ceil(100 * 1.1 * 2));
+  });
+
+  test('should not surcharge a free 3.1 request that fell back to 2.5 Flash', () => {
+    // The deduction bills against the model that actually ran; a 2.5 Flash
+    // fallback must stay at 1× even for a free user.
+    expect(
+      calculateCreditsFromTokens(100, {
+        model: 'gemini-2.5-flash-preview-tts',
+        userHasPaid: false,
+      }),
+    ).toBe(calculateCreditsFromTokens(100));
+  });
 });
 
 describe('estimateGrokCredits', () => {

--- a/apps/web/tests/utils.test.ts
+++ b/apps/web/tests/utils.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'vitest';
 
 import {
+  calculateCreditsFromTokens,
   calculateGeminiTtsDollarAmount,
   calculateGrokTtsDollarAmount,
   calculateReadingTime,
@@ -75,6 +76,55 @@ describe('estimateCredits', () => {
     const text = '<fast>Hello</fast> [laugh]';
     const credits = estimateCredits(text, 'eve', 'xai');
     expect(credits).toBe(100); // 27 characters = 1 bucket
+  });
+
+  test('should charge free users roughly double for Gemini 3.1 voices', () => {
+    const text =
+      'This is a longer sentence that should take more time to speak';
+    const paid = estimateCredits(text, 'achernar', 'gpro31', true);
+    const free = estimateCredits(text, 'achernar', 'gpro31', false);
+    // Free users run the full Gemini 3.1 model (twice the cost of the 2.5
+    // Flash model that gpro voices are downgraded to), so they pay double.
+    // ceil() can shift the result by at most 1 credit either side of 2x.
+    expect(free).toBeGreaterThan(paid);
+    expect(free).toBeGreaterThanOrEqual(paid * 2 - 1);
+    expect(free).toBeLessThanOrEqual(paid * 2);
+  });
+
+  test('should not change Gemini 2.5 (gpro) pricing by tier', () => {
+    const text =
+      'This is a longer sentence that should take more time to speak';
+    const paid = estimateCredits(text, 'kore', 'gpro', true);
+    const free = estimateCredits(text, 'kore', 'gpro', false);
+    expect(free).toBe(paid);
+  });
+});
+
+describe('calculateCreditsFromTokens', () => {
+  test('should convert tokens to credits at the base rate', () => {
+    expect(calculateCreditsFromTokens(100)).toBe(Math.ceil(100 * 1.1));
+  });
+
+  test('should clamp negative token counts to zero', () => {
+    expect(calculateCreditsFromTokens(-50)).toBe(0);
+  });
+
+  test('should charge free users double for Gemini 3.1 voices', () => {
+    expect(
+      calculateCreditsFromTokens(100, { model: 'gpro31', userHasPaid: false }),
+    ).toBe(Math.ceil(100 * 1.1 * 2));
+  });
+
+  test('should not double credits for paid Gemini 3.1 users', () => {
+    expect(
+      calculateCreditsFromTokens(100, { model: 'gpro31', userHasPaid: true }),
+    ).toBe(calculateCreditsFromTokens(100));
+  });
+
+  test('should not double credits for Gemini 2.5 (gpro) voices', () => {
+    expect(
+      calculateCreditsFromTokens(100, { model: 'gpro', userHasPaid: false }),
+    ).toBe(calculateCreditsFromTokens(100));
   });
 });
 


### PR DESCRIPTION
Free dashboard users get `gpro` (Gemini 2.5) voices downgraded to the
2.5 Flash model ($0.5/$10 per 1M in/out tokens), and our credit rates
are calibrated to that cost. Gemini 3.1 (`gpro31`) voices have no flash
variant and always run on the full 3.1 model, which costs the provider
twice as much ($1/$20) — the same as 2.5 Pro. That meant free users were
getting 3.1 audio for the price of 2.5 Flash.

Apply a 2x credit multiplier for free users on `gpro31` across the credit
estimate (estimate-credits route), the upfront reservation, and the
actual token-based deduction (generate-voice route, streaming and
non-streaming). Paid users are unaffected: they run 2.5 Pro for `gpro`,
which costs the same as 3.1. The external API (`v1/speech`) is also
unaffected — it runs 2.5 Pro for `gpro` regardless of tier, so `gpro`
and `gpro31` already cost the same there.

Extract the rule into a shared `getGemini31FreeMultiplier` helper used by
both the word-based and token-based credit paths.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01U3tqqbWCYp5TcSRHf3AmAb