### PR TITLE
feat(call): upgrade to grok-voice-think-fast-2.0 and raise call price to 1100 credits/min

### DIFF
--- a/.agents/product-marketing.md
+++ b/.agents/product-marketing.md
@@ -1,7 +1,7 @@
 # Product Marketing Context
 
-**Document version:** v4
-**Last updated:** 2026-07-25
+**Document version:** v5
+**Last updated:** 2026-08-01
 
 > Shared positioning context, written to the canonical path the external
 > product-marketing skill toolchain looks for. No skill checked into this repo
@@ -105,7 +105,7 @@ Mostly a self-serve consumer/prosumer product, so these are buyer *types*, not a
 |-----------|----------|
 | "Will it actually sound natural, or robotic like everything else?" | The models interpret context, not just characters — tone, pacing, and expression. Emotion tags and style prompting are built in. Try it free before paying. |
 | "Is my voice data safe?" | Recordings and generated files are encrypted. Cloning samples are deleted after the voice is built. You can delete generated audio any time. We never share voice data without consent. |
-| "I don't know if I'll use enough to justify paying." | 10,000 free credits, no credit card. ~1,000 credits ≈ 1 minute of generation as a rule of thumb, and live calling is 1,000 credits/minute — so you can do the math before you spend. (Check the burn-rate table under Proof Points before quoting this to a cloning-led audience; cloned voices cost far more per minute.) |
+| "I don't know if I'll use enough to justify paying." | 10,000 free credits, no credit card. ~1,000 credits ≈ 1 minute of generation as a rule of thumb, and live calling is 1,100 credits/minute — so you can do the math before you spend. (Check the burn-rate table under Proof Points before quoting this to a cloning-led audience; cloned voices cost far more per minute.) |
 | "Do I have to rebuild if I need an API later?" | The speech-generation API is live today — keys, CLI, OpenAPI docs — and runs on the same credits as the dashboard. Cloning and live calling are web-app only for now, so don't promise those programmatically. |
 | "Can I use this commercially?" | Yes — you own the audio you generate, including via the API, and may distribute and commercially exploit it (`policies/terms.mdx`, "Ownership and Use of Generated Content"). That grant does not extend to any voice, likeness, or content you aren't authorised to use. |
 
@@ -153,7 +153,7 @@ Mostly a self-serve consumer/prosumer product, so these are buyer *types*, not a
 |------|---------|
 | Credits | Usage unit for all paid features (~1,000 ≈ 1 minute of generation) |
 | Voice cloning | Building a reusable voice model from a sample as short as 10 seconds |
-| Live calling | Real-time two-way AI voice conversation, billed at 1,000 credits/minute |
+| Live calling | Real-time two-way AI voice conversation, billed at 1,100 credits/minute |
 | Emotion tags | Inline markup that triggers laughter, sighs, coughs, and similar in output |
 | Cross-language cloning | One cloned voice generating speech across 23 supported languages |
 | `gpro` / `gpro31` | Gemini 2.5 and Gemini 3.1 Flash voice models |
@@ -170,7 +170,7 @@ Mostly a self-serve consumer/prosumer product, so these are buyer *types*, not a
 **Metrics:**
 
 - 10,000 free credits ≈ 10 minutes of speech at the published ~1,000 credits/minute rule of thumb, no card required. Actual burn rate varies a lot by voice and model — see the table below before quoting a duration.
-- Live calls cost 1,000 credits/minute
+- Live calls cost 1,100 credits/minute
 - Live calling on the free tier stops after **5 minutes total across all calls ever made** (`FREE_USER_CALL_LIMIT_SECONDS`) — a cumulative allowance, not a per-call cap. It lifts permanently on the user's first purchase or top-up (`isFreeUserOverCallLimit` → `hasUserPaid`). The in-product string says it correctly: "Free users are limited to 5 minutes of calls."
 - Pro is 37.5% cheaper per credit than Standard; subscriptions add 15% more credits
 - Voice cloning from as little as 10 seconds of audio
