### PR TITLE
feat(voice-call): add privacy and custom character sections to landing page

### DIFF
--- a/apps/web/app/[lang]/page.tsx
+++ b/apps/web/app/[lang]/page.tsx
@@ -11,7 +11,6 @@ import type { Metadata } from 'next';
 import Image from 'next/image';
 import { redirect } from 'next/navigation';
 import { getMessages, setRequestLocale } from 'next-intl/server';
-import type { ReactNode } from 'react';
 import type { Graph } from 'schema-dts';
 
 import type { Locale } from '@/lib/i18n/i18n-config';
@@ -21,6 +20,7 @@ import { Link } from '@/lib/i18n/navigation';
 // import { PopularAudios } from '@/components/popular-audios';
 
 import { Banner } from '@/components/banner';
+import { CardDecorator } from '@/components/card-decorator';
 import { FAQComponent } from '@/components/faq';
 import Footer from '@/components/footer';
 import { HeaderStatic } from '@/components/header-static';
@@ -376,11 +376,3 @@ export default async function LandingPage(props: {
     </>
   );
 }
-
-const CardDecorator = ({ children }: { children: ReactNode }) => (
-  <div className="mx-auto grid size-36 place-items-center">
-    <div className="flex size-12 items-center justify-center rounded-sm border-t border-l bg-brand-red/65">
-      {children}
-    </div>
-  </div>
-);

