### PR TITLE
refactor(characters): centralize custom character limit

### DIFF
--- a/apps/web/app/api/characters/route.ts
+++ b/apps/web/app/api/characters/route.ts
@@ -3,6 +3,7 @@ import { NextResponse } from 'next/server';
 import { z } from 'zod';
 
 import { normalizeModelId } from '@/data/models';
+import { MAX_CUSTOM_CHARACTERS } from '@/lib/characters';
 import { APIErrorResponse } from '@/lib/error-ts';
 import {
   countUserCallCharacters,
@@ -11,7 +12,6 @@ import {
 } from '@/lib/supabase/queries';
 import { createClient } from '@/lib/supabase/server';
 
-const MAX_CUSTOM_CHARACTERS = 10;
 const MAX_NAME_LENGTH = 50;
 const MAX_PROMPT_LENGTH = 5000;
 

--- a/apps/web/components/call/preset-selector.tsx
+++ b/apps/web/components/call/preset-selector.tsx
@@ -40,14 +40,16 @@ import type { Preset } from '@/data/presets';
 import type { DBVoice } from '@/data/voices';
 import { useConnection } from '@/hooks/use-connection';
 import { usePlaygroundState } from '@/hooks/use-playground-state';
-import { mapApiCharacterToPreset, saveCharacter } from '@/lib/characters';
+import {
+  MAX_CUSTOM_CHARACTERS,
+  mapApiCharacterToPreset,
+  saveCharacter,
+} from '@/lib/characters';
 import {
   CreateCharacterDialog,
   type NewCharacterPayload,
 } from './create-character-dialog';
 import { VoicePlayButton } from './voice-play-button';
-
-const MAX_CUSTOM_CHARACTERS = 10;
 
 function getInitials(name: string): string {
   return name

--- a/apps/web/lib/characters.ts
+++ b/apps/web/lib/characters.ts
@@ -1,6 +1,8 @@
 import { normalizeModelId } from '@/data/models';
 import type { Preset } from '@/data/presets';
 
+export const MAX_CUSTOM_CHARACTERS = 10;
+
 // ─── API response shape (from POST /api/characters) ───────────────────────────
 
 export interface ApiCharacterResponse {


### PR DESCRIPTION
## Summary

Centralize the custom-character limit so the preset selector and characters API use the same value. Server-side enforcement remains authoritative while the UI continues to hide the add control at the limit.

## Changes

- Export `MAX_CUSTOM_CHARACTERS` from the shared characters module.
- Import the shared constant in the preset selector and characters API route.
- Remove the two duplicate local definitions.

## How to test

1. Run `pnpm run fixall`.
2. Run `pnpm run type-check`.
3. Verify that a paid user with 10 custom characters does not see the add-character control, and that a POST for an 11th character still returns the existing 400 response.

## Scope

- [x] Frontend
- [x] Backend
- [ ] Database
- [ ] Infra / config
- [ ] Docs
- [ ] Breaking change

## Checklist

- [x] I self-reviewed this PR
- [x] I ran `pnpm run fixall`
- [x] I ran `pnpm run type-check`
- [ ] I added or updated tests where needed
- [ ] I updated translations for any user-facing text
- [ ] I updated docs/comments where needed
- [ ] I included screenshots/video for UI changes
- [ ] I documented env vars, migrations, or rollout notes if needed

## Related issues

Closes #514

## Notes for reviewers

The existing API limit test passed (26 tests in `tests/characters-api.test.ts`), and the existing preset-selector max-limit case passed via a temporary focused Vitest include override. A full local web-suite attempt did not complete because `redis-memory-server` stalled while downloading Redis 7.2.4 at 0%; no Redis-dependent code is changed here.