@@ -232,6 +232,7 @@ varies. Speech generation is the widest, and Gemini goes furthest.
 
 *Newest first. One line per revision: what changed and why.*
 
+- v5 (2026-08-01) — Raised the live-call rate from 1,000 to 1,100 credits/minute ($0.55) alongside the upgrade to the grok-voice-think-fast-2.0 voice model. The "~1,000 credits ≈ 1 minute" rule of thumb is unchanged: it is about speech generation, not calls, and the two rates are no longer the same number.
 - v4 (2026-07-25) — Fixed four claims flagged in review. Corrected the free-tier call limit, which v3 got backwards: it is a cumulative 5-minute total across all calls that lifts on first purchase, not a per-call cap. Scoped API positioning to speech generation only, with a capability table — cloning and live calling are web-app features and `/voices` serves public voices only. Withdrew the "our terms prohibit deception and impersonation" claim, which the published terms do not support, and flagged that the live FAQ already makes it. Added a model-dependent credit burn-rate table, since a cloned voice costs ~10× a Gemini voice and the "~1,000 credits/minute" figure is an average no single voice charges. Also corrected the header's claim that skills in this repo read the file.
 - v3 (2026-07-25) — Corrected the free tier to ~10 minutes of speech (10,000 credits at ~1,000/min) and split out the 5-minute free-tier call limit that it was conflated with (mischaracterised as per-call; corrected in v4); replaced scattered per-feature language counts with a single "language coverage by feature" table in Proof Points, since coverage varies by feature and voice model (speech generation widest, Gemini furthest); standardised marketing copy on "languages" instead of "locales"; flagged transcription coverage as unverified because site meta says 99+ while the on-page FAQ says 32.
 - v2 (2026-07-24) — Repositioned lead from "commercial adult content allowed" to expressive voices + live calling + multilingual + developer API, demoting content policy to a secondary, flagged-unverified point; corrected live-call rate to 1,000 credits/min, marked the API live, added Starter/subscription tiers, Grok and Gemini 3.1 models, 70+ language coverage, and the free browser audio tools; replaced the obsolete API-related anti-persona; migrated from the legacy `product-marketing-context.md` filename and added versioning.

--- a/apps/web/app/[lang]/(dashboard)/dashboard/call/layout.tsx
+++ b/apps/web/app/[lang]/(dashboard)/dashboard/call/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 
 import { RoomWrapper } from '@/components/call/room-wrapper';
 import { TooltipProvider } from '@/components/ui/tooltip';
+import { normalizeModelId } from '@/data/models';
 import type { CallLanguage } from '@/data/playground-state';
 import type { Preset } from '@/data/presets';
 import { ConnectionProvider } from '@/hooks/use-connection';