--- a/apps/web/app/[lang]/page.tsx
+++ b/apps/web/app/[lang]/page.tsx
@@ -241,7 +241,7 @@ export default async function LandingPage(props: {
                   </CardHeader>
 
                   <CardContent>
-                    <p className="text-pretty text-center text-sm transition-colors group-hover:text-promo-accent">
+                    <p className="text-justify text-sm transition-colors group-hover:text-promo-accent">
                       {dictLanding.features.voiceCalling.description}
                     </p>
                   </CardContent>
@@ -258,7 +258,7 @@ export default async function LandingPage(props: {
                   </h3>
                 </CardHeader>
                 <CardContent>
-                  <p className="text-pretty text-center text-sm">
+                  <p className="text-justify text-sm">
                     {dictLanding.features.security.description}
                   </p>
                 </CardContent>
@@ -275,7 +275,7 @@ export default async function LandingPage(props: {
                 </CardHeader>
 
                 <CardContent>
-                  <p className="text-pretty text-center text-sm">
+                  <p className="text-justify text-sm">
                     {dictLanding.features.voiceCloning.description}
                   </p>
                 </CardContent>
@@ -293,7 +293,7 @@ export default async function LandingPage(props: {
                 </CardHeader>
 
                 <CardContent>
-                  <p className="text-pretty text-center text-sm">
+                  <p className="text-justify text-sm">
                     {dictLanding.features.multiLanguage.description}
                   </p>
                 </CardContent>

--- a/apps/web/app/[lang]/page.tsx
+++ b/apps/web/app/[lang]/page.tsx
@@ -241,7 +241,7 @@ export default async function LandingPage(props: {
                   </CardHeader>
 
                   <CardContent>
-                    <p className="text-justify text-sm transition-colors group-hover:text-promo-accent">
+                    <p className="text-pretty text-center text-sm transition-colors group-hover:text-promo-accent">
                       {dictLanding.features.voiceCalling.description}
                     </p>
                   </CardContent>
@@ -258,7 +258,7 @@ export default async function LandingPage(props: {
                   </h3>
                 </CardHeader>
                 <CardContent>
-                  <p className="text-justify text-sm">
+                  <p className="text-pretty text-center text-sm">
                     {dictLanding.features.security.description}
                   </p>
                 </CardContent>
@@ -275,7 +275,7 @@ export default async function LandingPage(props: {
                 </CardHeader>
 
                 <CardContent>
-                  <p className="text-justify text-sm">
+                  <p className="text-pretty text-center text-sm">
                     {dictLanding.features.voiceCloning.description}
                   </p>
                 </CardContent>
@@ -293,7 +293,7 @@ export default async function LandingPage(props: {
                 </CardHeader>
 
                 <CardContent>
-                  <p className="text-justify text-sm">
+                  <p className="text-pretty text-center text-sm">
                     {dictLanding.features.multiLanguage.description}
                   </p>
                 </CardContent>

--- a/apps/web/app/[lang]/voice-call/page.tsx
+++ b/apps/web/app/[lang]/voice-call/page.tsx
@@ -238,7 +238,7 @@ export default async function LandingPage(props: Props) {
                   >
                     <Link href="/signup">{dictCustomCharacter.action}</Link>
                   </Button>
-                  <p className="text-gray-400 text-xs">
+                  <p className="text-pretty text-gray-400 text-xs">
                     {dictCustomCharacter.note}
                   </p>
                 </div>

--- a/apps/web/app/[lang]/voice-call/page.tsx
+++ b/apps/web/app/[lang]/voice-call/page.tsx
@@ -210,9 +210,7 @@ export default async function LandingPage(props: Props) {
                       </h3>
                     </CardHeader>
                     <CardContent>
-                      <p className="text-pretty text-center text-sm">
-                        {description}
-                      </p>
+                      <p className="text-justify text-sm">{description}</p>
                     </CardContent>
                   </Card>
                 ))}

--- a/apps/web/app/[lang]/voice-call/page.tsx
+++ b/apps/web/app/[lang]/voice-call/page.tsx
@@ -1,4 +1,4 @@
-import { Sparkles } from 'lucide-react';
+import { EyeOff, Lock, MessageCircleOff, Sparkles, Wand2 } from 'lucide-react';
 import type { Metadata } from 'next';
 import { redirect } from 'next/navigation';
 import {
@@ -9,12 +9,14 @@ import {
 import type { Graph } from 'schema-dts';
 
 import { Banner } from '@/components/banner';
+import { CardDecorator } from '@/components/card-decorator';
 import { DemoCallSection } from '@/components/demo-call/demo-call-section';
 import Footer from '@/components/footer';
 import { HeaderStatic } from '@/components/header-static';
 import HeroWaveform from '@/components/hero-waveform';
 import { JsonLd } from '@/components/json-ld';
 import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
 import { resolveActiveBanner } from '@/lib/banners/resolve-banner';
 import type { Locale } from '@/lib/i18n/i18n-config';
 import { Link } from '@/lib/i18n/navigation';
@@ -96,6 +98,14 @@ export default async function LandingPage(props: Props) {
   const [firstPart, ...restParts] = dictLanding.voiceCall.hero.title.split(',');
   const titleRestParts = restParts.join(',');
 
+  const dictPrivacy = dictLanding.voiceCall.privacy;
+  const dictCustomCharacter = dictLanding.voiceCall.customCharacter;
+  const privacyPoints = [
+    { Icon: MessageCircleOff, ...dictPrivacy.unrestricted },
+    { Icon: Lock, ...dictPrivacy.encrypted },
+    { Icon: EyeOff, ...dictPrivacy.forgotten },
+  ];
+
   const siteUrl = `https://sexyvoice.ai/${lang}/voice-call`;
 
   const jsonLd: Graph = {
@@ -175,6 +185,67 @@ export default async function LandingPage(props: Props) {
 
               <DemoCallSection lang={lang} />
             </div>
+
+            {/* Privacy Section */}
+            <section className="mx-auto max-w-4xl space-y-6 py-16 text-center">
+              <h2 className="text-balance font-bold text-3xl text-white md:text-4xl">
+                {dictPrivacy.title}
+              </h2>
+              <p className="mx-auto max-w-2xl text-pretty text-gray-300 text-xl leading-8">
+                {dictPrivacy.subtitle}
+              </p>
+              <div className="grid gap-6 pt-4 md:grid-cols-3">
+                {privacyPoints.map(({ Icon, title, description }) => (
+                  <Card
+                    className="mx-auto max-w-sm shadow-zinc-950/5"
+                    key={title}
+                  >
+                    <CardHeader className="pb-3">
+                      <CardDecorator>
+                        <Icon aria-hidden className="size-6 text-gray-200" />
+                      </CardDecorator>
+
+                      <h3 className="mt-6 text-balance text-center font-medium text-pink-200">
+                        {title}
+                      </h3>
+                    </CardHeader>
+                    <CardContent>
+                      <p className="text-pretty text-center text-sm">
+                        {description}
+                      </p>
+                    </CardContent>
+                  </Card>
+                ))}
+              </div>
+            </section>
+
+            {/* Custom Character Section */}
+            <section className="mx-auto max-w-3xl py-16">
+              <div className="space-y-6 rounded-2xl border border-fuchsia-800/60 bg-white/5 p-8 text-center md:p-12">
+                <div className="inline-flex items-center rounded-full bg-fuchsia-600/20 p-3 text-fuchsia-300">
+                  <Wand2 aria-hidden className="size-6" />
+                </div>
+                <h2 className="text-balance font-bold text-3xl text-white md:text-4xl">
+                  {dictCustomCharacter.title}
+                </h2>
+                <p className="mx-auto max-w-2xl text-pretty text-gray-300 text-lg leading-8">
+                  {dictCustomCharacter.subtitle}
+                </p>
+                <div className="flex flex-col items-center gap-2">
+                  <Button
+                    asChild
+                    className="hit-area-4 bg-fuchsia-600 hover:bg-fuchsia-700"
+                    effect="ringHover"
+                    size="lg"
+                  >
+                    <Link href="/signup">{dictCustomCharacter.action}</Link>
+                  </Button>
+                  <p className="text-gray-400 text-xs">
+                    {dictCustomCharacter.note}
+                  </p>
+                </div>
+              </div>
+            </section>
 
             {/* CTA Section */}
             <div className="space-y-8 py-16 text-center">

--- a/apps/web/components/card-decorator.tsx
+++ b/apps/web/components/card-decorator.tsx
@@ -1,0 +1,12 @@
+import type { ReactNode } from 'react';
+
+/**
+ * Square icon badge used above feature card titles on the marketing pages.
+ */
+export const CardDecorator = ({ children }: { children: ReactNode }) => (
+  <div className="mx-auto grid size-36 place-items-center">
+    <div className="flex size-12 items-center justify-center rounded-sm border-t border-l bg-brand-red/65">
+      {children}
+    </div>
+  </div>
+);

--- a/apps/web/messages/da.json
+++ b/apps/web/messages/da.json
@@ -131,6 +131,28 @@
         "title": "Tal med AI-karakterer, live i realtid",
         "subtitle": "Live AI-telefonopkald med naturlige, udtryksfulde stemmer.\nVælg en karakter og begynd at tale med det samme."
       },
+      "privacy": {
+        "title": "Uden begrænsninger, krypteret.",
+        "subtitle": "Udforsk dine dybeste ønsker i total privatliv. Ingen filtre, ingen fordomme, ingen der lytter med.",
+        "unrestricted": {
+          "title": "Intet emne er forbudt",
+          "description": "Sig hvad du vil, og som du vil. Din karakter viger ikke tilbage og løfter aldrig pegefingeren."
+        },
+        "encrypted": {
+          "title": "End-to-end krypteret",
+          "description": "Hvert opkald krypteres undervejs. Intet menneske lytter til dine samtaler."
+        },
+        "forgotten": {
+          "title": "Glemt som standard",
+          "description": "Intet føres videre mellem opkald, medmindre du selv slår hukommelsen til."
+        }
+      },
+      "customCharacter": {
+        "title": "Skab din egen karakter",
+        "subtitle": "Giv den et navn, en personlighed, en baggrundshistorie og en stemme. Ring så til den, når du vil – den er i rollen hver eneste gang.",
+        "note": "Egne karakterer er inkluderet i alle betalte planer.",
+        "action": "Skab din karakter"
+      },
       "cta": {
         "freeCredits": "Start med 10.000 gratis kreditter",
         "title": "Klar til at høre en stemme komme til live?",

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -131,6 +131,28 @@
         "title": "Sprechen Sie mit KI-Charakteren, live in Echtzeit",
         "subtitle": "Live-KI-Telefonate mit natürlichen, ausdrucksstarken Stimmen.\nWählen Sie einen Charakter und legen Sie sofort los."
       },
+      "privacy": {
+        "title": "Grenzenlos, verschlüsselt.",
+        "subtitle": "Erkunden Sie Ihre tiefsten Wünsche in völliger Privatsphäre. Keine Filter, keine Urteile, niemand hört mit.",
+        "unrestricted": {
+          "title": "Kein Thema ist tabu",
+          "description": "Sagen Sie, was Sie wollen, und wie Sie wollen. Ihr Charakter zuckt nicht zusammen und belehrt Sie nicht."
+        },
+        "encrypted": {
+          "title": "Ende-zu-Ende verschlüsselt",
+          "description": "Jeder Anruf wird bei der Übertragung verschlüsselt. Kein Mensch hört Ihre Gespräche mit."
+        },
+        "forgotten": {
+          "title": "Standardmäßig vergessen",
+          "description": "Zwischen den Anrufen bleibt nichts erhalten, solange Sie die Erinnerung nicht selbst aktivieren."
+        }
+      },
+      "customCharacter": {
+        "title": "Erstellen Sie Ihren eigenen Charakter",
+        "subtitle": "Geben Sie ihm einen Namen, eine Persönlichkeit, eine Vorgeschichte und eine Stimme. Rufen Sie ihn dann an, wann immer Sie wollen – er bleibt jedes Mal in seiner Rolle.",
+        "note": "Eigene Charaktere sind in jedem kostenpflichtigen Tarif enthalten.",
+        "action": "Charakter erstellen"
+      },
       "cta": {
         "freeCredits": "Starten Sie mit 10.000 kostenlosen Credits",
         "title": "Bereit, eine Stimme zum Leben zu erwecken?",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -131,6 +131,28 @@
         "title": "Talk to AI Characters, Live in Real Time",
         "subtitle": "Live AI phone calls with natural, expressive voices.\nPick a character and start talking instantly."
       },
+      "privacy": {
+        "title": "Unrestricted, encrypted.",
+        "subtitle": "Explore your deepest desires in total privacy. No filters, no judgment, no one listening in.",
+        "unrestricted": {
+          "title": "No topic off limits",
+          "description": "Say what you want, how you want. Your character never flinches and never lectures you."
+        },
+        "encrypted": {
+          "title": "End-to-end encrypted",
+          "description": "Every call is encrypted in transit. No human ever listens to your conversations."
+        },
+        "forgotten": {
+          "title": "Forgotten by default",
+          "description": "Nothing carries over between calls unless you switch memory on yourself."
+        }
+      },
+      "customCharacter": {
+        "title": "Create your custom character",
+        "subtitle": "Give them a name, a personality, a backstory and a voice. Then call them whenever you want — they pick up in character, every time.",
+        "note": "Custom characters come with every paid plan.",
+        "action": "Create your character"
+      },
       "cta": {
         "freeCredits": "Start with 10,000 free credits",
         "title": "Ready to hear a voice come alive?",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -131,6 +131,28 @@
         "title": "Habla con Personajes de IA, en Tiempo Real",
         "subtitle": "Llamadas telefónicas con IA y voces naturales y expresivas.\nElige un personaje y empieza a hablar al instante."
       },
+      "privacy": {
+        "title": "Sin límites, cifrado.",
+        "subtitle": "Explora tus deseos más profundos en total privacidad. Sin filtros, sin juicios, sin nadie escuchando.",
+        "unrestricted": {
+          "title": "Ningún tema está prohibido",
+          "description": "Di lo que quieras, como quieras. Tu personaje nunca se incomoda ni te sermonea."
+        },
+        "encrypted": {
+          "title": "Cifrado de extremo a extremo",
+          "description": "Cada llamada se cifra en tránsito. Ninguna persona escucha tus conversaciones."
+        },
+        "forgotten": {
+          "title": "Olvidado por defecto",
+          "description": "No se guarda nada entre llamadas a menos que actives la memoria tú mismo."
+        }
+      },
+      "customCharacter": {
+        "title": "Crea tu personaje personalizado",
+        "subtitle": "Dale un nombre, una personalidad, una historia y una voz. Luego llámalo cuando quieras: siempre responde en su papel.",
+        "note": "Los personajes personalizados están incluidos en todos los planes de pago.",
+        "action": "Crear tu personaje"
+      },
       "cta": {
         "freeCredits": "Comienza con 10,000 créditos gratis",
         "title": "¿Listo para escuchar una voz cobrar vida?",

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -131,6 +131,28 @@
         "title": "Parlez à des Personnages IA, en Direct",
         "subtitle": "Appels téléphoniques IA en direct avec des voix naturelles et expressives.\nChoisissez un personnage et commencez à parler instantanément."
       },
+      "privacy": {
+        "title": "Sans limites, chiffré.",
+        "subtitle": "Explorez vos désirs les plus profonds en toute intimité. Aucun filtre, aucun jugement, personne à l'écoute.",
+        "unrestricted": {
+          "title": "Aucun sujet interdit",
+          "description": "Dites ce que vous voulez, comme vous le voulez. Votre personnage ne se braque jamais et ne vous fait pas la morale."
+        },
+        "encrypted": {
+          "title": "Chiffré de bout en bout",
+          "description": "Chaque appel est chiffré pendant son transit. Aucun humain n'écoute vos conversations."
+        },
+        "forgotten": {
+          "title": "Oublié par défaut",
+          "description": "Rien ne subsiste d'un appel à l'autre, sauf si vous activez vous-même la mémoire."
+        }
+      },
+      "customCharacter": {
+        "title": "Créez votre personnage sur mesure",
+        "subtitle": "Donnez-lui un nom, une personnalité, une histoire et une voix. Appelez-le ensuite quand vous voulez : il reste dans son rôle à chaque fois.",
+        "note": "Les personnages sur mesure sont inclus dans toutes les formules payantes.",
+        "action": "Créer votre personnage"
+      },
       "cta": {
         "freeCredits": "Commencez avec 10 000 crédits gratuits",
         "title": "Prêt à entendre une voix prendre vie ?",

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -131,6 +131,28 @@
         "title": "Parla con Personaggi IA, dal Vivo in Tempo Reale",
         "subtitle": "Chiamate telefoniche IA dal vivo con voci naturali ed espressive.\nScegli un personaggio e inizia subito a parlare."
       },
+      "privacy": {
+        "title": "Senza limiti, crittografato.",
+        "subtitle": "Esplora i tuoi desideri più profondi in totale privacy. Nessun filtro, nessun giudizio, nessuno in ascolto.",
+        "unrestricted": {
+          "title": "Nessun argomento è vietato",
+          "description": "Di' quello che vuoi, come vuoi. Il tuo personaggio non si imbarazza e non ti fa la predica."
+        },
+        "encrypted": {
+          "title": "Crittografia end-to-end",
+          "description": "Ogni chiamata è crittografata in transito. Nessuna persona ascolta le tue conversazioni."
+        },
+        "forgotten": {
+          "title": "Dimenticato per impostazione predefinita",
+          "description": "Non resta nulla da una chiamata all'altra, a meno che non attivi tu stesso la memoria."
+        }
+      },
+      "customCharacter": {
+        "title": "Crea il tuo personaggio personalizzato",
+        "subtitle": "Dagli un nome, una personalità, un passato e una voce. Poi chiamalo quando vuoi: risponde sempre restando nel personaggio.",
+        "note": "I personaggi personalizzati sono inclusi in tutti i piani a pagamento.",
+        "action": "Crea il tuo personaggio"
+      },
       "cta": {
         "freeCredits": "Inizia con 10.000 crediti gratuiti",
         "title": "Pronto a sentire una voce prendere vita?",


### PR DESCRIPTION
Bring the dashboard call page's privacy promise onto the /voice-call
landing page and add a dedicated callout for custom characters.

- New "Unrestricted, encrypted." section mirroring the dashboard call
  notice copy, with three proof points: no topic off limits, end-to-end
  encrypted, forgotten by default (memory is opt-in).
- New "Create your custom character" callout with its own CTA, noting
  the feature ships with paid plans.
- Extract the local CardDecorator from the homepage into
  components/card-decorator.tsx so both marketing pages share it.
- Add the new landing.voiceCall.privacy and
  landing.voiceCall.customCharacter keys to all six locales.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01AubGjXn911ChCRyenyJCPm