### PR TITLE
fix: Clarify ending credit plans

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -21,7 +21,7 @@
 - test and implement text interruptions <https://github.com/livekit/agents-js/pull/998>
 - add duration to generate audios. if there is a high duration and short text, add warning in `usage` JSON col that the audio may be silent for a long time.
 - fix: voice cloning page. audio should stop if sample Marilyn is selected and is hidden / unmounted
-- fix: landing page audios not stopping if another audio is played
+- fix: landing page audios is not stopping if another audio is played
 - Add usage page in Dashboard
 - Update daily-stats API route to include usage and a section for Voice calls. Mins, credits used, Top preset/voice/language and the averages
 - add audio clones demos on landing page
@@ -130,6 +130,8 @@ Ciao, mi chiamo Carlo, <gasp> , e sono un modello di generazione vocale che può
 ## Later
 
 - Multiple API keys functionality. LLM router (<https://github.com/theopenco/llmgateway>, <https://github.com/BerriAI/litellm>)
+- Audio wave preview like <https://www.muna.ai/@kitten-ml/kitten-tts> (canvas)
+- Voice list search and preview like <https://platform.inworld.ai/v2/workspaces/default-g16raugwkppmeeuex7qjla/tts-playground>
 - add a 'Remove background noise' checkbox in the Voice cloning upload step. (Extra 500 credits). 'You can download the cleaned audio after too'.
 
 ## Other Voice cloning demos

--- a/apps/web/app/[lang]/(dashboard)/dashboard/clone/new.client.tsx
+++ b/apps/web/app/[lang]/(dashboard)/dashboard/clone/new.client.tsx
@@ -11,13 +11,6 @@ import {
 } from 'react';
 
 import { useFFmpeg } from '@/app/[lang]/tools/audio-converter/hooks/use-ffmpeg';
-import {
-  CLONE_FORM_FIELDS,
-  type CloneErrorResponseBody,
-  type CloneRouteErrorCode,
-  type CloneSuccessResponse,
-  type RouteErrorDetails,
-} from '@/lib/clone/api-types';
 import { AudioPlayerWithContext } from '@/components/audio-player-with-context';
 import { GenerateButton } from '@/components/generate-button';
 import { toast } from '@/components/services/toast';
@@ -27,6 +20,13 @@ import { Card, CardContent } from '@/components/ui/card';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { useFileUpload } from '@/hooks/use-file-upload';
 import useMediaRecorder from '@/hooks/use-media-recorder';
+import {
+  CLONE_FORM_FIELDS,
+  type CloneErrorResponseBody,
+  type CloneRouteErrorCode,
+  type CloneSuccessResponse,
+  type RouteErrorDetails,
+} from '@/lib/clone/api-types';
 import { VOXTRAL_SUPPORTED_LOCALE_CODES } from '@/lib/clone/constants';
 import {
   createMicrophoneReferenceAudioFile,

--- a/apps/web/app/[lang]/(dashboard)/dashboard/credits/page.tsx
+++ b/apps/web/app/[lang]/(dashboard)/dashboard/credits/page.tsx
@@ -223,7 +223,14 @@ export default async function CreditsPage(props: {
                 date: scheduledSubscriptionEndDate,
               })}
             </p>
-            <Button asChild className="mt-2" size="sm" variant="outline">
+            <Button
+              asChild
+              className="mt-2"
+              icon={ExternalLink}
+              iconPlacement="right"
+              size="sm"
+              variant="secondary"
+            >
               <Link
                 href="https://billing.stripe.com/p/login/28o01hfsn1gUccU8ww"
                 target="_blank"

--- a/apps/web/app/[lang]/(dashboard)/dashboard/credits/page.tsx
+++ b/apps/web/app/[lang]/(dashboard)/dashboard/credits/page.tsx
@@ -40,6 +40,9 @@ function getScheduledSubscriptionEndDate(
   }).format(new Date(customerData.currentPeriodEnd * 1000));
 }
 
