### PR TITLE
fix: keep voice names fully readable in the Generate voice selector

### DIFF
--- a/apps/web/components/voice-select.tsx
+++ b/apps/web/components/voice-select.tsx
@@ -243,7 +243,10 @@ export function VoiceSelect({
         <Button
           aria-expanded={open}
           aria-label={t('selectVoicePlaceholder')}
-          className={cn('h-12 w-full justify-between px-3', className)}
+          className={cn(
+            'h-auto min-h-12 w-full justify-between whitespace-normal px-3 py-2 text-left',
+            className,
+          )}
           role="combobox"
           variant="outline"
         >
@@ -253,12 +256,14 @@ export function VoiceSelect({
                 <AudioLines className="size-4 text-muted-foreground" />
               </span>
               <span className="flex min-w-0 flex-col items-start">
-                <span className="truncate font-medium text-sm leading-tight">
+                <span className="break-words font-medium text-sm leading-tight">
                   {capitalizeFirstLetter(selected.name)}
                 </span>
-                <span className="flex items-center gap-1.5 text-muted-foreground text-xs">
+                <span className="flex flex-wrap items-center gap-1.5 text-muted-foreground text-xs">
                   {selectedModel && <ModelDot model={selectedModel} />}
-                  {selectedModel} &middot; {selected.description ?? ''}
+                  <span className="break-words">
+                    {selectedModel} &middot; {selected.description ?? ''}
+                  </span>
                 </span>
               </span>
             </span>
@@ -434,12 +439,15 @@ export function VoiceSelect({
                       type="button"
                     >
                       <span className="flex min-w-0 flex-1 flex-col">
-                        <span className="flex items-center gap-2">
-                          <span className="truncate font-medium text-sm">
+                        {/* Wrap instead of truncating so long descriptions push
+                            to their own line and the voice name stays readable
+                            on narrow screens. */}
+                        <span className="flex flex-wrap items-baseline gap-x-2">
+                          <span className="break-words font-medium text-sm">
                             {capitalizeFirstLetter(voice.name)}
                           </span>
                           {voice.description && (
-                            <span className="text-muted-foreground text-xs">
+                            <span className="min-w-0 break-words text-muted-foreground text-xs">
                               {voice.description}
                             </span>
                           )}


### PR DESCRIPTION
## What changed

The voice name in the Generate voice selector was ellipsed on mobile (e.g. `Zag...`) because the name carried `truncate` and was the flex item that shrank when a long description shared the row.

- **List rows**: the name/description row now wraps (`flex flex-wrap items-baseline`) and the name uses `break-words` instead of `truncate`, so a long description moves to its own line and the name is always fully readable.
- **Trigger button**: `h-12` + `whitespace-nowrap` + `truncate` replaced with `h-auto min-h-12 py-2 whitespace-normal text-left`, so the selected voice name wraps and grows the button instead of being clipped.

## Desktop

`min-h-12` preserves the current trigger height and rows only wrap when content does not fit, so desktop rendering is unchanged.

## Tests

CSS-class only change (no logic, no text-content change). `pnpm fixall`, `pnpm type-check` and `pnpm test` could not be run in the agent environment (no pnpm/node_modules) - relying on CI.

Fixes #521

Generated with [Claude Code](https://claude.ai/code)