@@ -89,8 +90,7 @@ function mapCharacterToPreset(character: CharacterRow): Preset {
     instructions: prompts?.prompt ?? '',
     localizedInstructions: prompts?.localized_prompts ?? {},
     sessionConfig: {
-      model: (sessionConfig.model ??
-        'grok-voice-think-fast-1.0') as Preset['sessionConfig']['model'],
+      model: normalizeModelId(sessionConfig.model),
       voice: sessionConfig.voice ?? voice?.name ?? 'Ara',
       temperature: sessionConfig.temperature ?? 0.8,
       maxOutputTokens:

--- a/apps/web/app/api/characters/route.ts
+++ b/apps/web/app/api/characters/route.ts
@@ -2,6 +2,7 @@ import { captureException } from '@sentry/nextjs';
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
 
+import { normalizeModelId } from '@/data/models';
 import { APIErrorResponse } from '@/lib/error-ts';
 import {
   countUserCallCharacters,
@@ -17,7 +18,10 @@ const MAX_PROMPT_LENGTH = 5000;
 // ── Zod Schemas ──
 
 const sessionConfigSchema = z.object({
-  model: z.string().min(1, 'Model is required'),
+  // Normalized before it is spread into the session_config JSONB, so a stale
+  // client cannot write a retired model id back into a row that was just
+  // cleaned up.
+  model: z.string().min(1, 'Model is required').transform(normalizeModelId),
   voice: z.string().min(1, 'Voice is required'),
   temperature: z.number().min(0).max(1.2),
   maxOutputTokens: z.number().nullable(),

--- a/apps/web/components/call/preset-selector.test.tsx
+++ b/apps/web/components/call/preset-selector.test.tsx
@@ -69,7 +69,7 @@ beforeEach(() => {
           localized_descriptions: { en: 'A new custom character.' },
           image: null,
           session_config: {
-            model: 'grok-voice-think-fast-1.0',
+            model: 'grok-voice-think-fast-2.0',
             voice: 'Ara',
             temperature: 0.8,
             maxOutputTokens: null,

--- a/apps/web/data/default-config.ts
+++ b/apps/web/data/default-config.ts
@@ -2,7 +2,7 @@ import { ModelId } from './models';
 import type { SessionConfig } from './session-config';
 
 export const defaultSessionConfig: SessionConfig = {
-  model: ModelId.GROK_VOICE_THINK_FAST_1_0,
+  model: ModelId.GROK_VOICE_THINK_FAST_2_0,
   voice: 'Ara',
   temperature: 0.8,
   maxOutputTokens: null,

--- a/apps/web/data/models.ts
+++ b/apps/web/data/models.ts
@@ -1,4 +1,31 @@
 export const ModelId = {
   // Grok Voice Agent model
-  GROK_VOICE_THINK_FAST_1_0: 'grok-voice-think-fast-1.0',
+  GROK_VOICE_THINK_FAST_2_0: 'grok-voice-think-fast-2.0',
 } as const;
+
+export type ModelIdValue = (typeof ModelId)[keyof typeof ModelId];
+
+export const DEFAULT_MODEL_ID: ModelIdValue = ModelId.GROK_VOICE_THINK_FAST_2_0;
+
+/**
+ * Model ids that are no longer offered, mapped to their replacement. Rows in
+ * `characters.session_config` created before an upgrade keep the old id, so
+ * every read path normalizes instead of trusting the stored value.
+ */
+const REPLACED_MODEL_IDS: Record<string, ModelIdValue> = {
+  'grok-voice-think-fast-1.0': ModelId.GROK_VOICE_THINK_FAST_2_0,
+};
+
+const SUPPORTED_MODEL_IDS = new Set<string>(Object.values(ModelId));
+
+/**
+ * Resolves a persisted or client-supplied model id to a currently supported
+ * one, falling back to the default for unknown values.
+ */
+export function normalizeModelId(
+  model: string | null | undefined,
+): ModelIdValue {
+  if (!model) return DEFAULT_MODEL_ID;
+  if (SUPPORTED_MODEL_IDS.has(model)) return model as ModelIdValue;
+  return REPLACED_MODEL_IDS[model] ?? DEFAULT_MODEL_ID;
+}

--- a/apps/web/lib/call-token-schema.ts
+++ b/apps/web/lib/call-token-schema.ts
@@ -1,9 +1,14 @@
 import { z } from 'zod';
 
 import { callScenes } from '@/data/call-scenes';
+import { normalizeModelId } from '@/data/models';
 
 const sessionConfigSchema = z.object({
-  model: z.string(),
+  // Normalized at the trust boundary: this value is forwarded verbatim into the
+  // LiveKit token metadata and is what the agent runs on, while credits are
+  // charged at the current rate. A stale tab or a shared URL carrying a retired
+  // id must not be able to run an old model at the new price.
+  model: z.string().transform(normalizeModelId),
   voice: z.string(),
   temperature: z.number().min(0).max(1.2),
   maxOutputTokens: z.number().nullable(),

--- a/apps/web/lib/characters.ts
+++ b/apps/web/lib/characters.ts
@@ -1,3 +1,4 @@
+import { normalizeModelId } from '@/data/models';
 import type { Preset } from '@/data/presets';
 
 // ─── API response shape (from POST /api/characters) ───────────────────────────
@@ -52,8 +53,7 @@ export function mapApiCharacterToPreset(
     instructions: character.prompts?.prompt ?? '',
     localizedInstructions: character.prompts?.localized_prompts ?? {},
     sessionConfig: {
-      model: (sessionConfig.model ??
-        'grok-voice-think-fast-1.0') as Preset['sessionConfig']['model'],
+      model: normalizeModelId(sessionConfig.model),
       voice: sessionConfig.voice ?? character.voices?.name ?? 'Ara',
       temperature: sessionConfig.temperature ?? 0.8,
       maxOutputTokens:

--- a/apps/web/lib/playground-state-helpers.ts
+++ b/apps/web/lib/playground-state-helpers.ts
@@ -1,4 +1,5 @@
 import { defaultSessionConfig } from '@/data/default-config';
+import { normalizeModelId } from '@/data/models';
 import type { PlaygroundState } from '@/data/playground-state';
 import type { Preset } from '@/data/presets';
 import type { SessionConfig } from '@/data/session-config';
@@ -99,7 +100,9 @@ export const createPlaygroundStateHelpers = (defaultPresets: Preset[] = []) => {
                 value === 'null' ? null : Number(value);
               break;
             case 'model':
-              sessionConfig.model = value as SessionConfig['model'];
+              // A shared/bookmarked URL can carry a retired id indefinitely;
+              // unnormalized it would also fail ConfigurationFormSchema's enum.
+              sessionConfig.model = normalizeModelId(value);
               break;
             case 'temperature':
               sessionConfig.temperature = Number(value);

--- a/apps/web/lib/supabase/constants.ts
+++ b/apps/web/lib/supabase/constants.ts
@@ -1,8 +1,8 @@
 export const MAX_FREE_GENERATIONS = 10;
 export const OAUTH_CALLBACK_COOKIE_NAME = 'sv_oauth_callback_ok';
 
-export const MINIMUM_CREDITS_FOR_CALL = 1000;
-export const CREDITS_PER_MINUTE = 1000;
+export const MINIMUM_CREDITS_FOR_CALL = 1100;
+export const CREDITS_PER_MINUTE = 1100;
 
 // 5 minutes in seconds - free users can only make calls up to this limit
 export const FREE_USER_CALL_LIMIT_SECONDS = 5 * 60;

--- a/apps/web/tests/call-token.test.ts
+++ b/apps/web/tests/call-token.test.ts
@@ -29,7 +29,7 @@ describe('call-token API validation', () => {
         instructions: 'Test instructions',
         selectedPresetId: null,
         sessionConfig: {
-          model: 'grok-voice-think-fast-1.0',
+          model: 'grok-voice-think-fast-2.0',
           voice: 'Ara',
           temperature: 0.8,
           maxOutputTokens: null,
@@ -46,7 +46,7 @@ describe('call-token API validation', () => {
         language: 'en' as const,
         selectedPresetId: '123e4567-e89b-12d3-a456-426614174000',
         sessionConfig: {
-          model: 'grok-voice-think-fast-1.0',
+          model: 'grok-voice-think-fast-2.0',
           voice: 'Ara',
           temperature: 0.8,
           maxOutputTokens: 1000,
@@ -65,7 +65,7 @@ describe('call-token API validation', () => {
         selectedPresetId: null,
         selectedSceneId: 'bartender-after-closing',
         sessionConfig: {
-          model: 'grok-voice-think-fast-1.0',
+          model: 'grok-voice-think-fast-2.0',
           voice: 'Ara',
           temperature: 0.8,
           maxOutputTokens: null,
@@ -82,7 +82,7 @@ describe('call-token API validation', () => {
         selectedPresetId: null,
         selectedSceneId: null,
         sessionConfig: {
-          model: 'grok-voice-think-fast-1.0',
+          model: 'grok-voice-think-fast-2.0',
           voice: 'Ara',
           temperature: 0.8,
           maxOutputTokens: null,
@@ -97,7 +97,7 @@ describe('call-token API validation', () => {
         instructions: 'Test',
         selectedPresetId: null,
         sessionConfig: {
-          model: 'grok-voice-think-fast-1.0',
+          model: 'grok-voice-think-fast-2.0',
           voice: 'Ara',
           temperature: 0.8,
           maxOutputTokens: null,
@@ -121,7 +121,7 @@ describe('call-token API validation', () => {
         selectedPresetId: null,
         memory: 'yes',
         sessionConfig: {
-          model: 'grok-voice-think-fast-1.0',
+          model: 'grok-voice-think-fast-2.0',
           voice: 'Ara',
           temperature: 0.8,
           maxOutputTokens: null,
@@ -138,7 +138,7 @@ describe('call-token API validation', () => {
           selectedPresetId: null,
           selectedSceneId: scene.id,
           sessionConfig: {
-            model: 'grok-voice-think-fast-1.0',
+            model: 'grok-voice-think-fast-2.0',
             voice: 'Ara',
             temperature: 0.8,
             maxOutputTokens: null,
@@ -155,7 +155,7 @@ describe('call-token API validation', () => {
         language: 'es' as const,
         selectedPresetId: '123e4567-e89b-12d3-a456-426614174000',
         sessionConfig: {
-          model: 'grok-voice-think-fast-1.0',
+          model: 'grok-voice-think-fast-2.0',
           voice: 'Eve',
           temperature: 1.2,
           maxOutputTokens: null,
@@ -220,7 +220,7 @@ describe('call-token API validation', () => {
       const payload = {
         selectedPresetId: null,
         sessionConfig: {
-          model: 'grok-voice-think-fast-1.0',
+          model: 'grok-voice-think-fast-2.0',
           voice: 'Ara',
           temperature: 0.8,
           maxOutputTokens: null,
@@ -247,7 +247,7 @@ describe('call-token API validation', () => {
         selectedPresetId: null,
         selectedSceneId: 'totally-made-up-scene',
         sessionConfig: {
-          model: 'grok-voice-think-fast-1.0',
+          model: 'grok-voice-think-fast-2.0',
           voice: 'Ara',
           temperature: 0.8,
           maxOutputTokens: null,
@@ -262,7 +262,7 @@ describe('call-token API validation', () => {
         instructions: 'Test instructions',
         selectedPresetId: 'not-a-valid-uuid',
         sessionConfig: {
-          model: 'grok-voice-think-fast-1.0',
+          model: 'grok-voice-think-fast-2.0',
           voice: 'Ara',
           temperature: 0.8,
           maxOutputTokens: null,
@@ -279,7 +279,7 @@ describe('call-token API validation', () => {
         language: 'invalid',
         selectedPresetId: null,
         sessionConfig: {
-          model: 'grok-voice-think-fast-1.0',
+          model: 'grok-voice-think-fast-2.0',
           voice: 'Ara',
           temperature: 0.8,
           maxOutputTokens: null,
@@ -295,7 +295,7 @@ describe('call-token API validation', () => {
         instructions: 'Test instructions',
         selectedPresetId: null,
         sessionConfig: {
-          model: 'grok-voice-think-fast-1.0',
+          model: 'grok-voice-think-fast-2.0',
           voice: 'Ara',
           temperature: 2.5, // Max is 2.0
           maxOutputTokens: null,
@@ -311,7 +311,7 @@ describe('call-token API validation', () => {
         instructions: 'Test instructions',
         selectedPresetId: null,
         sessionConfig: {
-          model: 'grok-voice-think-fast-1.0',
+          model: 'grok-voice-think-fast-2.0',
           voice: 'Ara',
           temperature: -0.5, // Min is 0
           maxOutputTokens: null,
@@ -327,7 +327,7 @@ describe('call-token API validation', () => {
         instructions: 'Test instructions',
         selectedPresetId: null,
         sessionConfig: {
-          model: 'grok-voice-think-fast-1.0',
+          model: 'grok-voice-think-fast-2.0',
           temperature: 0.8,
           maxOutputTokens: null,
         },
@@ -342,7 +342,7 @@ describe('call-token API validation', () => {
         instructions: 'Test instructions',
         selectedPresetId: null,
         sessionConfig: {
-          model: 'grok-voice-think-fast-1.0',
+          model: 'grok-voice-think-fast-2.0',
           voice: 'Ara',
           temperature: 0.8,
           maxOutputTokens: '1000', // Should be number or null

--- a/apps/web/tests/call-token.test.ts
+++ b/apps/web/tests/call-token.test.ts
@@ -40,6 +40,42 @@ describe('call-token API validation', () => {
       expect(result.success).toBe(true);
     });
 
+    it('upgrades a retired model id instead of forwarding it to the agent', () => {
+      // A stale tab or a shared URL can still post 1.0. Forwarding it verbatim
+      // would run the old model while charging the current rate.
+      const payload = {
+        instructions: 'Test instructions',
+        selectedPresetId: null,
+        sessionConfig: {
+          model: 'grok-voice-think-fast-1.0',
+          voice: 'Ara',
+          temperature: 0.8,
+          maxOutputTokens: null,
+        },
+      };
+
+      const result = playgroundStateSchema.safeParse(payload);
+      expect(result.success).toBe(true);
+      expect(result.data?.sessionConfig.model).toBe('grok-voice-think-fast-2.0');
+    });
+
+    it('falls back to the default for an unknown model id', () => {
+      const payload = {
+        instructions: 'Test instructions',
+        selectedPresetId: null,
+        sessionConfig: {
+          model: 'totally-made-up-model',
+          voice: 'Ara',
+          temperature: 0.8,
+          maxOutputTokens: null,
+        },
+      };
+
+      const result = playgroundStateSchema.safeParse(payload);
+      expect(result.success).toBe(true);
+      expect(result.data?.sessionConfig.model).toBe('grok-voice-think-fast-2.0');
+    });
+
     it('should accept a payload with selectedPresetId (UUID)', () => {
       const payload = {
         instructions: 'Test instructions',

--- a/apps/web/tests/characters-api.test.ts
+++ b/apps/web/tests/characters-api.test.ts
@@ -452,6 +452,24 @@ describe('/api/characters', () => {
       expect(res.status).toBe(201);
       expect(insertedCharacters[0].name).toBe('Padded Name');
     });
+
+    it('upgrades a retired model id before persisting session_config', async () => {
+      // Otherwise a stale client writes the dead id straight back into the
+      // JSONB column after it has been cleaned up.
+      const body = validCreateBody({
+        sessionConfig: {
+          model: 'grok-voice-think-fast-1.0',
+          voice: 'Ara',
+          temperature: 0.8,
+          maxOutputTokens: null,
+        },
+      });
+      const res = await POST(makeRequest(body));
+      expect(res.status).toBe(201);
+      expect(insertedCharacters[0]).toMatchObject({
+        session_config: { model: 'grok-voice-think-fast-2.0' },
+      });
+    });
   });
 
   // ─── POST: update (happy path) ────────────────────────────────────

--- a/apps/web/tests/characters-api.test.ts
+++ b/apps/web/tests/characters-api.test.ts
@@ -39,7 +39,7 @@ const fakeUserCharacter = {
   voice_id: '76071f55-b9d5-4852-a96e-dbadb7b93e9e',
   localized_descriptions: {},
   session_config: {
-    model: 'grok-voice-think-fast-1.0',
+    model: 'grok-voice-think-fast-2.0',
     voice: 'Ara',
     temperature: 0.8,
     maxOutputTokens: null,
@@ -286,7 +286,7 @@ function validCreateBody(overrides: Record<string, unknown> = {}) {
     prompt: 'You are a helpful test character.',
     voiceName: 'Ara',
     sessionConfig: {
-      model: 'grok-voice-think-fast-1.0',
+      model: 'grok-voice-think-fast-2.0',
       voice: 'Ara',
       temperature: 0.8,
       maxOutputTokens: null,

--- a/apps/web/tests/models.test.ts
+++ b/apps/web/tests/models.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+
+import { DEFAULT_MODEL_ID, ModelId, normalizeModelId } from '@/data/models';
+import { mapApiCharacterToPreset } from '@/lib/characters';
+
+describe('normalizeModelId', () => {
+  it('keeps a supported model id', () => {
+    expect(normalizeModelId(ModelId.GROK_VOICE_THINK_FAST_2_0)).toBe(
+      'grok-voice-think-fast-2.0',
+    );
+  });
+
+  it('upgrades the retired grok-voice-think-fast-1.0 id', () => {
+    expect(normalizeModelId('grok-voice-think-fast-1.0')).toBe(
+      'grok-voice-think-fast-2.0',
+    );
+  });
+
+  it('falls back to the default for missing or unknown ids', () => {
+    expect(normalizeModelId(undefined)).toBe(DEFAULT_MODEL_ID);
+    expect(normalizeModelId(null)).toBe(DEFAULT_MODEL_ID);
+    expect(normalizeModelId('')).toBe(DEFAULT_MODEL_ID);
+    expect(normalizeModelId('not-a-real-model')).toBe(DEFAULT_MODEL_ID);
+  });
+});
+
+describe('mapApiCharacterToPreset', () => {
+  it('upgrades a legacy model id stored in session_config', () => {
+    const preset = mapApiCharacterToPreset({
+      id: '00000000-0000-4000-a000-000000000201',
+      name: 'Legacy character',
+      session_config: {
+        model: 'grok-voice-think-fast-1.0',
+        voice: 'Eve',
+        temperature: 0.8,
+        maxOutputTokens: null,
+      },
+    });
+
+    expect(preset.sessionConfig.model).toBe('grok-voice-think-fast-2.0');
+  });
+});


### PR DESCRIPTION
## What & why

Upgrades the live-call voice model from `grok-voice-think-fast-1.0` to
`grok-voice-think-fast-2.0` and raises the call price from **1000 credits/min
($0.50)** to **1100 credits/min ($0.55)**.

Paired with gianpaj/sexycall#51 — **both must ship**, see *Rollout* below.

## Changes

- `apps/web/data/models.ts` — `GROK_VOICE_THINK_FAST_2_0`, plus a
  `normalizeModelId()` helper.
- `apps/web/lib/supabase/constants.ts` — `CREDITS_PER_MINUTE` and
  `MINIMUM_CREDITS_FOR_CALL` → `1100`. They move together so starting a call
  still requires one minute of credits.
- `apps/web/lib/characters.ts` and
  `apps/web/app/[lang]/(dashboard)/dashboard/call/layout.tsx` — both read paths
  duplicated a hardcoded `?? 'grok-voice-think-fast-1.0'` fallback; both now go
  through `normalizeModelId()`.
- **Write paths also normalized** (added after review): `lib/call-token-schema.ts`
  (the value forwarded into the LiveKit token metadata),
  `app/api/characters/route.ts` (before it is persisted to `session_config`), and
  `lib/playground-state-helpers.ts` (the `?sessionConfig.model=` URL param, which
  was a raw cast). A stale tab or an old share link can otherwise carry a retired
  id indefinitely.
- `.agents/product-marketing.md` — the live-call rate is quoted in three places;
  bumped to v5. The `~1,000 credits ≈ 1 minute` rule of thumb is untouched, since
  that is about speech generation and the two figures are no longer the same.

### Why the normalizer

`characters.session_config` is JSONB, and rows written before this change still
hold the old id. That value is read straight into the playground state and sent
to the agent, so without normalization a user would be charged the 1100 rate
while still being served 1.0. `normalizeModelId()` maps any retired or unknown
id to the current model, which also makes the data cleanup below non-blocking.

## Data cleanup (run manually — not a migration)

Per `CLAUDE.md`, no backfill migration is included. The normalizer means the app
is correct without this, but run it to stop persisting the dead id.

**1. Dry run — see what will change:**

```sql
select id, is_public, name, session_config->>'model' as model
from public.characters
where session_config->>'model' is distinct from 'grok-voice-think-fast-2.0'
order by is_public desc, sort_order;
```

**2. Predefined ("default") characters** — targeted by id, mirroring the
`20260515115400` precedent. `jsonb_set(..., true)` sets `model` even when the
key is absent, which the value-matching `where` in step 3 would skip:

```sql
update public.characters
set session_config = jsonb_set(
  session_config,
  '{model}',
  '"grok-voice-think-fast-2.0"'::jsonb,
  true
)
where id in (
  '00000000-0000-4000-a000-000000000201'::uuid,  -- Ramona
  '00000000-0000-4000-a000-000000000202'::uuid,
  '00000000-0000-4000-a000-000000000203'::uuid,
  '00000000-0000-4000-a000-000000000204'::uuid
)
and is_public = true;
```

**3. User-created characters** — everything still on the retired id:

```sql
update public.characters
set session_config = jsonb_set(
  session_config,
  '{model}',
  '"grok-voice-think-fast-2.0"'::jsonb,
  true
)
where session_config->>'model' = 'grok-voice-think-fast-1.0';
```

**4. Verify — should return 0 rows:**

```sql
select id, session_config->>'model' as model
from public.characters
where session_config->>'model' is distinct from 'grok-voice-think-fast-2.0';
```

## Rollout

**Merge this PR first, then gianpaj/sexycall#51, then run the SQL above.**

Both repos have a pre-call credit gate (`MINIMUM_CREDITS_FOR_CALL`): this one at
`app/api/call-token/route.ts:60`, the agent's at `src/agent.py:1145`. Nothing in
this repo deducts credits — `CREDITS_PER_MINUTE` here only drives display copy
and that gate. The metering lives in the agent.

That makes web-first the safe order, because it leaves the **web gate stricter
than the agent gate**:

| | Web first (this order) | Agent first |
|---|---|---|
| Price shown vs charged | quoted 1100, charged 1000 — **under**charged | quoted 1000, charged 1100 — **over**charged |
| Credit gates | web 1100 > agent 1000 → nobody passes the web gate and is then rejected | web 1000 < agent 1100 → a user with 1000-1099 credits passes the web gate and the agent kills the call with `insufficient_credits` |
| `minutesRemaining` | divides by 1100, conservative | divides by 1000, overstates |
| Model vs price | old model at old price — consistent | new model at new price — consistent |
| Cost of the window | `call_sessions.model` records `2.0` while 1.0 actually ran | real users hit failed calls |

Sending `2.0` to the not-yet-updated agent is harmless: it stores the string on
the `call_sessions` row and never passes it to `RealtimeModel`, so the window
costs a few mislabeled analytics rows. That is clearly cheaper than failed calls
and charging above the quoted rate.

Wait for the Vercel deploy to go live before merging the agent PR, rather than
merging both at once — concurrent builds make the live order non-deterministic,
and the agent-first ordering is the one to avoid.

Run the SQL **last**. It is safe at any point after this PR is live, but not
before: on the current build `ConfigurationFormSchema` is
`z.enum(['grok-voice-think-fast-1.0'])`, and `configuration-form.tsx:222` does
`form.reset(pgState.sessionConfig)`, so a DB value of `2.0` would make
`formState.isValid` false. That doesn't block starting a call, but it does
silently stop mid-call config updates (`configuration-form.tsx:227`).

## Billing impact

Call price +10% (1000 → 1100 credits/min). Nothing else — TTS, cloning, and the
external API are untouched. Per-minute copy interpolates `{count}` from
`CREDITS_PER_MINUTE`, so no `messages/*.json` changes and no
`check-translations` impact.

## Checks

- `pnpm type-check` — pass
- `pnpm test` — 682 passed. `tests/stripe-webhook.test.ts` fails on a Redis
  setup hook timeout; **pre-existing**, reproduces unchanged in isolation on a
  clean tree and is unrelated to these files.
- `pnpm fixall` — the touched files are clean. The repo-wide run still reports
  81 pre-existing errors; the 8 in `characters-api.test.ts` are on lines 16-19
  and 208-249, and this PR only changes lines 42 and 289 there.
- New `apps/web/tests/models.test.ts` covers the normalizer and the legacy-id
  path through `mapApiCharacterToPreset`.

## Docs

No doc changes needed — `apps/docs/content/docs/features/voice-call.mdx` says
"billed per minute" without quoting a number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)