+const STRIPE_BILLING_PORTAL_URL =
+  'https://billing.stripe.com/p/login/28o01hfsn1gUccU8ww';
+
 async function canApplyFirstMonthSubscriptionDiscount(stripeId: string) {
   const subscriptionDiscountCouponId =
     process.env.STRIPE_SUBSCRIPTION_FIRST_MONTH_COUPON_ID;
@@ -188,10 +191,7 @@ export default async function CreditsPage(props: {
           <p className="text-muted-foreground">{t('topup.description')}</p>
         </div>
         <Button asChild icon={ExternalLink} iconPlacement="right">
-          <Link
-            href="https://billing.stripe.com/p/login/28o01hfsn1gUccU8ww"
-            target="_blank"
-          >
+          <Link href={STRIPE_BILLING_PORTAL_URL} target="_blank">
             Stripe Customer Portal
           </Link>
         </Button>
@@ -231,10 +231,7 @@ export default async function CreditsPage(props: {
               size="sm"
               variant="secondary"
             >
-              <Link
-                href="https://billing.stripe.com/p/login/28o01hfsn1gUccU8ww"
-                target="_blank"
-              >
+              <Link href={STRIPE_BILLING_PORTAL_URL} target="_blank">
                 {t('subscriptionScheduledToCancel.manageButton')}
               </Link>
             </Button>

--- a/apps/web/app/[lang]/(dashboard)/dashboard/credits/page.tsx
+++ b/apps/web/app/[lang]/(dashboard)/dashboard/credits/page.tsx
@@ -1,15 +1,16 @@
 import { captureException } from '@sentry/nextjs';
-import { ExternalLink, Sparkles } from 'lucide-react';
+import { CircleAlert, ExternalLink, Sparkles } from 'lucide-react';
 import Link from 'next/link';
 import { redirect } from 'next/navigation';
 import { getTranslations } from 'next-intl/server';
 import { Suspense } from 'react';
 
 import PricingTable from '@/components/pricing-table';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import { E2E_CREDIT_TRANSACTIONS, isE2E } from '@/lib/e2e-mocks';
 import type { Locale } from '@/lib/i18n/i18n-config';
-import { getCustomerData } from '@/lib/redis/queries';
+import { type CustomerData, getCustomerData } from '@/lib/redis/queries';
 import { SUBSCRIPTION_BONUS_MULTIPLIER } from '@/lib/stripe/pricing';
 import {
   createOrRetrieveCustomer,
@@ -21,6 +22,23 @@ import { getUserByIdWithError } from '@/lib/supabase/queries';
 import { createClient } from '@/lib/supabase/server';
 import { CreditHistory } from './credit-history';
 import { PaymentStatus } from './payment-status';
+
+function getScheduledSubscriptionEndDate(
+  customerData: CustomerData | null,
+  lang: Locale,
+) {
+  if (
+    customerData?.status !== 'active' ||
+    !customerData.cancelAtPeriodEnd ||
+    !customerData.currentPeriodEnd
+  ) {
+    return null;
+  }
+
+  return new Intl.DateTimeFormat(lang, {
+    dateStyle: 'medium',
+  }).format(new Date(customerData.currentPeriodEnd * 1000));
+}
 
 async function canApplyFirstMonthSubscriptionDiscount(stripeId: string) {
   const subscriptionDiscountCouponId =
@@ -91,6 +109,7 @@ export default async function CreditsPage(props: {
 
   let shouldShowSubscriptionPlans = false;
   let isEligibleForSubscriptionDiscount = false;
+  let scheduledSubscriptionEndDate: string | null = null;
   let existingTransactions:
     | Pick<
         Tables<'credit_transactions'>,
@@ -131,6 +150,11 @@ export default async function CreditsPage(props: {
         shouldShowSubscriptionPlans = false;
       }
     }
+
+    scheduledSubscriptionEndDate = getScheduledSubscriptionEndDate(
+      customerData,
+      lang,
+    );
 
     if (shouldShowSubscriptionPlans) {
       isEligibleForSubscriptionDiscount =
@@ -185,6 +209,30 @@ export default async function CreditsPage(props: {
             })}
           </span>
         </div>
+      ) : null}
+
+      {scheduledSubscriptionEndDate ? (
+        <Alert className="border-amber-500/30 bg-amber-500/10 [&>svg]:text-amber-500">
+          <CircleAlert />
+          <AlertTitle className="line-clamp-none">
+            {t('subscriptionScheduledToCancel.title')}
+          </AlertTitle>
+          <AlertDescription>
+            <p>
+              {t('subscriptionScheduledToCancel.description', {
+                date: scheduledSubscriptionEndDate,
+              })}
+            </p>
+            <Button asChild className="mt-2" size="sm" variant="outline">
+              <Link
+                href="https://billing.stripe.com/p/login/28o01hfsn1gUccU8ww"
+                target="_blank"
+              >
+                {t('subscriptionScheduledToCancel.manageButton')}
+              </Link>
+            </Button>
+          </AlertDescription>
+        </Alert>
       ) : null}
 
       <PricingTable

--- a/apps/web/app/api/generate-voice/route.ts
+++ b/apps/web/app/api/generate-voice/route.ts
@@ -38,7 +38,6 @@ import {
 import { createClient } from '@/lib/supabase/server';
 import {
   buildGeminiTtsPrompt,
-  GEMINI_TTS_31,
   resolveGeminiTtsModel,
 } from '@/lib/tts/gemini-prompt';
 import { generateXaiTts } from '@/lib/tts/xai';
@@ -1493,7 +1492,7 @@ function streamGeminiTtsResponse({
 
       const isProhibitedContent =
         Error.isError(error) && error.cause === 'PROHIBITED_CONTENT';
-      if (!audioStarted && !isProhibitedContent) {
+      if (!(audioStarted || isProhibitedContent)) {
         captureException(error, {
           extra: { model: modelUsed, voice: voiceObj.name, stream: true },
           user: { id: user.id },

--- a/apps/web/lib/clone/api-types.ts
+++ b/apps/web/lib/clone/api-types.ts
@@ -33,18 +33,18 @@ export type CloneRouteErrorCode =
 
 /** Shape of the JSON body returned by every clone-voice error response. */
 export interface CloneErrorResponseBody {
+  code?: CloneRouteErrorCode;
+  details?: RouteErrorDetails;
   error: string;
   serverMessage: string;
   status: number;
-  code?: CloneRouteErrorCode;
-  details?: RouteErrorDetails;
 }
 
 /** Shape of the JSON body returned by a successful clone-voice request. */
 export interface CloneSuccessResponse {
-  url: string;
-  creditsUsed: number;
   creditsRemaining: number;
+  creditsUsed: number;
+  url: string;
 }
 
 /** Names of the multipart form fields accepted by `POST /api/clone-voice`. */

--- a/apps/web/messages/da.json
+++ b/apps/web/messages/da.json
@@ -272,7 +272,11 @@
       "starter": {
         "name": "Starter",
         "description": "For afslappede brugere, der udforsker AI-lyd.",
-        "features": ["Alt i Gratis", "2× længere tekstgenerering", "API-adgang"]
+        "features": [
+          "Alt i Gratis",
+          "2× længere tekstgenerering",
+          "API-adgang"
+        ]
       },
       "standard": {
         "name": "Standard",

--- a/apps/web/messages/da.json
+++ b/apps/web/messages/da.json
@@ -272,11 +272,7 @@
       "starter": {
         "name": "Starter",
         "description": "For afslappede brugere, der udforsker AI-lyd.",
-        "features": [
-          "Alt i Gratis",
-          "2× længere tekstgenerering",
-          "API-adgang"
-        ]
+        "features": ["Alt i Gratis", "2× længere tekstgenerering", "API-adgang"]
       },
       "standard": {
         "name": "Standard",
@@ -299,6 +295,11 @@
           "Stemmeopkald: Brugerdefinerede karakterer"
         ]
       }
+    },
+    "subscriptionScheduledToCancel": {
+      "title": "Dit månedlige kreditabonnement er planlagt til at ophøre",
+      "description": "Dit månedlige kreditabonnement er stadig aktivt indtil {date}, men det fornyes ikke og tilføjer ikke flere månedlige kreditter efter det. Du kan fortsætte med at bruge de kreditter, du har på din konto. Hvis du vil skifte niveau, skal du administrere dit abonnement i Stripe.",
+      "manageButton": "Administrer abonnement"
     },
     "topup": {
       "title": "Køb kreditter",

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -300,6 +300,11 @@
         ]
       }
     },
+    "subscriptionScheduledToCancel": {
+      "title": "Ihr monatlicher Credit-Plan endet demnächst",
+      "description": "Ihr monatlicher Credit-Plan ist noch bis zum {date} aktiv, wird danach aber nicht verlängert und fügt keine weiteren monatlichen Credits hinzu. Sie können alle Credits in Ihrem Konto weiter nutzen. Um die Stufe zu wechseln, verwalten Sie Ihr Abonnement in Stripe.",
+      "manageButton": "Abonnement verwalten"
+    },
     "topup": {
       "title": "Credits kaufen",
       "description": "Füllen Sie Ihre Credits sofort auf oder abonnieren Sie und erhalten Sie mehr Credits",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -295,7 +295,9 @@
         "description": "For bigger creative needs and bolder content.",
         "creditsWithAudio": "{numCredits} credits (~125 minutes of audio)",
         "creditsWithPromo": "{numCredits} credits",
-        "features": ["Everything in Standard, just cheaper"]
+        "features": [
+          "Everything in Standard, just cheaper"
+        ]
       }
     },
     "subscriptionScheduledToCancel": {

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -295,10 +295,13 @@
         "description": "For bigger creative needs and bolder content.",
         "creditsWithAudio": "{numCredits} credits (~125 minutes of audio)",
         "creditsWithPromo": "{numCredits} credits",
-        "features": [
-          "Everything in Standard, just cheaper"
-        ]
+        "features": ["Everything in Standard, just cheaper"]
       }
+    },
+    "subscriptionScheduledToCancel": {
+      "title": "Your monthly credit plan is scheduled to end",
+      "description": "Your monthly credit plan is still active until {date}, but it won’t renew or add more monthly credits after that. You can keep using any credits in your account. To switch tiers, manage your subscription in Stripe.",
+      "manageButton": "Manage subscription"
     },
     "topup": {
       "title": "Buy Credits",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -300,6 +300,11 @@
         ]
       }
     },
+    "subscriptionScheduledToCancel": {
+      "title": "Tu plan mensual de créditos está programado para finalizar",
+      "description": "Tu plan mensual de créditos sigue activo hasta el {date}, pero después no se renovará ni añadirá más créditos mensuales. Puedes seguir usando los créditos que tengas en tu cuenta. Para cambiar de nivel, gestiona tu suscripción en Stripe.",
+      "manageButton": "Gestionar suscripción"
+    },
     "topup": {
       "title": "Comprar Créditos",
       "description": "Recarga tus créditos instantáneamente o suscríbete y obtén más créditos",

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -300,6 +300,11 @@
         ]
       }
     },
+    "subscriptionScheduledToCancel": {
+      "title": "Votre forfait mensuel de crédits est programmé pour se terminer",
+      "description": "Votre forfait mensuel de crédits reste actif jusqu’au {date}, mais il ne sera pas renouvelé et n’ajoutera plus de crédits mensuels ensuite. Vous pouvez continuer à utiliser les crédits disponibles sur votre compte. Pour changer de niveau, gérez votre abonnement dans Stripe.",
+      "manageButton": "Gérer l’abonnement"
+    },
     "topup": {
       "title": "Acheter des crédits",
       "description": "Rechargez vos crédits instantanément ou abonnez-vous et obtenez plus de crédits",

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -300,6 +300,11 @@
         ]
       }
     },
+    "subscriptionScheduledToCancel": {
+      "title": "Il tuo piano mensile di crediti è programmato per terminare",
+      "description": "Il tuo piano mensile di crediti è ancora attivo fino al {date}, ma dopo non si rinnoverà né aggiungerà altri crediti mensili. Puoi continuare a usare i crediti presenti nel tuo account. Per cambiare livello, gestisci l’abbonamento in Stripe.",
+      "manageButton": "Gestisci abbonamento"
+    },
     "topup": {
       "title": "Acquista crediti",
       "description": "Ricarica i tuoi crediti istantaneamente o abbonati e ottieni più crediti",


### PR DESCRIPTION
## Summary
- Add a dashboard alert for active Stripe subscriptions scheduled to cancel at period end.
- Clarify that the monthly credit plan remains active until the end date, then stops renewing and adding monthly credits.
- Keep subscription checkout hidden for active subscriptions to avoid creating duplicate Stripe subscriptions.
- Add localized copy for all supported web locales.

## Validation
- pnpm check-translations
- pnpm --dir apps/web exec biome check app/[lang]/(dashboard)/dashboard/credits/page.tsx messages/da.json messages/de.json messages/en.json messages/es.json messages/fr.json messages/it.json
- pnpm type-check

Note: pnpm fixall was attempted, but the repo currently has unrelated pre-existing lint failures outside this change.