### PR TITLE
Refine voice error handling and Sentry filters

### DIFF
--- a/apps/web/app/api/generate-voice/route.ts
+++ b/apps/web/app/api/generate-voice/route.ts
@@ -663,10 +663,11 @@ export async function POST(request: Request) {
       const isProhibitedContent =
         finishReason === FinishReason.PROHIBITED_CONTENT ||
         blockReason === 'PROHIBITED_CONTENT';
-      // Finished normally but no audio came back — transient provider glitch
-      // rather than a content block, so surface it as retryable.
+      // Finished without audio — transient provider glitch rather than a content
+      // block, so surface it as retryable. Gemini 3.1 may report this as OTHER.
       const isNoAudioData =
-        finishReason === FinishReason.STOP && !(data && mimeType);
+        (finishReason === FinishReason.STOP || finishReason === 'OTHER') &&
+        !(data && mimeType);
 
       if (finishReason !== FinishReason.STOP || !data || !mimeType) {
         if (isProhibitedContent) {

--- a/apps/web/app/api/generate-voice/route.ts
+++ b/apps/web/app/api/generate-voice/route.ts
@@ -666,7 +666,8 @@ export async function POST(request: Request) {
       // Finished without audio — transient provider glitch rather than a content
       // block, so surface it as retryable. Gemini 3.1 may report this as OTHER.
       const isNoAudioData =
-        (finishReason === FinishReason.STOP || finishReason === 'OTHER') &&
+        (finishReason === FinishReason.STOP ||
+          finishReason === FinishReason.OTHER) &&
         !(data && mimeType);
 
       if (finishReason !== FinishReason.STOP || !data || !mimeType) {

--- a/apps/web/lib/sentry/client-filters.ts
+++ b/apps/web/lib/sentry/client-filters.ts
@@ -26,16 +26,22 @@ const reactDomMutationNoisePatterns = [
   reactRemoveChildNotFoundPattern,
   /Failed to execute 'insertBefore' on 'Node': The node before which the new node is to be inserted is not a child of this node/i,
   /Cannot read properties of null \(reading 'removeChild'\)/i,
-  /NotFoundError: The object can not be found here/i,
+  /(?:NotFoundError[:\s]+)?The object can not be found here/i,
 ];
 
 const reactHydrationRecoverablePattern =
   /^(Hydration failed because the server rendered HTML didn't match the client|There was an error while hydrating|Text content does not match server-rendered HTML|Hydration Error)/i;
 
 const rscConnectionClosedPattern = /^Connection closed\.$/i;
+const nextClientTransientPattern =
+  /^(?:Error\s+)?(Connection closed\.|An unexpected response was received from the server\.)$/i;
+const reactRenderLifecycleNoisePattern =
+  /Maximum update depth exceeded|Rendered more hooks than during the previous render/i;
 
 const reactCommitDeletionFramePattern =
   /commitDeletionEffectsOnFiber|commitMutationEffectsOnFiber|recursivelyTraverseMutationEffects|react-dom-client|react-server-dom/i;
+const nextClientFrameworkFramePattern =
+  /app-router|react-dom-client|react-server-dom|server-action-reducer|next\/src\/client|next\/dist\/compiled\/react/i;
 const thirdPartyScriptFramePattern = /posthog-recorder\.js|addEL_hook/i;
 const localAppFramePattern = /apps\/web|\/_next\/static\/chunks\/app\//i;
 const browserMediaNoisePattern =
@@ -46,6 +52,8 @@ const injectedBrowserGlobalPattern =
   /(?:Can't find variable: __firefox__|window\.__firefox__|window\.ethereum\.selectedAddress)/i;
 const externalWorkerImportPattern =
   /Failed to execute 'importScripts' on 'WorkerGlobalScope': The script at 'https?:\/\/(?!([^/]+\.)?sexyvoice\.ai\/)[^']+' failed to load/i;
+const staleNextWorkerImportPattern =
+  /Failed to execute 'importScripts' on 'WorkerGlobalScope': The script at 'https?:\/\/(www\.)?sexyvoice\.ai\/_next\/static\/chunks\/[^']+' failed to load/i;
 const webViewBridgeNoisePattern =
   /WKWebView API client did not respond to this postMessage/i;
 const transientBrowserNetworkPattern =
@@ -54,6 +62,9 @@ const browserSecurityNoisePattern =
   /Permission to call 'get parentNode' denied|The request was denied/i;
 const nullTagNamePattern =
   /Cannot read properties of null \(reading 'tagName'\)/i;
+const prosemirrorSelectionCollapsePattern =
+  /Failed to execute 'collapse' on 'Selection': The offset \d+ is larger than the node's length \(\d+\)\./i;
+const prosemirrorFramePattern = /prosemirror-view/i;
 
 function getExceptionText(exception: SentryException): string {
   return [exception.type, exception.value].filter(Boolean).join(' ');
@@ -69,12 +80,24 @@ function frameMatchesReactInternals(frame: SentryStackFrame): boolean {
   return reactCommitDeletionFramePattern.test(getFrameText(frame));
 }
 
+function frameMatchesNextClientFramework(frame: SentryStackFrame): boolean {
+  return nextClientFrameworkFramePattern.test(getFrameText(frame));
+}
+
 function frameMatchesThirdPartyScript(frame: SentryStackFrame): boolean {
   return thirdPartyScriptFramePattern.test(getFrameText(frame));
 }
 
 function frameMatchesLocalApp(frame: SentryStackFrame): boolean {
   return localAppFramePattern.test(getFrameText(frame));
+}
+
+function frameMatchesProsemirror(frame: SentryStackFrame): boolean {
+  return prosemirrorFramePattern.test(getFrameText(frame));
+}
+
+function framesHaveNoLocalAppFrame(frames: SentryStackFrame[]): boolean {
+  return frames.length === 0 || !frames.some(frameMatchesLocalApp);
 }
 
 function isReactDomNoiseException(exception: SentryException): boolean {
@@ -94,6 +117,21 @@ function isReactDomNoiseException(exception: SentryException): boolean {
     frames.length === 0 ||
     frames.some(frameMatchesReactInternals) ||
     !frames.some(frameMatchesLocalApp)
+  );
+}
+
+function isReactRenderLifecycleNoiseException(
+  exception: SentryException,
+): boolean {
+  const exceptionText = getExceptionText(exception);
+  if (!reactRenderLifecycleNoisePattern.test(exceptionText)) {
+    return false;
+  }
+
+  const frames = exception.stacktrace?.frames ?? [];
+  return (
+    framesHaveNoLocalAppFrame(frames) &&
+    (frames.length === 0 || frames.some(frameMatchesReactInternals))
   );
 }
 
@@ -121,6 +159,7 @@ function isBrowserRuntimeNoiseException(exception: SentryException): boolean {
       opaqueBrowserEventRejectionPattern.test(exceptionText) ||
       injectedBrowserGlobalPattern.test(exceptionText) ||
       externalWorkerImportPattern.test(exceptionText) ||
+      staleNextWorkerImportPattern.test(exceptionText) ||
       webViewBridgeNoisePattern.test(exceptionText) ||
       transientBrowserNetworkPattern.test(exceptionText)
     )
@@ -129,7 +168,34 @@ function isBrowserRuntimeNoiseException(exception: SentryException): boolean {
   }
 
   const frames = exception.stacktrace?.frames ?? [];
-  return frames.length === 0 || !frames.some(frameMatchesLocalApp);
+  return framesHaveNoLocalAppFrame(frames);
+}
+
+function isNextClientTransientException(exception: SentryException): boolean {
+  const exceptionText = getExceptionText(exception);
+  if (!nextClientTransientPattern.test(exceptionText)) {
+    return false;
+  }
+
+  const frames = exception.stacktrace?.frames ?? [];
+  return (
+    framesHaveNoLocalAppFrame(frames) &&
+    (frames.length === 0 || frames.some(frameMatchesNextClientFramework))
+  );
+}
+
+function isProsemirrorSelectionNoiseException(
+  exception: SentryException,
+): boolean {
+  const exceptionText = getExceptionText(exception);
+  if (!prosemirrorSelectionCollapsePattern.test(exceptionText)) {
+    return false;
+  }
+
+  const frames = exception.stacktrace?.frames ?? [];
+  return (
+    framesHaveNoLocalAppFrame(frames) && frames.some(frameMatchesProsemirror)
+  );
 }
 
 export function shouldDropClientSentryEvent(event: SentryClientEvent): boolean {
@@ -139,11 +205,23 @@ export function shouldDropClientSentryEvent(event: SentryClientEvent): boolean {
     return true;
   }
 
+  if (exceptions.some(isReactRenderLifecycleNoiseException)) {
+    return true;
+  }
+
+  if (exceptions.some(isNextClientTransientException)) {
+    return true;
+  }
+
   if (exceptions.some(isThirdPartyScriptNoiseException)) {
     return true;
   }
 
   if (exceptions.some(isBrowserRuntimeNoiseException)) {
+    return true;
+  }
+
+  if (exceptions.some(isProsemirrorSelectionNoiseException)) {
     return true;
   }
 

--- a/apps/web/lib/sentry/client-filters.ts
+++ b/apps/web/lib/sentry/client-filters.ts
@@ -51,9 +51,9 @@ const opaqueBrowserEventRejectionPattern =
 const injectedBrowserGlobalPattern =
   /(?:Can't find variable: __firefox__|window\.__firefox__|window\.ethereum\.selectedAddress)/i;
 const externalWorkerImportPattern =
-  /Failed to execute 'importScripts' on 'WorkerGlobalScope': The script at 'https?:\/\/(?!([^/]+\.)?sexyvoice\.ai\/)[^']+' failed to load/i;
+  /Failed to execute 'importScripts' on 'WorkerGlobalScope': The script at 'https?:\/\/(?!([^/]+\.)?sexyvoice\.ai\/)(?![^']*\/_next\/static\/chunks\/)[^']+' failed to load/i;
 const staleNextWorkerImportPattern =
-  /Failed to execute 'importScripts' on 'WorkerGlobalScope': The script at 'https?:\/\/(www\.)?sexyvoice\.ai\/_next\/static\/chunks\/[^']+' failed to load/i;
+  /Failed to execute 'importScripts' on 'WorkerGlobalScope': The script at 'https?:\/\/[^']+\/_next\/static\/chunks\/[^']+' failed to load/i;
 const webViewBridgeNoisePattern =
   /WKWebView API client did not respond to this postMessage/i;
 const transientBrowserNetworkPattern =

--- a/apps/web/lib/sentry/client-filters.ts
+++ b/apps/web/lib/sentry/client-filters.ts
@@ -44,6 +44,7 @@ const nextClientFrameworkFramePattern =
   /app-router|react-dom-client|react-server-dom|server-action-reducer|next\/src\/client|next\/dist\/compiled\/react/i;
 const thirdPartyScriptFramePattern = /posthog-recorder\.js|addEL_hook/i;
 const localAppFramePattern = /apps\/web|\/_next\/static\/chunks\/app\//i;
+const nextSharedChunkFramePattern = /\/_next\/static\/chunks\/(?!app\/)/i;
 const browserMediaNoisePattern =
   /Track has ended|WASM_OR_WORKER_NOT_READY|Wasm SIMD unsupported|Lock was stolen by another request/i;
 const opaqueBrowserEventRejectionPattern =
@@ -92,6 +93,10 @@ function frameMatchesLocalApp(frame: SentryStackFrame): boolean {
   return localAppFramePattern.test(getFrameText(frame));
 }
 
+function frameMatchesNextSharedChunk(frame: SentryStackFrame): boolean {
+  return nextSharedChunkFramePattern.test(getFrameText(frame));
+}
+
 function frameMatchesProsemirror(frame: SentryStackFrame): boolean {
   return prosemirrorFramePattern.test(getFrameText(frame));
 }
@@ -129,6 +134,10 @@ function isReactRenderLifecycleNoiseException(
   }
 
   const frames = exception.stacktrace?.frames ?? [];
+  if (frames.some(frameMatchesNextSharedChunk)) {
+    return false;
+  }
+
   return (
     framesHaveNoLocalAppFrame(frames) &&
     (frames.length === 0 || frames.some(frameMatchesReactInternals))

--- a/apps/web/tests/generate-voice.test.ts
+++ b/apps/web/tests/generate-voice.test.ts
@@ -1727,6 +1727,57 @@ describe('Generate Voice API Route', () => {
       );
     });
 
+    it('should return 503 without Sentry capture when Gemini finishes with OTHER and no audio data', async () => {
+      setMockGoogleGenAIFactory(() => ({
+        models: {
+          generateContent: vi.fn().mockResolvedValue({
+            candidates: [
+              {
+                finishReason: 'OTHER',
+                content: {
+                  parts: [],
+                },
+              },
+            ],
+          }),
+        },
+      }));
+
+      const request = new Request('http://localhost/api/generate-voice', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          text: 'Hello world',
+          voiceId: 'voice-achernar-31-id',
+        }),
+      });
+
+      const response = await POST(request);
+      const json = await response.json();
+
+      expect(response.status).toBe(503);
+      expect(json.error).toBe(
+        getErrorMessage('NO_AUDIO_DATA', 'voice-generation'),
+      );
+      expect(Sentry.captureException).not.toHaveBeenCalled();
+      expect(Sentry.logger.warn).toHaveBeenCalledWith(
+        'Gemini voice generation returned no audio data',
+        expect.objectContaining({
+          extra: expect.objectContaining({
+            finishReason: 'OTHER',
+            model: 'gemini-3.1-flash-tts-preview',
+            voice: 'achernar',
+          }),
+          user: {
+            id: 'test-user-id',
+            email: 'test@example.com',
+          },
+        }),
+      );
+    });
+
     it('should throw error when Gemini response has no data', async () => {
       // Mock Gemini to return response without data (both pro and flash will fail)
       setMockGoogleGenAIFactory(() => ({

--- a/apps/web/tests/generate-voice.test.ts
+++ b/apps/web/tests/generate-voice.test.ts
@@ -1733,7 +1733,7 @@ describe('Generate Voice API Route', () => {
           generateContent: vi.fn().mockResolvedValue({
             candidates: [
               {
-                finishReason: 'OTHER',
+                finishReason: FinishReason.OTHER,
                 content: {
                   parts: [],
                 },
@@ -1766,7 +1766,7 @@ describe('Generate Voice API Route', () => {
         'Gemini voice generation returned no audio data',
         expect.objectContaining({
           extra: expect.objectContaining({
-            finishReason: 'OTHER',
+            finishReason: FinishReason.OTHER,
             model: 'gemini-3.1-flash-tts-preview',
             voice: 'achernar',
           }),

--- a/apps/web/tests/sentry-client-filters.test.ts
+++ b/apps/web/tests/sentry-client-filters.test.ts
@@ -495,6 +495,29 @@ describe('shouldDropClientSentryEvent', () => {
         },
       }),
     ).toBe(true);
+
+    expect(
+      shouldDropClientSentryEvent({
+        exception: {
+          values: [
+            {
+              type: 'Error',
+              value:
+                "Uncaught NetworkError: Failed to execute 'importScripts' on 'WorkerGlobalScope': The script at 'https://sexyvoice-git-fix-sentry.vercel.app/_next/static/chunks/0a1ki9igslyi1.js?dpl=dpl_F6PAqfgpYrrgLMxCTpLSnibogqzK' failed to load.",
+              stacktrace: {
+                frames: [
+                  {
+                    filename:
+                      'app:///_next/static/chunks/turbopack-worker-0g5kymvzkx-yr.js',
+                    function: 'global code',
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      }),
+    ).toBe(true);
   });
 
   it('does not drop injected browser global text with app frames', () => {

--- a/apps/web/tests/sentry-client-filters.test.ts
+++ b/apps/web/tests/sentry-client-filters.test.ts
@@ -25,6 +25,31 @@ describe('shouldDropClientSentryEvent', () => {
         },
       }),
     ).toBe(true);
+
+    expect(
+      shouldDropClientSentryEvent({
+        exception: {
+          values: [
+            {
+              type: 'NotFoundError',
+              value: 'The object can not be found here.',
+              stacktrace: {
+                frames: [
+                  {
+                    filename: 'react-dom-client.production.js',
+                    function: 'commitDeletionEffectsOnFiber',
+                  },
+                  {
+                    filename: '[native code]',
+                    function: 'removeChild',
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      }),
+    ).toBe(true);
   });
 
   it('does not drop app exceptions that only look superficially similar', () => {
@@ -118,6 +143,75 @@ describe('shouldDropClientSentryEvent', () => {
     expect(shouldDropClientSentryEvent({ message: 'Connection closed.' })).toBe(
       true,
     );
+  });
+
+  it('drops framework-only Next client transient exceptions', () => {
+    expect(
+      shouldDropClientSentryEvent({
+        exception: {
+          values: [
+            {
+              type: 'Error',
+              value: 'Connection closed.',
+              stacktrace: {
+                frames: [
+                  {
+                    filename:
+                      'react-server-dom-turbopack-client.browser.production.js',
+                    function: 'close',
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldDropClientSentryEvent({
+        exception: {
+          values: [
+            {
+              type: 'Error',
+              value: 'An unexpected response was received from the server.',
+              stacktrace: {
+                frames: [
+                  {
+                    filename:
+                      'node_modules/next/src/client/components/router-reducer/reducers/server-action-reducer.ts',
+                    function: 'fetchServerAction',
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it('keeps Next client transient exceptions with app frames', () => {
+    expect(
+      shouldDropClientSentryEvent({
+        exception: {
+          values: [
+            {
+              type: 'Error',
+              value: 'An unexpected response was received from the server.',
+              stacktrace: {
+                frames: [
+                  {
+                    filename: 'apps/web/app/[lang]/login/actions.ts',
+                    function: 'login',
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      }),
+    ).toBe(false);
   });
 
   it('drops PostHog recorder security errors', () => {
@@ -237,6 +331,78 @@ describe('shouldDropClientSentryEvent', () => {
     ).toBe(true);
   });
 
+  it('drops framework-only React render loop noise', () => {
+    expect(
+      shouldDropClientSentryEvent({
+        exception: {
+          values: [
+            {
+              type: 'Error',
+              value:
+                'Maximum update depth exceeded. This can happen when a component repeatedly calls setState inside componentWillUpdate or componentDidUpdate.',
+              stacktrace: {
+                frames: [
+                  {
+                    filename: 'react-dom-client.production.js',
+                    function: 'dispatchSetStateInternal',
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldDropClientSentryEvent({
+        exception: {
+          values: [
+            {
+              type: 'Error',
+              value: 'Rendered more hooks than during the previous render.',
+              stacktrace: {
+                frames: [
+                  {
+                    filename: 'next/src/client/components/app-router.tsx',
+                    function: 'Router',
+                  },
+                  {
+                    filename: 'react-dom-client.production.js',
+                    function: 'updateWorkInProgressHook',
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it('keeps React render loop errors with app frames', () => {
+    expect(
+      shouldDropClientSentryEvent({
+        exception: {
+          values: [
+            {
+              type: 'Error',
+              value: 'Maximum update depth exceeded.',
+              stacktrace: {
+                frames: [
+                  {
+                    filename: 'apps/web/components/audio-generator.tsx',
+                    function: 'AudioGenerator',
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      }),
+    ).toBe(false);
+  });
+
   it('keeps Wasm SIMD errors with app frames', () => {
     expect(
       shouldDropClientSentryEvent({
@@ -306,6 +472,29 @@ describe('shouldDropClientSentryEvent', () => {
         },
       }),
     ).toBe(true);
+
+    expect(
+      shouldDropClientSentryEvent({
+        exception: {
+          values: [
+            {
+              type: 'Error',
+              value:
+                "Uncaught NetworkError: Failed to execute 'importScripts' on 'WorkerGlobalScope': The script at 'https://sexyvoice.ai/_next/static/chunks/0a1ki9igslyi1.js?dpl=dpl_F6PAqfgpYrrgLMxCTpLSnibogqzK' failed to load.",
+              stacktrace: {
+                frames: [
+                  {
+                    filename:
+                      'app:///_next/static/chunks/turbopack-worker-0g5kymvzkx-yr.js',
+                    function: 'global code',
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      }),
+    ).toBe(true);
   });
 
   it('does not drop injected browser global text with app frames', () => {
@@ -361,5 +550,54 @@ describe('shouldDropClientSentryEvent', () => {
         },
       }),
     ).toBe(true);
+  });
+
+  it('drops ProseMirror selection collapse noise without app frames', () => {
+    expect(
+      shouldDropClientSentryEvent({
+        exception: {
+          values: [
+            {
+              type: 'IndexSizeError',
+              value:
+                "Failed to execute 'collapse' on 'Selection': The offset 37 is larger than the node's length (36).",
+              stacktrace: {
+                frames: [
+                  {
+                    filename:
+                      'node_modules/.pnpm/prosemirror-view@1.41.6/node_modules/prosemirror-view/dist/index.js',
+                    function: 'df.setSelection',
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it('keeps ProseMirror selection errors with app frames', () => {
+    expect(
+      shouldDropClientSentryEvent({
+        exception: {
+          values: [
+            {
+              type: 'IndexSizeError',
+              value:
+                "Failed to execute 'collapse' on 'Selection': The offset 37 is larger than the node's length (36).",
+              stacktrace: {
+                frames: [
+                  {
+                    filename: 'apps/web/components/grok-tts-editor.tsx',
+                    function: 'restoreSelection',
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      }),
+    ).toBe(false);
   });
 });

--- a/apps/web/tests/sentry-client-filters.test.ts
+++ b/apps/web/tests/sentry-client-filters.test.ts
@@ -380,7 +380,7 @@ describe('shouldDropClientSentryEvent', () => {
     ).toBe(true);
   });
 
-  it('keeps React render loop errors with app frames', () => {
+  it('keeps React render loop errors with app or shared chunk frames', () => {
     expect(
       shouldDropClientSentryEvent({
         exception: {
@@ -393,6 +393,28 @@ describe('shouldDropClientSentryEvent', () => {
                   {
                     filename: 'apps/web/components/audio-generator.tsx',
                     function: 'AudioGenerator',
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      }),
+    ).toBe(false);
+
+    expect(
+      shouldDropClientSentryEvent({
+        exception: {
+          values: [
+            {
+              type: 'Error',
+              value: 'Maximum update depth exceeded.',
+              stacktrace: {
+                frames: [
+                  {
+                    filename:
+                      'https://sexyvoice.ai/_next/static/chunks/1234.js',
+                    module: 'react-dom-client',
                   },
                 ],
               },


### PR DESCRIPTION
## Summary
- Treat Gemini 3.1 `OTHER` responses with no audio as retryable `NO_AUDIO_DATA` failures
- Expand client-side Sentry noise filtering for Next.js transient errors, React render loops, stale worker imports, and ProseMirror selection noise
- Add coverage for the new voice-generation and Sentry filter cases

## Testing
- Added unit tests for the voice generation route and client Sentry filter behavior
- Not run (not requested)