### PR TITLE
Let users clear their audio history

### DIFF
--- a/apps/web/app/[lang]/(dashboard)/dashboard/history/actions.ts
+++ b/apps/web/app/[lang]/(dashboard)/dashboard/history/actions.ts
@@ -52,6 +52,13 @@ async function deleteAudioFiles(options: DeleteAudioFilesOptions) {
     await deleteQuery.select('id, storage_key');
 
   if (error) {
+    captureException(error, {
+      extra:
+        options.scope === 'single'
+          ? { audioId: options.id, errorData: error }
+          : { errorData: error, scope: 'all' },
+      user: { email: user.email, id: user.id },
+    });
     throw new Error('Failed to delete audio files', { cause: error });
   }
 

--- a/apps/web/app/[lang]/(dashboard)/dashboard/history/actions.ts
+++ b/apps/web/app/[lang]/(dashboard)/dashboard/history/actions.ts
@@ -7,90 +7,95 @@ import { after } from 'next/server';
 import PostHogClient from '@/lib/posthog';
 import { createClient } from '@/lib/supabase/server';
 
-// Initialize Redis
 const redis = Redis.fromEnv();
+
+interface DeleteAudioFilesOptions {
+  id?: string;
+}
+
+async function deleteAudioFiles({ id }: DeleteAudioFilesOptions = {}) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    throw new Error('User not found');
+  }
+
+  let deleteQuery = supabase
+    .from('audio_files')
+    .update({
+      deleted_at: new Date().toISOString(),
+      status: 'deleted',
+    })
+    .eq('user_id', user.id)
+    .eq('status', 'active');
+
+  if (id) {
+    deleteQuery = deleteQuery.eq('id', id);
+  }
+
+  const { data: deletedAudioFiles, error } =
+    await deleteQuery.select('id, storage_key');
+
+  if (error) {
+    throw new Error('Failed to delete audio files', { cause: error });
+  }
+
+  if (id && deletedAudioFiles.length === 0) {
+    throw new Error('Audio file not found or unauthorized');
+  }
+
+  const storageKeys = deletedAudioFiles.map(({ storage_key }) => storage_key);
+
+  if (storageKeys.length > 0) {
+    try {
+      // Clear generated-audio cache entries so deleted audio can be regenerated.
+      await redis.del(...storageKeys);
+    } catch (cacheError) {
+      // The database is authoritative. A cache outage must not report a
+      // successful soft delete as failed.
+      captureException(cacheError, {
+        extra: {
+          audioIds: deletedAudioFiles.map(({ id: audioId }) => audioId),
+        },
+        level: 'warning',
+        user: { email: user.email, id: user.id },
+      });
+    }
+  }
+
+  after(async () => {
+    const posthog = PostHogClient();
+    posthog.capture({
+      distinctId: user.id,
+      event: id ? 'delete-audio' : 'delete-all-audio',
+      properties: id ? { id } : { count: deletedAudioFiles.length },
+    });
+    await posthog.shutdown();
+  });
+
+  // R2 objects are intentionally retained for potential recovery.
+  return { deletedCount: deletedAudioFiles.length, success: true };
+}
 
 export const handleDeleteAction = async (id: string) => {
   try {
-    const supabase = await createClient();
-
-    const { data } = await supabase.auth.getUser();
-    const user = data?.user;
-
-    if (!user) {
-      throw new Error('User not found');
-    }
-
-    // First, get the audio file to ensure it exists and belongs to the user
-    const { data: audioFile, error: fetchError } = await supabase
-      .from('audio_files')
-      .select('url, storage_key')
-      .eq('id', id)
-      .eq('user_id', user.id)
-      .single();
-
-    if (fetchError) {
-      captureException(fetchError, {
-        extra: {
-          audioId: id,
-          errorData: fetchError,
-        },
-        user: {
-          email: user.email,
-          id: user.id,
-        },
-      });
-      throw new Error('Audio file not found');
-    }
-
-    if (!audioFile) {
-      throw new Error('Audio file not found or unauthorized');
-    }
-
-    // Soft delete: update status to 'deleted' and set deleted_at timestamp
-    const { error: deleteError } = await supabase
-      .from('audio_files')
-      .update({
-        deleted_at: new Date().toISOString(),
-        status: 'deleted',
-      })
-      .eq('id', id)
-      .eq('user_id', user.id);
-
-    // allow for regeneration of audio
-    await redis.del(audioFile.storage_key);
-
-    after(async () => {
-      const posthog = PostHogClient();
-      posthog.capture({
-        distinctId: user.id,
-        event: 'delete-audio',
-        properties: {
-          id,
-        },
-      });
-      await posthog.shutdown();
-    });
-
-    if (deleteError) {
-      captureException(deleteError, {
-        extra: {
-          audioId: id,
-        },
-        user: { email: user.email, id: user.id },
-      });
-      throw new Error('Failed to delete audio file');
-    }
-
-    // Note: We keep the file in R2 storage for potential recovery
-    // In the future, we could implement a cleanup job to remove old deleted files
-
-    return { success: true };
+    return await deleteAudioFiles({ id });
   } catch (error) {
-    captureException(error, {
-      extra: { audioId: id },
-    });
+    captureException(error, { extra: { audioId: id } });
     console.error('Error deleting audio file:', error);
+    throw error;
+  }
+};
+
+export const handleDeleteAllAction = async () => {
+  try {
+    return await deleteAudioFiles();
+  } catch (error) {
+    captureException(error, { extra: { scope: 'all' } });
+    console.error('Error deleting all audio files:', error);
     throw error;
   }
 };

--- a/apps/web/app/[lang]/(dashboard)/dashboard/history/actions.ts
+++ b/apps/web/app/[lang]/(dashboard)/dashboard/history/actions.ts
@@ -5,6 +5,7 @@ import { Redis } from '@upstash/redis';
 import { after } from 'next/server';
 
 import PostHogClient from '@/lib/posthog';
+import { createAdminClient } from '@/lib/supabase/admin';
 import { createClient } from '@/lib/supabase/server';
 
 const redis = Redis.fromEnv();
@@ -30,7 +31,10 @@ async function deleteAudioFiles(options: DeleteAudioFilesOptions) {
     throw new Error('User not found');
   }
 
-  let deleteQuery = supabase
+  // The tracked audio_files RLS policies are read-only. Authenticate with the
+  // session client, then keep this privileged write scoped to the user's rows.
+  const admin = createAdminClient();
+  let deleteQuery = admin
     .from('audio_files')
     .update({
       deleted_at: new Date().toISOString(),

--- a/apps/web/app/[lang]/(dashboard)/dashboard/history/actions.ts
+++ b/apps/web/app/[lang]/(dashboard)/dashboard/history/actions.ts
@@ -80,7 +80,9 @@ async function deleteAudioFiles(options: DeleteAudioFilesOptions) {
       index + CACHE_DELETE_BATCH_SIZE,
     );
     try {
-      // Clear generated-audio cache entries so deleted audio can be regenerated.
+      // Cache keys are shared across users. Match the existing single-delete
+      // regeneration behavior even though another user's identical request
+      // may need to regenerate after this eviction.
       await redis.del(...storageKeyBatch);
     } catch (cacheError) {
       // The database is authoritative. A cache outage must not report a

--- a/apps/web/app/[lang]/(dashboard)/dashboard/history/actions.ts
+++ b/apps/web/app/[lang]/(dashboard)/dashboard/history/actions.ts
@@ -9,11 +9,18 @@ import { createClient } from '@/lib/supabase/server';
 
 const redis = Redis.fromEnv();
 
-interface DeleteAudioFilesOptions {
-  id?: string;
-}
+type DeleteAudioFilesOptions =
+  | { scope: 'all' }
+  | { id: string; scope: 'single' };
 
-async function deleteAudioFiles({ id }: DeleteAudioFilesOptions = {}) {
+async function deleteAudioFiles(options: DeleteAudioFilesOptions) {
+  if (
+    options.scope === 'single' &&
+    (typeof options.id !== 'string' || options.id.length === 0)
+  ) {
+    throw new Error('Audio file not found or unauthorized');
+  }
+
   const supabase = await createClient();
   const {
     data: { user },
@@ -32,8 +39,8 @@ async function deleteAudioFiles({ id }: DeleteAudioFilesOptions = {}) {
     .eq('user_id', user.id)
     .eq('status', 'active');
 
-  if (id) {
-    deleteQuery = deleteQuery.eq('id', id);
+  if (options.scope === 'single') {
+    deleteQuery = deleteQuery.eq('id', options.id);
   }
 
   const { data: deletedAudioFiles, error } =
@@ -43,7 +50,7 @@ async function deleteAudioFiles({ id }: DeleteAudioFilesOptions = {}) {
     throw new Error('Failed to delete audio files', { cause: error });
   }
 
-  if (id && deletedAudioFiles.length === 0) {
+  if (options.scope === 'single' && deletedAudioFiles.length === 0) {
     throw new Error('Audio file not found or unauthorized');
   }
 
@@ -70,8 +77,11 @@ async function deleteAudioFiles({ id }: DeleteAudioFilesOptions = {}) {
     const posthog = PostHogClient();
     posthog.capture({
       distinctId: user.id,
-      event: id ? 'delete-audio' : 'delete-all-audio',
-      properties: id ? { id } : { count: deletedAudioFiles.length },
+      event: options.scope === 'single' ? 'delete-audio' : 'delete-all-audio',
+      properties:
+        options.scope === 'single'
+          ? { id: options.id }
+          : { count: deletedAudioFiles.length },
     });
     await posthog.shutdown();
   });
@@ -82,7 +92,7 @@ async function deleteAudioFiles({ id }: DeleteAudioFilesOptions = {}) {
 
 export const handleDeleteAction = async (id: string) => {
   try {
-    return await deleteAudioFiles({ id });
+    return await deleteAudioFiles({ id, scope: 'single' });
   } catch (error) {
     captureException(error, { extra: { audioId: id } });
     console.error('Error deleting audio file:', error);
@@ -92,7 +102,7 @@ export const handleDeleteAction = async (id: string) => {
 
 export const handleDeleteAllAction = async () => {
   try {
-    return await deleteAudioFiles();
+    return await deleteAudioFiles({ scope: 'all' });
   } catch (error) {
     captureException(error, { extra: { scope: 'all' } });
     console.error('Error deleting all audio files:', error);

--- a/apps/web/app/[lang]/(dashboard)/dashboard/history/actions.ts
+++ b/apps/web/app/[lang]/(dashboard)/dashboard/history/actions.ts
@@ -81,8 +81,8 @@ async function deleteAudioFiles(options: DeleteAudioFilesOptions) {
     );
     try {
       // Cache keys are shared across users. Match the existing single-delete
-      // regeneration behavior even though another user's identical request
-      // may need to regenerate after this eviction.
+      // behavior even though another user's identical request may become a
+      // cache miss and consume credits after this eviction.
       await redis.del(...storageKeyBatch);
     } catch (cacheError) {
       // The database is authoritative. A cache outage must not report a

--- a/apps/web/app/[lang]/(dashboard)/dashboard/history/actions.ts
+++ b/apps/web/app/[lang]/(dashboard)/dashboard/history/actions.ts
@@ -6,6 +6,7 @@ import { after } from 'next/server';
 
 import PostHogClient from '@/lib/posthog';
 import { createAdminClient } from '@/lib/supabase/admin';
+import { getMyActiveAudioFilesFilter } from '@/lib/supabase/queries.client';
 import { createClient } from '@/lib/supabase/server';
 
 const redis = Redis.fromEnv();
@@ -41,8 +42,7 @@ async function deleteAudioFiles(options: DeleteAudioFilesOptions) {
       deleted_at: new Date().toISOString(),
       status: 'deleted',
     })
-    .eq('user_id', user.id)
-    .eq('status', 'active');
+    .match(getMyActiveAudioFilesFilter(user.id));
 
   if (options.scope === 'single') {
     deleteQuery = deleteQuery.eq('id', options.id);

--- a/apps/web/app/[lang]/(dashboard)/dashboard/history/actions.ts
+++ b/apps/web/app/[lang]/(dashboard)/dashboard/history/actions.ts
@@ -96,18 +96,20 @@ async function deleteAudioFiles(options: DeleteAudioFilesOptions) {
     }
   }
 
-  after(async () => {
-    const posthog = PostHogClient();
-    posthog.capture({
-      distinctId: user.id,
-      event: options.scope === 'single' ? 'delete-audio' : 'delete-all-audio',
-      properties:
-        options.scope === 'single'
-          ? { id: options.id }
-          : { count: deletedAudioFiles.length },
+  if (deletedAudioFiles.length > 0) {
+    after(async () => {
+      const posthog = PostHogClient();
+      posthog.capture({
+        distinctId: user.id,
+        event: options.scope === 'single' ? 'delete-audio' : 'delete-all-audio',
+        properties:
+          options.scope === 'single'
+            ? { id: options.id }
+            : { count: deletedAudioFiles.length },
+      });
+      await posthog.shutdown();
     });
-    await posthog.shutdown();
-  });
+  }
 
   // R2 objects are intentionally retained for potential recovery.
   return { deletedCount: deletedAudioFiles.length, success: true };

--- a/apps/web/app/[lang]/(dashboard)/dashboard/history/actions.ts
+++ b/apps/web/app/[lang]/(dashboard)/dashboard/history/actions.ts
@@ -9,6 +9,7 @@ import { createAdminClient } from '@/lib/supabase/admin';
 import { createClient } from '@/lib/supabase/server';
 
 const redis = Redis.fromEnv();
+const CACHE_DELETE_BATCH_SIZE = 100;
 
 type DeleteAudioFilesOptions =
   | { scope: 'all' }
@@ -58,18 +59,29 @@ async function deleteAudioFiles(options: DeleteAudioFilesOptions) {
     throw new Error('Audio file not found or unauthorized');
   }
 
-  const storageKeys = deletedAudioFiles.map(({ storage_key }) => storage_key);
+  const storageKeys = [
+    ...new Set(deletedAudioFiles.map(({ storage_key }) => storage_key)),
+  ];
 
-  if (storageKeys.length > 0) {
+  for (
+    let index = 0;
+    index < storageKeys.length;
+    index += CACHE_DELETE_BATCH_SIZE
+  ) {
+    const storageKeyBatch = storageKeys.slice(
+      index,
+      index + CACHE_DELETE_BATCH_SIZE,
+    );
     try {
       // Clear generated-audio cache entries so deleted audio can be regenerated.
-      await redis.del(...storageKeys);
+      await redis.del(...storageKeyBatch);
     } catch (cacheError) {
       // The database is authoritative. A cache outage must not report a
       // successful soft delete as failed.
       captureException(cacheError, {
         extra: {
-          audioIds: deletedAudioFiles.map(({ id: audioId }) => audioId),
+          deletedCount: deletedAudioFiles.length,
+          storageKeys: storageKeyBatch,
         },
         level: 'warning',
         user: { email: user.email, id: user.id },

--- a/apps/web/app/[lang]/(dashboard)/dashboard/history/data-table.tsx
+++ b/apps/web/app/[lang]/(dashboard)/dashboard/history/data-table.tsx
@@ -38,6 +38,7 @@ import {
   getMyAudioFiles,
 } from '@/lib/supabase/queries.client';
 import { useColumns } from './columns';
+import { DeleteAllButton } from './delete-all-button';
 
 interface DataTableProps {
   showApiColumns: boolean;
@@ -94,6 +95,10 @@ export function DataTable({ userId, showApiColumns }: DataTableProps) {
           </p>
         </div>
         <div className="flex items-center gap-2">
+          <DeleteAllButton
+            disabled={(data?.length ?? 0) === 0}
+            userId={userId}
+          />
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <Button size="sm" variant="outline">

--- a/apps/web/app/[lang]/(dashboard)/dashboard/history/data-table.tsx
+++ b/apps/web/app/[lang]/(dashboard)/dashboard/history/data-table.tsx
@@ -96,6 +96,7 @@ export function DataTable({ userId, showApiColumns }: DataTableProps) {
         </div>
         <div className="flex items-center gap-2">
           <DeleteAllButton
+            count={data?.length ?? 0}
             disabled={(data?.length ?? 0) === 0}
             userId={userId}
           />

--- a/apps/web/app/[lang]/(dashboard)/dashboard/history/data-table.tsx
+++ b/apps/web/app/[lang]/(dashboard)/dashboard/history/data-table.tsx
@@ -42,10 +42,15 @@ import { DeleteAllButton } from './delete-all-button';
 
 interface DataTableProps {
   showApiColumns: boolean;
+  totalCount: number;
   userId: string;
 }
 
-export function DataTable({ userId, showApiColumns }: DataTableProps) {
+export function DataTable({
+  userId,
+  showApiColumns,
+  totalCount,
+}: DataTableProps) {
   const t = useTranslations('history');
   const [sorting, setSorting] = useState<SortingState>([]);
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
@@ -96,8 +101,8 @@ export function DataTable({ userId, showApiColumns }: DataTableProps) {
         </div>
         <div className="flex items-center gap-2">
           <DeleteAllButton
-            count={data?.length ?? 0}
-            disabled={(data?.length ?? 0) === 0}
+            count={totalCount}
+            disabled={totalCount === 0}
             userId={userId}
           />
           <DropdownMenu>

--- a/apps/web/app/[lang]/(dashboard)/dashboard/history/data-table.tsx
+++ b/apps/web/app/[lang]/(dashboard)/dashboard/history/data-table.tsx
@@ -36,21 +36,17 @@ import useSupabaseBrowser from '@/lib/supabase/client';
 import {
   type AudioFileAndVoicesRes,
   getMyAudioFiles,
+  getMyAudioFilesCount,
 } from '@/lib/supabase/queries.client';
 import { useColumns } from './columns';
 import { DeleteAllButton } from './delete-all-button';
 
 interface DataTableProps {
   showApiColumns: boolean;
-  totalCount: number;
   userId: string;
 }
 
-export function DataTable({
-  userId,
-  showApiColumns,
-  totalCount,
-}: DataTableProps) {
+export function DataTable({ userId, showApiColumns }: DataTableProps) {
   const t = useTranslations('history');
   const [sorting, setSorting] = useState<SortingState>([]);
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
@@ -61,6 +57,11 @@ export function DataTable({
     enabled: !!userId,
     queryFn: () => getMyAudioFiles(supabase, userId),
     queryKey: ['audio_files', userId],
+  });
+  const { data: totalCount = 0 } = useQuery({
+    enabled: !!userId,
+    queryFn: () => getMyAudioFilesCount(supabase, userId),
+    queryKey: ['audio_files_count', userId],
   });
   const columns = useColumns({ showApiColumns });
 

--- a/apps/web/app/[lang]/(dashboard)/dashboard/history/delete-all-button.tsx
+++ b/apps/web/app/[lang]/(dashboard)/dashboard/history/delete-all-button.tsx
@@ -61,6 +61,7 @@ export function DeleteAllButton({ disabled, userId }: DeleteAllButtonProps) {
         <Button
           aria-label={t('all.trigger')}
           disabled={disabled}
+          size="sm"
           type="button"
           variant="destructive"
         >

--- a/apps/web/app/[lang]/(dashboard)/dashboard/history/delete-all-button.tsx
+++ b/apps/web/app/[lang]/(dashboard)/dashboard/history/delete-all-button.tsx
@@ -21,11 +21,16 @@ import type { AudioFileAndVoicesRes } from '@/lib/supabase/queries.client';
 import { handleDeleteAllAction } from './actions';
 
 interface DeleteAllButtonProps {
+  count: number;
   disabled: boolean;
   userId: string;
 }
 
-export function DeleteAllButton({ disabled, userId }: DeleteAllButtonProps) {
+export function DeleteAllButton({
+  count,
+  disabled,
+  userId,
+}: DeleteAllButtonProps) {
   const t = useTranslations('history.delete');
   const queryClient = useQueryClient();
   const [isDeleting, setIsDeleting] = useState(false);
@@ -73,7 +78,7 @@ export function DeleteAllButton({ disabled, userId }: DeleteAllButtonProps) {
         <AlertDialogHeader>
           <AlertDialogTitle>{t('all.title')}</AlertDialogTitle>
           <AlertDialogDescription>
-            {t('all.description')}
+            {t('all.description', { count })}
           </AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>

--- a/apps/web/app/[lang]/(dashboard)/dashboard/history/delete-all-button.tsx
+++ b/apps/web/app/[lang]/(dashboard)/dashboard/history/delete-all-button.tsx
@@ -47,6 +47,7 @@ export function DeleteAllButton({
         ['audio_files', userId],
         [],
       );
+      queryClient.setQueryData(['audio_files_count', userId], 0);
       router.refresh();
       setIsOpen(false);
       toast.success(t('all.success'));

--- a/apps/web/app/[lang]/(dashboard)/dashboard/history/delete-all-button.tsx
+++ b/apps/web/app/[lang]/(dashboard)/dashboard/history/delete-all-button.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import { useQueryClient } from '@tanstack/react-query';
+import { Trash2 } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import { useState } from 'react';
+import { toast } from 'sonner';
+
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog';
+import { Button } from '@/components/ui/button';
+import type { AudioFileAndVoicesRes } from '@/lib/supabase/queries.client';
+import { handleDeleteAllAction } from './actions';
+
+interface DeleteAllButtonProps {
+  disabled: boolean;
+  userId: string;
+}
+
+export function DeleteAllButton({ disabled, userId }: DeleteAllButtonProps) {
+  const t = useTranslations('history.delete');
+  const queryClient = useQueryClient();
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [isOpen, setIsOpen] = useState(false);
+
+  const handleDeleteAll = async () => {
+    setIsDeleting(true);
+
+    try {
+      await handleDeleteAllAction();
+      queryClient.setQueryData<AudioFileAndVoicesRes[]>(
+        ['audio_files', userId],
+        [],
+      );
+      setIsOpen(false);
+      toast.success(t('all.success'));
+    } catch (error) {
+      console.error('Failed to delete all audio files:', error);
+      toast.error(t('all.error'));
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  return (
+    <AlertDialog
+      onOpenChange={(open) => {
+        if (!isDeleting) setIsOpen(open);
+      }}
+      open={isOpen}
+    >
+      <AlertDialogTrigger asChild>
+        <Button
+          aria-label={t('all.trigger')}
+          disabled={disabled}
+          type="button"
+          variant="destructive"
+        >
+          <Trash2 />
+          <span className="hidden sm:inline">{t('all.trigger')}</span>
+        </Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{t('all.title')}</AlertDialogTitle>
+          <AlertDialogDescription>
+            {t('all.description')}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isDeleting}>
+            {t('cancel')}
+          </AlertDialogCancel>
+          <Button
+            disabled={isDeleting}
+            onClick={handleDeleteAll}
+            type="button"
+            variant="destructive"
+          >
+            {isDeleting ? t('deleting') : t('all.confirm')}
+          </Button>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/apps/web/app/[lang]/(dashboard)/dashboard/history/delete-all-button.tsx
+++ b/apps/web/app/[lang]/(dashboard)/dashboard/history/delete-all-button.tsx
@@ -2,6 +2,7 @@
 
 import { useQueryClient } from '@tanstack/react-query';
 import { Trash2 } from 'lucide-react';
+import { useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { useState } from 'react';
 import { toast } from 'sonner';
@@ -33,6 +34,7 @@ export function DeleteAllButton({
 }: DeleteAllButtonProps) {
   const t = useTranslations('history.delete');
   const queryClient = useQueryClient();
+  const router = useRouter();
   const [isDeleting, setIsDeleting] = useState(false);
   const [isOpen, setIsOpen] = useState(false);
 
@@ -45,6 +47,7 @@ export function DeleteAllButton({
         ['audio_files', userId],
         [],
       );
+      router.refresh();
       setIsOpen(false);
       toast.success(t('all.success'));
     } catch (error) {

--- a/apps/web/app/[lang]/(dashboard)/dashboard/history/delete-button.tsx
+++ b/apps/web/app/[lang]/(dashboard)/dashboard/history/delete-button.tsx
@@ -2,7 +2,8 @@
 
 import { Trash2 } from 'lucide-react';
 import { useRouter } from 'next/navigation';
-import { useCallback, useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { useState } from 'react';
 import { toast } from 'sonner';
 
 import {
@@ -27,25 +28,26 @@ export function DeleteButton({
   id: string;
   handleCloseDropdown: () => void;
 }) {
+  const t = useTranslations('history.delete');
   const [isDeleting, setIsDeleting] = useState(false);
   const [isOpen, setIsOpen] = useState(false);
   const router = useRouter();
 
-  const handleDelete = useCallback(async () => {
+  const handleDelete = async () => {
     setIsDeleting(true);
     try {
       await handleDeleteAction(id);
       setIsOpen(false);
-      toast.success('Audio file deleted successfully');
+      toast.success(t('single.success'));
       handleCloseDropdown(); // Close the dropdown menu after deletion
       router.refresh();
     } catch (error) {
       console.error('Failed to delete audio file:', error);
-      toast.error('Failed to delete audio file. Please try again later.');
+      toast.error(t('single.error'));
     } finally {
       setIsDeleting(false);
     }
-  }, [id, handleCloseDropdown, router]);
+  };
 
   return (
     <AlertDialog onOpenChange={setIsOpen} open={isOpen}>
@@ -57,26 +59,27 @@ export function DeleteButton({
           }}
         >
           <Trash2 className="mr-2 h-4 w-4" />
-          Delete
+          {t('single.trigger')}
         </DropdownMenuItem>
       </AlertDialogTrigger>
       <AlertDialogContent>
         <AlertDialogHeader>
-          <AlertDialogTitle>Delete Audio File</AlertDialogTitle>
+          <AlertDialogTitle>{t('single.title')}</AlertDialogTitle>
           <AlertDialogDescription>
-            Are you sure you want to delete this audio file? This action cannot
-            be undone.
+            {t('single.description')}
           </AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>
-          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogCancel disabled={isDeleting}>
+            {t('cancel')}
+          </AlertDialogCancel>
           <AlertDialogAction asChild>
             <Button
               disabled={isDeleting}
               onClick={handleDelete}
               variant="destructive"
             >
-              {isDeleting ? 'Deleting...' : 'Delete'}
+              {isDeleting ? t('deleting') : t('single.confirm')}
             </Button>
           </AlertDialogAction>
         </AlertDialogFooter>

--- a/apps/web/app/[lang]/(dashboard)/dashboard/history/page.tsx
+++ b/apps/web/app/[lang]/(dashboard)/dashboard/history/page.tsx
@@ -51,16 +51,16 @@ export default async function HistoryPage(props: {
       ]);
 
   queryClient.setQueryData(['audio_files', user.id], audioFiles);
+  queryClient.setQueryData(
+    ['audio_files_count', user.id],
+    totalAudioFilesCount ?? 0,
+  );
 
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>
       <div className="container mx-auto pb-10">
         <h2 className="mb-4 font-bold text-2xl">{t('header')}</h2>
-        <DataTable
-          showApiColumns={(apiKeysCount ?? 0) > 0}
-          totalCount={totalAudioFilesCount ?? 0}
-          userId={user.id}
-        />
+        <DataTable showApiColumns={(apiKeysCount ?? 0) > 0} userId={user.id} />
       </div>
     </HydrationBoundary>
   );

--- a/apps/web/app/[lang]/(dashboard)/dashboard/history/page.tsx
+++ b/apps/web/app/[lang]/(dashboard)/dashboard/history/page.tsx
@@ -7,7 +7,10 @@ import { getTranslations } from 'next-intl/server';
 
 import { E2E_AUDIO_FILES, isE2E } from '@/lib/e2e-mocks';
 import type { Locale } from '@/lib/i18n/i18n-config';
-import { getMyAudioFilesQuery } from '@/lib/supabase/queries.client';
+import {
+  getMyAudioFilesCountQuery,
+  getMyAudioFilesQuery,
+} from '@/lib/supabase/queries.client';
 import { createClient } from '@/lib/supabase/server';
 import { DataTable } from './data-table';
 
@@ -40,11 +43,7 @@ export default async function HistoryPage(props: {
       ]
     : await Promise.all([
         getMyAudioFilesQuery(supabase, user.id),
-        supabase
-          .from('audio_files')
-          .select('id', { count: 'exact', head: true })
-          .eq('user_id', user.id)
-          .eq('status', 'active'),
+        getMyAudioFilesCountQuery(supabase, user.id),
         supabase
           .from('api_keys')
           .select('id', { count: 'exact', head: true })

--- a/apps/web/app/[lang]/(dashboard)/dashboard/history/page.tsx
+++ b/apps/web/app/[lang]/(dashboard)/dashboard/history/page.tsx
@@ -28,10 +28,23 @@ export default async function HistoryPage(props: {
   // In E2E mode serve deterministic data: the table is hydrated from this RSC
   // query and the client never refetches, so live rows would otherwise leak
   // into the Argos screenshot. Pin apiKeysCount to 0 to hide the API columns.
-  const [{ data: audioFiles }, { count: apiKeysCount }] = isE2E()
-    ? [{ data: E2E_AUDIO_FILES }, { count: 0 }]
+  const [
+    { data: audioFiles },
+    { count: totalAudioFilesCount },
+    { count: apiKeysCount },
+  ] = isE2E()
+    ? [
+        { data: E2E_AUDIO_FILES },
+        { count: E2E_AUDIO_FILES.length },
+        { count: 0 },
+      ]
     : await Promise.all([
         getMyAudioFilesQuery(supabase, user.id),
+        supabase
+          .from('audio_files')
+          .select('id', { count: 'exact', head: true })
+          .eq('user_id', user.id)
+          .eq('status', 'active'),
         supabase
           .from('api_keys')
           .select('id', { count: 'exact', head: true })
@@ -44,7 +57,11 @@ export default async function HistoryPage(props: {
     <HydrationBoundary state={dehydrate(queryClient)}>
       <div className="container mx-auto pb-10">
         <h2 className="mb-4 font-bold text-2xl">{t('header')}</h2>
-        <DataTable showApiColumns={(apiKeysCount ?? 0) > 0} userId={user.id} />
+        <DataTable
+          showApiColumns={(apiKeysCount ?? 0) > 0}
+          totalCount={totalAudioFilesCount ?? 0}
+          userId={user.id}
+        />
       </div>
     </HydrationBoundary>
   );

--- a/apps/web/app/actions.ts
+++ b/apps/web/app/actions.ts
@@ -114,7 +114,7 @@ export const handleDeleteAccountAction = async ({ lang }: { lang: Locale }) => {
     { data: audio_files, error: audioFilesError },
     { data: customCharacters, error: customCharactersError },
     { data: apiKeys, error: apiKeysError },
-    { count: usageEventsCount, error: usageEventsError },
+    { count: retainedUsageEventsCount, error: usageEventsError },
   ] = await Promise.all([
     supabase.from('audio_files').select().eq('user_id', user.id),
     supabase.from('characters').select('id, prompt_id').eq('user_id', user.id),
@@ -204,19 +204,16 @@ export const handleDeleteAccountAction = async ({ lang }: { lang: Locale }) => {
     }
   }
 
-  const { error: deleteUsageEventsError } = await supabase
-    .from('usage_events')
-    .delete()
-    .eq('user_id', user.id);
-
-  if (error || deleteError || deleteUsageEventsError) {
+  if (error || deleteError) {
     throw new Error('User deletion failed');
   }
   logger.info('User deleted', {
     apiKeysDeleted: apiKeys ? apiKeys.length : 0,
     deleted: deleteData?.length,
     deletedCustomCharacters: customCharacters?.length ?? 0,
-    usageEventsDeleted: usageEventsCount ?? 0,
+    // usage_events is an immutable audit log protected from deletion by the
+    // database. Report retained rows instead of claiming they were removed.
+    usageEventsRetained: retainedUsageEventsCount ?? 0,
     userId: user.id,
   });
 
@@ -224,7 +221,7 @@ export const handleDeleteAccountAction = async ({ lang }: { lang: Locale }) => {
     apiKeysDeleted: apiKeys?.length ?? 0,
     deleted: deleteData?.length,
     deletedCustomCharacters: customCharacters?.length ?? 0,
-    usageEventsDeleted: usageEventsCount ?? 0,
+    usageEventsRetained: retainedUsageEventsCount ?? 0,
     userId: user.id,
   });
   await supabase.auth.signOut();

--- a/apps/web/app/actions.ts
+++ b/apps/web/app/actions.ts
@@ -6,6 +6,7 @@ import { z } from 'zod';
 
 import type { Locale } from '@/lib/i18n/i18n-config';
 import { deleteFileFromR2 } from '@/lib/storage/upload';
+import { createAdminClient } from '@/lib/supabase/admin';
 import { createClient } from '@/lib/supabase/server';
 import { encodedRedirect } from '@/lib/utils';
 
@@ -158,14 +159,15 @@ export const handleDeleteAccountAction = async ({ lang }: { lang: Locale }) => {
     });
   }
 
-  const { error: deleteError, data: deleteData } = await supabase
+  const admin = createAdminClient();
+  const { error: deleteError, data: deleteData } = await admin
     .from('audio_files')
     .update({
       deleted_at: deletedAtIso,
       status: 'deleted',
     })
     .eq('user_id', user.id)
-    .select();
+    .select('id');
 
   if (customCharacters && customCharacters.length > 0) {
     const characterIds = customCharacters.map((character) => character.id);

--- a/apps/web/app/actions.ts
+++ b/apps/web/app/actions.ts
@@ -216,7 +216,7 @@ export const handleDeleteAccountAction = async ({ lang }: { lang: Locale }) => {
     deletedCustomCharacters: customCharacters?.length ?? 0,
     // usage_events is an immutable audit log protected from deletion by the
     // database. Report retained rows instead of claiming they were removed.
-    usageEventsRetained: retainedUsageEventsCount ?? 0,
+    usageEventsRetained: retainedUsageEventsCount,
     userId: user.id,
   });
 
@@ -224,7 +224,7 @@ export const handleDeleteAccountAction = async ({ lang }: { lang: Locale }) => {
     apiKeysDeleted: apiKeys?.length ?? 0,
     deleted: deleteData?.length,
     deletedCustomCharacters: customCharacters?.length ?? 0,
-    usageEventsRetained: retainedUsageEventsCount ?? 0,
+    usageEventsRetained: retainedUsageEventsCount,
     userId: user.id,
   });
   await supabase.auth.signOut();

--- a/apps/web/app/actions.ts
+++ b/apps/web/app/actions.ts
@@ -125,13 +125,16 @@ export const handleDeleteAccountAction = async ({ lang }: { lang: Locale }) => {
       .eq('user_id', user.id),
   ]);
 
-  if (
-    audioFilesError ||
-    customCharactersError ||
-    apiKeysError ||
-    usageEventsError
-  ) {
+  if (audioFilesError || customCharactersError || apiKeysError) {
     throw new Error('User deletion failed');
+  }
+
+  if (usageEventsError) {
+    captureException(usageEventsError, {
+      extra: { context: 'retained usage event count during account deletion' },
+      level: 'warning',
+      user: { email: user.email, id: user.id },
+    });
   }
 
   if (audio_files) {

--- a/apps/web/lib/supabase/queries.client.ts
+++ b/apps/web/lib/supabase/queries.client.ts
@@ -45,6 +45,15 @@ export async function getMyAudioFiles(
   return data;
 }
 
+export async function getMyAudioFilesCount(
+  client: TypedSupabaseClient,
+  userId: string,
+) {
+  const { count, error } = await getMyAudioFilesCountQuery(client, userId);
+  if (error) throw error;
+  return count ?? 0;
+}
+
 // For server-side prefetching with supabase-cache-helpers
 export function getCreditsQuery(client: TypedSupabaseClient, userId: string) {
   return client

--- a/apps/web/lib/supabase/queries.client.ts
+++ b/apps/web/lib/supabase/queries.client.ts
@@ -4,7 +4,7 @@ export type AudioFileAndVoicesRes = Tables<'audio_files'> & {
   voices: Tables<'voices'>;
 };
 
-function getMyActiveAudioFilesFilter(userId: string) {
+export function getMyActiveAudioFilesFilter(userId: string) {
   return { status: 'active' as const, user_id: userId };
 }
 

--- a/apps/web/lib/supabase/queries.client.ts
+++ b/apps/web/lib/supabase/queries.client.ts
@@ -4,6 +4,10 @@ export type AudioFileAndVoicesRes = Tables<'audio_files'> & {
   voices: Tables<'voices'>;
 };
 
+function getMyActiveAudioFilesFilter(userId: string) {
+  return { status: 'active' as const, user_id: userId };
+}
+
 export function getMyAudioFilesQuery(
   client: TypedSupabaseClient,
   userId: string,
@@ -16,10 +20,19 @@ export function getMyAudioFilesQuery(
         name
       )
     `)
-    .eq('user_id', userId)
-    .eq('status', 'active')
+    .match(getMyActiveAudioFilesFilter(userId))
     .order('created_at', { ascending: false })
     .throwOnError();
+}
+
+export function getMyAudioFilesCountQuery(
+  client: TypedSupabaseClient,
+  userId: string,
+) {
+  return client
+    .from('audio_files')
+    .select('id', { count: 'exact', head: true })
+    .match(getMyActiveAudioFilesFilter(userId));
 }
 
 // For client-side useQuery

--- a/apps/web/messages/da.json
+++ b/apps/web/messages/da.json
@@ -916,7 +916,7 @@
       "all": {
         "trigger": "Slet alle",
         "title": "Slet alle lydfiler?",
-        "description": "Alle lydfiler bliver fjernet fra din historik. Handlingen kan ikke fortrydes.",
+        "description": "{count, plural, one {Lydfilen bliver fjernet fra din historik. Handlingen kan ikke fortrydes.} other {Alle # lydfiler bliver fjernet fra din historik. Handlingen kan ikke fortrydes.}}",
         "confirm": "Slet alle",
         "success": "Alle lydfiler er slettet",
         "error": "Alle lydfiler kunne ikke slettes. Prøv igen."

--- a/apps/web/messages/da.json
+++ b/apps/web/messages/da.json
@@ -902,6 +902,26 @@
     "header": "Genereringshistorik",
     "empty": "Ingen historik endnu",
     "downloadError": "Kunne ikke downloade lyd",
+    "delete": {
+      "cancel": "Annuller",
+      "deleting": "Sletter...",
+      "single": {
+        "trigger": "Slet",
+        "title": "Slet lydfil?",
+        "description": "Denne lydfil bliver fjernet fra din historik. Handlingen kan ikke fortrydes.",
+        "confirm": "Slet",
+        "success": "Lydfilen er slettet",
+        "error": "Lydfilen kunne ikke slettes. Prøv igen."
+      },
+      "all": {
+        "trigger": "Slet alle",
+        "title": "Slet alle lydfiler?",
+        "description": "Alle lydfiler bliver fjernet fra din historik. Handlingen kan ikke fortrydes.",
+        "confirm": "Slet alle",
+        "success": "Alle lydfiler er slettet",
+        "error": "Alle lydfiler kunne ikke slettes. Prøv igen."
+      }
+    },
     "ui": {
       "filterText": "Filtrer tekst...",
       "customizeColumns": "Tilpas kolonner",

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -906,6 +906,26 @@
     "header": "Generierungsverlauf",
     "empty": "Noch kein Verlauf",
     "downloadError": "Audio konnte nicht heruntergeladen werden",
+    "delete": {
+      "cancel": "Abbrechen",
+      "deleting": "Wird gelöscht...",
+      "single": {
+        "trigger": "Löschen",
+        "title": "Audiodatei löschen?",
+        "description": "Diese Audiodatei wird aus deinem Verlauf entfernt. Diese Aktion kann nicht rückgängig gemacht werden.",
+        "confirm": "Löschen",
+        "success": "Audiodatei gelöscht",
+        "error": "Die Audiodatei konnte nicht gelöscht werden. Bitte versuche es erneut."
+      },
+      "all": {
+        "trigger": "Alle löschen",
+        "title": "Alle Audiodateien löschen?",
+        "description": "Alle Audiodateien werden aus deinem Verlauf entfernt. Diese Aktion kann nicht rückgängig gemacht werden.",
+        "confirm": "Alle löschen",
+        "success": "Alle Audiodateien gelöscht",
+        "error": "Die Audiodateien konnten nicht gelöscht werden. Bitte versuche es erneut."
+      }
+    },
     "ui": {
       "filterText": "Text filtern...",
       "customizeColumns": "Spalten anpassen",

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -920,7 +920,7 @@
       "all": {
         "trigger": "Alle löschen",
         "title": "Alle Audiodateien löschen?",
-        "description": "Alle Audiodateien werden aus deinem Verlauf entfernt. Diese Aktion kann nicht rückgängig gemacht werden.",
+        "description": "{count, plural, one {Die Audiodatei wird aus deinem Verlauf entfernt. Diese Aktion kann nicht rückgängig gemacht werden.} other {Alle # Audiodateien werden aus deinem Verlauf entfernt. Diese Aktion kann nicht rückgängig gemacht werden.}}",
         "confirm": "Alle löschen",
         "success": "Alle Audiodateien gelöscht",
         "error": "Die Audiodateien konnten nicht gelöscht werden. Bitte versuche es erneut."

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -918,7 +918,7 @@
       "all": {
         "trigger": "Delete all",
         "title": "Delete all audio files?",
-        "description": "Every audio file will be removed from your history. This action cannot be undone.",
+        "description": "{count, plural, one {The audio file will be removed from your history. This action cannot be undone.} other {All # audio files will be removed from your history. This action cannot be undone.}}",
         "confirm": "Delete all",
         "success": "All audio files deleted",
         "error": "Failed to delete all audio files. Please try again."

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -904,6 +904,26 @@
     "header": "Generation History",
     "empty": "No history yet",
     "downloadError": "Failed to download audio",
+    "delete": {
+      "cancel": "Cancel",
+      "deleting": "Deleting...",
+      "single": {
+        "trigger": "Delete",
+        "title": "Delete audio file?",
+        "description": "This audio file will be removed from your history. This action cannot be undone.",
+        "confirm": "Delete",
+        "success": "Audio file deleted",
+        "error": "Failed to delete the audio file. Please try again."
+      },
+      "all": {
+        "trigger": "Delete all",
+        "title": "Delete all audio files?",
+        "description": "Every audio file will be removed from your history. This action cannot be undone.",
+        "confirm": "Delete all",
+        "success": "All audio files deleted",
+        "error": "Failed to delete all audio files. Please try again."
+      }
+    },
     "ui": {
       "filterText": "Filter text...",
       "customizeColumns": "Customize Columns",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -920,7 +920,7 @@
       "all": {
         "trigger": "Eliminar todo",
         "title": "¿Eliminar todos los archivos de audio?",
-        "description": "Todos los archivos de audio se eliminarán de tu historial. Esta acción no se puede deshacer.",
+        "description": "{count, plural, one {El archivo de audio se eliminará de tu historial. Esta acción no se puede deshacer.} other {Los # archivos de audio se eliminarán de tu historial. Esta acción no se puede deshacer.}}",
         "confirm": "Eliminar todo",
         "success": "Todos los archivos de audio se eliminaron",
         "error": "No se pudieron eliminar todos los archivos de audio. Inténtalo de nuevo."

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -906,6 +906,26 @@
     "header": "Historial de Generación",
     "empty": "Sin historial aún",
     "downloadError": "Error al descargar el audio",
+    "delete": {
+      "cancel": "Cancelar",
+      "deleting": "Eliminando...",
+      "single": {
+        "trigger": "Eliminar",
+        "title": "¿Eliminar el archivo de audio?",
+        "description": "Este archivo de audio se eliminará de tu historial. Esta acción no se puede deshacer.",
+        "confirm": "Eliminar",
+        "success": "Archivo de audio eliminado",
+        "error": "No se pudo eliminar el archivo de audio. Inténtalo de nuevo."
+      },
+      "all": {
+        "trigger": "Eliminar todo",
+        "title": "¿Eliminar todos los archivos de audio?",
+        "description": "Todos los archivos de audio se eliminarán de tu historial. Esta acción no se puede deshacer.",
+        "confirm": "Eliminar todo",
+        "success": "Todos los archivos de audio se eliminaron",
+        "error": "No se pudieron eliminar todos los archivos de audio. Inténtalo de nuevo."
+      }
+    },
     "ui": {
       "filterText": "Filtrar texto...",
       "customizeColumns": "Personalizar Columnas",

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -906,6 +906,26 @@
     "header": "Historique des générations",
     "empty": "Aucun historique pour le moment",
     "downloadError": "Échec du téléchargement de l'audio",
+    "delete": {
+      "cancel": "Annuler",
+      "deleting": "Suppression...",
+      "single": {
+        "trigger": "Supprimer",
+        "title": "Supprimer le fichier audio ?",
+        "description": "Ce fichier audio sera supprimé de votre historique. Cette action est irréversible.",
+        "confirm": "Supprimer",
+        "success": "Fichier audio supprimé",
+        "error": "Impossible de supprimer le fichier audio. Veuillez réessayer."
+      },
+      "all": {
+        "trigger": "Tout supprimer",
+        "title": "Supprimer tous les fichiers audio ?",
+        "description": "Tous les fichiers audio seront supprimés de votre historique. Cette action est irréversible.",
+        "confirm": "Tout supprimer",
+        "success": "Tous les fichiers audio ont été supprimés",
+        "error": "Impossible de supprimer tous les fichiers audio. Veuillez réessayer."
+      }
+    },
     "ui": {
       "filterText": "Filtrer le texte...",
       "customizeColumns": "Personnaliser les colonnes",

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -920,7 +920,7 @@
       "all": {
         "trigger": "Tout supprimer",
         "title": "Supprimer tous les fichiers audio ?",
-        "description": "Tous les fichiers audio seront supprimés de votre historique. Cette action est irréversible.",
+        "description": "{count, plural, one {Le fichier audio sera supprimé de votre historique. Cette action est irréversible.} other {Les # fichiers audio seront supprimés de votre historique. Cette action est irréversible.}}",
         "confirm": "Tout supprimer",
         "success": "Tous les fichiers audio ont été supprimés",
         "error": "Impossible de supprimer tous les fichiers audio. Veuillez réessayer."

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -920,7 +920,7 @@
       "all": {
         "trigger": "Elimina tutto",
         "title": "Eliminare tutti i file audio?",
-        "description": "Tutti i file audio verranno rimossi dalla cronologia. Questa azione non può essere annullata.",
+        "description": "{count, plural, one {Il file audio verrà rimosso dalla cronologia. Questa azione non può essere annullata.} other {Tutti i # file audio verranno rimossi dalla cronologia. Questa azione non può essere annullata.}}",
         "confirm": "Elimina tutto",
         "success": "Tutti i file audio sono stati eliminati",
         "error": "Impossibile eliminare tutti i file audio. Riprova."

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -906,6 +906,26 @@
     "header": "Cronologia generazioni",
     "empty": "Nessuna cronologia ancora",
     "downloadError": "Impossibile scaricare l'audio",
+    "delete": {
+      "cancel": "Annulla",
+      "deleting": "Eliminazione...",
+      "single": {
+        "trigger": "Elimina",
+        "title": "Eliminare il file audio?",
+        "description": "Questo file audio verrà rimosso dalla cronologia. Questa azione non può essere annullata.",
+        "confirm": "Elimina",
+        "success": "File audio eliminato",
+        "error": "Impossibile eliminare il file audio. Riprova."
+      },
+      "all": {
+        "trigger": "Elimina tutto",
+        "title": "Eliminare tutti i file audio?",
+        "description": "Tutti i file audio verranno rimossi dalla cronologia. Questa azione non può essere annullata.",
+        "confirm": "Elimina tutto",
+        "success": "Tutti i file audio sono stati eliminati",
+        "error": "Impossibile eliminare tutti i file audio. Riprova."
+      }
+    },
     "ui": {
       "filterText": "Filtra testo...",
       "customizeColumns": "Personalizza colonne",

--- a/apps/web/tests/account-deletion.test.ts
+++ b/apps/web/tests/account-deletion.test.ts
@@ -1,3 +1,4 @@
+import { captureException } from '@sentry/nextjs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { handleDeleteAccountAction } from '@/app/actions';
@@ -44,7 +45,11 @@ describe('account deletion', () => {
     });
     const charactersRead = createReadQuery({ data: [], error: null });
     const apiKeysRead = createReadQuery({ data: [], error: null });
-    const usageRead = createReadQuery({ count: 0, error: null });
+    const usageCountError = new Error('Count unavailable');
+    const usageRead = createReadQuery({
+      count: null,
+      error: usageCountError,
+    });
     const sessionSupabase = {
       auth: {
         getUser: vi.fn().mockResolvedValue({
@@ -94,5 +99,10 @@ describe('account deletion', () => {
         ([table]) => table === 'usage_events',
       ),
     ).toHaveLength(1);
+    expect(captureException).toHaveBeenCalledWith(usageCountError, {
+      extra: { context: 'retained usage event count during account deletion' },
+      level: 'warning',
+      user: { email: 'user@example.com', id: 'user-1' },
+    });
   });
 });

--- a/apps/web/tests/account-deletion.test.ts
+++ b/apps/web/tests/account-deletion.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { handleDeleteAccountAction } from '@/app/actions';
+import { deleteFileFromR2 } from '@/lib/storage/upload';
+import { createAdminClient } from '@/lib/supabase/admin';
+import { createClient } from '@/lib/supabase/server';
+
+vi.mock('@/lib/storage/upload', () => ({
+  deleteFileFromR2: vi.fn(),
+}));
+
+vi.mock('@/lib/supabase/admin', () => ({
+  createAdminClient: vi.fn(),
+}));
+
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: vi.fn(),
+}));
+
+vi.mock('@/lib/utils', () => ({
+  encodedRedirect: vi.fn(),
+}));
+
+function createReadQuery(result: object) {
+  const query = {
+    eq: vi.fn(),
+    select: vi.fn(),
+  };
+  query.select.mockReturnValue(query);
+  query.eq.mockResolvedValue(result);
+  return query;
+}
+
+describe('account deletion', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(deleteFileFromR2).mockResolvedValue(undefined);
+  });
+
+  it('uses the admin client for the user-scoped audio soft delete', async () => {
+    const audioRead = createReadQuery({
+      data: [{ id: 'audio-1', storage_key: 'audio/one.mp3' }],
+      error: null,
+    });
+    const charactersRead = createReadQuery({ data: [], error: null });
+    const apiKeysRead = createReadQuery({ data: [], error: null });
+    const usageRead = createReadQuery({ count: 0, error: null });
+    const usageDelete = {
+      delete: vi.fn(),
+      eq: vi.fn().mockResolvedValue({ error: null }),
+    };
+    usageDelete.delete.mockReturnValue(usageDelete);
+
+    const usageQueries = [usageRead, usageDelete];
+    const sessionSupabase = {
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: { email: 'user@example.com', id: 'user-1' } },
+        }),
+        signOut: vi.fn().mockResolvedValue({ error: null }),
+        updateUser: vi.fn().mockResolvedValue({ error: null }),
+      },
+      from: vi.fn((table: string) => {
+        if (table === 'audio_files') return audioRead;
+        if (table === 'characters') return charactersRead;
+        if (table === 'api_keys') return apiKeysRead;
+        if (table === 'usage_events') return usageQueries.shift();
+        throw new Error(`Unexpected table: ${table}`);
+      }),
+    };
+
+    const audioUpdate = {
+      eq: vi.fn(),
+      select: vi.fn().mockResolvedValue({
+        data: [{ id: 'audio-1' }],
+        error: null,
+      }),
+      update: vi.fn(),
+    };
+    audioUpdate.eq.mockReturnValue(audioUpdate);
+    audioUpdate.update.mockReturnValue(audioUpdate);
+    const adminSupabase = {
+      from: vi.fn().mockReturnValue(audioUpdate),
+    };
+
+    vi.mocked(createClient).mockResolvedValue(sessionSupabase as never);
+    vi.mocked(createAdminClient).mockReturnValue(adminSupabase as never);
+
+    await handleDeleteAccountAction({ lang: 'en' });
+
+    expect(adminSupabase.from).toHaveBeenCalledWith('audio_files');
+    expect(audioUpdate.update).toHaveBeenCalledWith({
+      deleted_at: expect.any(String),
+      status: 'deleted',
+    });
+    expect(audioUpdate.eq).toHaveBeenCalledWith('user_id', 'user-1');
+    expect(audioUpdate.select).toHaveBeenCalledWith('id');
+    expect(deleteFileFromR2).toHaveBeenCalledWith('audio/one.mp3');
+  });
+});

--- a/apps/web/tests/account-deletion.test.ts
+++ b/apps/web/tests/account-deletion.test.ts
@@ -45,13 +45,6 @@ describe('account deletion', () => {
     const charactersRead = createReadQuery({ data: [], error: null });
     const apiKeysRead = createReadQuery({ data: [], error: null });
     const usageRead = createReadQuery({ count: 0, error: null });
-    const usageDelete = {
-      delete: vi.fn(),
-      eq: vi.fn().mockResolvedValue({ error: null }),
-    };
-    usageDelete.delete.mockReturnValue(usageDelete);
-
-    const usageQueries = [usageRead, usageDelete];
     const sessionSupabase = {
       auth: {
         getUser: vi.fn().mockResolvedValue({
@@ -64,7 +57,7 @@ describe('account deletion', () => {
         if (table === 'audio_files') return audioRead;
         if (table === 'characters') return charactersRead;
         if (table === 'api_keys') return apiKeysRead;
-        if (table === 'usage_events') return usageQueries.shift();
+        if (table === 'usage_events') return usageRead;
         throw new Error(`Unexpected table: ${table}`);
       }),
     };
@@ -96,5 +89,10 @@ describe('account deletion', () => {
     expect(audioUpdate.eq).toHaveBeenCalledWith('user_id', 'user-1');
     expect(audioUpdate.select).toHaveBeenCalledWith('id');
     expect(deleteFileFromR2).toHaveBeenCalledWith('audio/one.mp3');
+    expect(
+      sessionSupabase.from.mock.calls.filter(
+        ([table]) => table === 'usage_events',
+      ),
+    ).toHaveLength(1);
   });
 });

--- a/apps/web/tests/account-deletion.test.ts
+++ b/apps/web/tests/account-deletion.test.ts
@@ -32,6 +32,55 @@ function createReadQuery(result: object) {
   return query;
 }
 
+function setupAccountDeletion({
+  usageResult = { count: 3, error: null },
+}: {
+  usageResult?: { count: number | null; error: Error | null };
+} = {}) {
+  const audioRead = createReadQuery({
+    data: [{ id: 'audio-1', storage_key: 'audio/one.mp3' }],
+    error: null,
+  });
+  const charactersRead = createReadQuery({ data: [], error: null });
+  const apiKeysRead = createReadQuery({ data: [], error: null });
+  const usageRead = createReadQuery(usageResult);
+  const sessionSupabase = {
+    auth: {
+      getUser: vi.fn().mockResolvedValue({
+        data: { user: { email: 'user@example.com', id: 'user-1' } },
+      }),
+      signOut: vi.fn().mockResolvedValue({ error: null }),
+      updateUser: vi.fn().mockResolvedValue({ error: null }),
+    },
+    from: vi.fn((table: string) => {
+      if (table === 'audio_files') return audioRead;
+      if (table === 'characters') return charactersRead;
+      if (table === 'api_keys') return apiKeysRead;
+      if (table === 'usage_events') return usageRead;
+      throw new Error(`Unexpected table: ${table}`);
+    }),
+  };
+
+  const audioUpdate = {
+    eq: vi.fn(),
+    select: vi.fn().mockResolvedValue({
+      data: [{ id: 'audio-1' }],
+      error: null,
+    }),
+    update: vi.fn(),
+  };
+  audioUpdate.eq.mockReturnValue(audioUpdate);
+  audioUpdate.update.mockReturnValue(audioUpdate);
+  const adminSupabase = {
+    from: vi.fn().mockReturnValue(audioUpdate),
+  };
+
+  vi.mocked(createClient).mockResolvedValue(sessionSupabase as never);
+  vi.mocked(createAdminClient).mockReturnValue(adminSupabase as never);
+
+  return { adminSupabase, audioUpdate, sessionSupabase };
+}
+
 describe('account deletion', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -39,50 +88,7 @@ describe('account deletion', () => {
   });
 
   it('uses the admin client for the user-scoped audio soft delete', async () => {
-    const audioRead = createReadQuery({
-      data: [{ id: 'audio-1', storage_key: 'audio/one.mp3' }],
-      error: null,
-    });
-    const charactersRead = createReadQuery({ data: [], error: null });
-    const apiKeysRead = createReadQuery({ data: [], error: null });
-    const usageCountError = new Error('Count unavailable');
-    const usageRead = createReadQuery({
-      count: null,
-      error: usageCountError,
-    });
-    const sessionSupabase = {
-      auth: {
-        getUser: vi.fn().mockResolvedValue({
-          data: { user: { email: 'user@example.com', id: 'user-1' } },
-        }),
-        signOut: vi.fn().mockResolvedValue({ error: null }),
-        updateUser: vi.fn().mockResolvedValue({ error: null }),
-      },
-      from: vi.fn((table: string) => {
-        if (table === 'audio_files') return audioRead;
-        if (table === 'characters') return charactersRead;
-        if (table === 'api_keys') return apiKeysRead;
-        if (table === 'usage_events') return usageRead;
-        throw new Error(`Unexpected table: ${table}`);
-      }),
-    };
-
-    const audioUpdate = {
-      eq: vi.fn(),
-      select: vi.fn().mockResolvedValue({
-        data: [{ id: 'audio-1' }],
-        error: null,
-      }),
-      update: vi.fn(),
-    };
-    audioUpdate.eq.mockReturnValue(audioUpdate);
-    audioUpdate.update.mockReturnValue(audioUpdate);
-    const adminSupabase = {
-      from: vi.fn().mockReturnValue(audioUpdate),
-    };
-
-    vi.mocked(createClient).mockResolvedValue(sessionSupabase as never);
-    vi.mocked(createAdminClient).mockReturnValue(adminSupabase as never);
+    const { adminSupabase, audioUpdate } = setupAccountDeletion();
 
     await handleDeleteAccountAction({ lang: 'en' });
 
@@ -94,6 +100,20 @@ describe('account deletion', () => {
     expect(audioUpdate.eq).toHaveBeenCalledWith('user_id', 'user-1');
     expect(audioUpdate.select).toHaveBeenCalledWith('id');
     expect(deleteFileFromR2).toHaveBeenCalledWith('audio/one.mp3');
+    expect(logger.info).toHaveBeenCalledWith(
+      'User deleted',
+      expect.objectContaining({ usageEventsRetained: 3 }),
+    );
+  });
+
+  it('continues when the retained usage-event count is unavailable', async () => {
+    const usageCountError = new Error('Count unavailable');
+    const { sessionSupabase } = setupAccountDeletion({
+      usageResult: { count: null, error: usageCountError },
+    });
+
+    await handleDeleteAccountAction({ lang: 'en' });
+
     expect(
       sessionSupabase.from.mock.calls.filter(
         ([table]) => table === 'usage_events',

--- a/apps/web/tests/account-deletion.test.ts
+++ b/apps/web/tests/account-deletion.test.ts
@@ -1,4 +1,4 @@
-import { captureException } from '@sentry/nextjs';
+import { captureException, logger } from '@sentry/nextjs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { handleDeleteAccountAction } from '@/app/actions';
@@ -104,5 +104,9 @@ describe('account deletion', () => {
       level: 'warning',
       user: { email: 'user@example.com', id: 'user-1' },
     });
+    expect(logger.info).toHaveBeenCalledWith(
+      'User deleted',
+      expect.objectContaining({ usageEventsRetained: null }),
+    );
   });
 });

--- a/apps/web/tests/components/history-delete-all-button.test.tsx
+++ b/apps/web/tests/components/history-delete-all-button.test.tsx
@@ -22,14 +22,17 @@ vi.mock('sonner', () => ({
   },
 }));
 
-function renderDeleteAllButton({ disabled = false } = {}) {
+function renderDeleteAllButton({ count = 2, disabled = false } = {}) {
   const queryClient = new QueryClient();
-  queryClient.setQueryData(['audio_files', 'user-1'], [{ id: 'audio-1' }]);
+  queryClient.setQueryData(
+    ['audio_files', 'user-1'],
+    [{ id: 'audio-1' }, { id: 'audio-2' }],
+  );
 
   render(
     <NextIntlClientProvider locale="en" messages={messages}>
       <QueryClientProvider client={queryClient}>
-        <DeleteAllButton disabled={disabled} userId="user-1" />
+        <DeleteAllButton count={count} disabled={disabled} userId="user-1" />
       </QueryClientProvider>
     </NextIntlClientProvider>,
   );
@@ -60,7 +63,7 @@ describe('DeleteAllButton', () => {
     ).toBeInTheDocument();
     expect(
       within(dialog).getByText(
-        'Every audio file will be removed from your history. This action cannot be undone.',
+        'All 2 audio files will be removed from your history. This action cannot be undone.',
       ),
     ).toBeInTheDocument();
     expect(handleDeleteAllAction).not.toHaveBeenCalled();
@@ -104,12 +107,13 @@ describe('DeleteAllButton', () => {
     );
     expect(queryClient.getQueryData(['audio_files', 'user-1'])).toEqual([
       { id: 'audio-1' },
+      { id: 'audio-2' },
     ]);
     expect(screen.getByRole('alertdialog')).toBeInTheDocument();
   });
 
   it('is disabled when there is no history', () => {
-    renderDeleteAllButton({ disabled: true });
+    renderDeleteAllButton({ count: 0, disabled: true });
 
     const button = screen.getByRole('button', { name: 'Delete all' });
     expect(button).toBeDisabled();

--- a/apps/web/tests/components/history-delete-all-button.test.tsx
+++ b/apps/web/tests/components/history-delete-all-button.test.tsx
@@ -11,8 +11,16 @@ import { handleDeleteAllAction } from '@/app/[lang]/(dashboard)/dashboard/histor
 import { DeleteAllButton } from '@/app/[lang]/(dashboard)/dashboard/history/delete-all-button';
 import messages from '@/messages/en.json';
 
+const mocks = vi.hoisted(() => ({
+  refresh: vi.fn(),
+}));
+
 vi.mock('@/app/[lang]/(dashboard)/dashboard/history/actions', () => ({
   handleDeleteAllAction: vi.fn(),
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: vi.fn(() => ({ refresh: mocks.refresh })),
 }));
 
 vi.mock('sonner', () => ({
@@ -82,6 +90,7 @@ describe('DeleteAllButton', () => {
 
     await waitFor(() => expect(handleDeleteAllAction).toHaveBeenCalledOnce());
     expect(queryClient.getQueryData(['audio_files', 'user-1'])).toEqual([]);
+    expect(mocks.refresh).toHaveBeenCalledOnce();
     expect(toast.success).toHaveBeenCalledWith('All audio files deleted');
     expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
   });
@@ -109,6 +118,7 @@ describe('DeleteAllButton', () => {
       { id: 'audio-1' },
       { id: 'audio-2' },
     ]);
+    expect(mocks.refresh).not.toHaveBeenCalled();
     expect(screen.getByRole('alertdialog')).toBeInTheDocument();
   });
 

--- a/apps/web/tests/components/history-delete-all-button.test.tsx
+++ b/apps/web/tests/components/history-delete-all-button.test.tsx
@@ -111,6 +111,8 @@ describe('DeleteAllButton', () => {
   it('is disabled when there is no history', () => {
     renderDeleteAllButton({ disabled: true });
 
-    expect(screen.getByRole('button', { name: 'Delete all' })).toBeDisabled();
+    const button = screen.getByRole('button', { name: 'Delete all' });
+    expect(button).toBeDisabled();
+    expect(button).toHaveAttribute('data-size', 'sm');
   });
 });

--- a/apps/web/tests/components/history-delete-all-button.test.tsx
+++ b/apps/web/tests/components/history-delete-all-button.test.tsx
@@ -1,0 +1,116 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { NextIntlClientProvider } from 'next-intl';
+import { toast } from 'sonner';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { handleDeleteAllAction } from '@/app/[lang]/(dashboard)/dashboard/history/actions';
+import { DeleteAllButton } from '@/app/[lang]/(dashboard)/dashboard/history/delete-all-button';
+import messages from '@/messages/en.json';
+
+vi.mock('@/app/[lang]/(dashboard)/dashboard/history/actions', () => ({
+  handleDeleteAllAction: vi.fn(),
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+function renderDeleteAllButton({ disabled = false } = {}) {
+  const queryClient = new QueryClient();
+  queryClient.setQueryData(['audio_files', 'user-1'], [{ id: 'audio-1' }]);
+
+  render(
+    <NextIntlClientProvider locale="en" messages={messages}>
+      <QueryClientProvider client={queryClient}>
+        <DeleteAllButton disabled={disabled} userId="user-1" />
+      </QueryClientProvider>
+    </NextIntlClientProvider>,
+  );
+
+  return queryClient;
+}
+
+describe('DeleteAllButton', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(handleDeleteAllAction).mockResolvedValue({
+      deletedCount: 1,
+      success: true,
+    });
+  });
+
+  it('requires confirmation before deleting history', async () => {
+    const user = userEvent.setup();
+    renderDeleteAllButton();
+
+    await user.click(screen.getByRole('button', { name: 'Delete all' }));
+
+    const dialog = screen.getByRole('alertdialog');
+    expect(
+      within(dialog).getByRole('heading', {
+        name: 'Delete all audio files?',
+      }),
+    ).toBeInTheDocument();
+    expect(
+      within(dialog).getByText(
+        'Every audio file will be removed from your history. This action cannot be undone.',
+      ),
+    ).toBeInTheDocument();
+    expect(handleDeleteAllAction).not.toHaveBeenCalled();
+  });
+
+  it('clears the history cache after confirmation succeeds', async () => {
+    const user = userEvent.setup();
+    const queryClient = renderDeleteAllButton();
+
+    await user.click(screen.getByRole('button', { name: 'Delete all' }));
+    await user.click(
+      within(screen.getByRole('alertdialog')).getByRole('button', {
+        name: 'Delete all',
+      }),
+    );
+
+    await waitFor(() => expect(handleDeleteAllAction).toHaveBeenCalledOnce());
+    expect(queryClient.getQueryData(['audio_files', 'user-1'])).toEqual([]);
+    expect(toast.success).toHaveBeenCalledWith('All audio files deleted');
+    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
+  });
+
+  it('keeps the existing history and reports a failed deletion', async () => {
+    const user = userEvent.setup();
+    const queryClient = renderDeleteAllButton();
+    vi.mocked(handleDeleteAllAction).mockRejectedValue(
+      new Error('Delete failed'),
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Delete all' }));
+    await user.click(
+      within(screen.getByRole('alertdialog')).getByRole('button', {
+        name: 'Delete all',
+      }),
+    );
+
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith(
+        'Failed to delete all audio files. Please try again.',
+      ),
+    );
+    expect(queryClient.getQueryData(['audio_files', 'user-1'])).toEqual([
+      { id: 'audio-1' },
+    ]);
+    expect(screen.getByRole('alertdialog')).toBeInTheDocument();
+  });
+
+  it('is disabled when there is no history', () => {
+    renderDeleteAllButton({ disabled: true });
+
+    expect(screen.getByRole('button', { name: 'Delete all' })).toBeDisabled();
+  });
+});

--- a/apps/web/tests/components/history-delete-all-button.test.tsx
+++ b/apps/web/tests/components/history-delete-all-button.test.tsx
@@ -36,6 +36,7 @@ function renderDeleteAllButton({ count = 2, disabled = false } = {}) {
     ['audio_files', 'user-1'],
     [{ id: 'audio-1' }, { id: 'audio-2' }],
   );
+  queryClient.setQueryData(['audio_files_count', 'user-1'], count);
 
   render(
     <NextIntlClientProvider locale="en" messages={messages}>
@@ -90,6 +91,7 @@ describe('DeleteAllButton', () => {
 
     await waitFor(() => expect(handleDeleteAllAction).toHaveBeenCalledOnce());
     expect(queryClient.getQueryData(['audio_files', 'user-1'])).toEqual([]);
+    expect(queryClient.getQueryData(['audio_files_count', 'user-1'])).toBe(0);
     expect(mocks.refresh).toHaveBeenCalledOnce();
     expect(toast.success).toHaveBeenCalledWith('All audio files deleted');
     expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();

--- a/apps/web/tests/history-actions.test.ts
+++ b/apps/web/tests/history-actions.test.ts
@@ -5,6 +5,7 @@ import {
   handleDeleteAction,
   handleDeleteAllAction,
 } from '@/app/[lang]/(dashboard)/dashboard/history/actions';
+import { createAdminClient } from '@/lib/supabase/admin';
 import { createClient } from '@/lib/supabase/server';
 
 const mocks = vi.hoisted(() => ({
@@ -24,6 +25,10 @@ vi.mock('@upstash/redis', () => ({
 
 vi.mock('@/lib/supabase/server', () => ({
   createClient: vi.fn(),
+}));
+
+vi.mock('@/lib/supabase/admin', () => ({
+  createAdminClient: vi.fn(),
 }));
 
 interface AudioFileRow {
@@ -48,14 +53,16 @@ function createSupabaseMock({
   query.eq.mockReturnValue(query);
   query.update.mockReturnValue(query);
 
-  const supabase = {
+  const sessionSupabase = {
     auth: {
       getUser: vi.fn().mockResolvedValue({ data: { user } }),
     },
+  };
+  const adminSupabase = {
     from: vi.fn().mockReturnValue(query),
   };
 
-  return { query, supabase };
+  return { adminSupabase, query, sessionSupabase };
 }
 
 describe('history deletion actions', () => {
@@ -69,15 +76,18 @@ describe('history deletion actions', () => {
       { id: 'audio-1', storage_key: 'audio/one.mp3' },
       { id: 'audio-2', storage_key: 'audio/two.mp3' },
     ];
-    const { query, supabase } = createSupabaseMock({ deletedAudioFiles });
-    vi.mocked(createClient).mockResolvedValue(supabase as never);
+    const { adminSupabase, query, sessionSupabase } = createSupabaseMock({
+      deletedAudioFiles,
+    });
+    vi.mocked(createClient).mockResolvedValue(sessionSupabase as never);
+    vi.mocked(createAdminClient).mockReturnValue(adminSupabase as never);
 
     await expect(handleDeleteAllAction()).resolves.toEqual({
       deletedCount: 2,
       success: true,
     });
 
-    expect(supabase.from).toHaveBeenCalledWith('audio_files');
+    expect(adminSupabase.from).toHaveBeenCalledWith('audio_files');
     expect(query.update).toHaveBeenCalledWith({
       deleted_at: expect.any(String),
       status: 'deleted',
@@ -94,10 +104,11 @@ describe('history deletion actions', () => {
   });
 
   it('keeps single-file deletion scoped to the requested file', async () => {
-    const { query, supabase } = createSupabaseMock({
+    const { adminSupabase, query, sessionSupabase } = createSupabaseMock({
       deletedAudioFiles: [{ id: 'audio-1', storage_key: 'audio/one.mp3' }],
     });
-    vi.mocked(createClient).mockResolvedValue(supabase as never);
+    vi.mocked(createClient).mockResolvedValue(sessionSupabase as never);
+    vi.mocked(createAdminClient).mockReturnValue(adminSupabase as never);
 
     await handleDeleteAction('audio-1');
 
@@ -115,21 +126,22 @@ describe('history deletion actions', () => {
   });
 
   it('does not access audio files without an authenticated user', async () => {
-    const { supabase } = createSupabaseMock({ user: null });
-    vi.mocked(createClient).mockResolvedValue(supabase as never);
+    const { sessionSupabase } = createSupabaseMock({ user: null });
+    vi.mocked(createClient).mockResolvedValue(sessionSupabase as never);
 
     await expect(handleDeleteAllAction()).rejects.toThrow('User not found');
 
-    expect(supabase.from).not.toHaveBeenCalled();
+    expect(createAdminClient).not.toHaveBeenCalled();
     expect(mocks.redisDel).not.toHaveBeenCalled();
   });
 
   it('does not turn a completed soft delete into a failure when Redis is down', async () => {
     const cacheError = new Error('Redis unavailable');
-    const { supabase } = createSupabaseMock({
+    const { adminSupabase, sessionSupabase } = createSupabaseMock({
       deletedAudioFiles: [{ id: 'audio-1', storage_key: 'audio/one.mp3' }],
     });
-    vi.mocked(createClient).mockResolvedValue(supabase as never);
+    vi.mocked(createClient).mockResolvedValue(sessionSupabase as never);
+    vi.mocked(createAdminClient).mockReturnValue(adminSupabase as never);
     mocks.redisDel.mockRejectedValue(cacheError);
 
     await expect(handleDeleteAllAction()).resolves.toEqual({

--- a/apps/web/tests/history-actions.test.ts
+++ b/apps/web/tests/history-actions.test.ts
@@ -1,0 +1,136 @@
+import { captureException } from '@sentry/nextjs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  handleDeleteAction,
+  handleDeleteAllAction,
+} from '@/app/[lang]/(dashboard)/dashboard/history/actions';
+import { createClient } from '@/lib/supabase/server';
+
+const mocks = vi.hoisted(() => ({
+  after: vi.fn(),
+  redisDel: vi.fn(),
+}));
+
+vi.mock('next/server', () => ({
+  after: mocks.after,
+}));
+
+vi.mock('@upstash/redis', () => ({
+  Redis: {
+    fromEnv: vi.fn(() => ({ del: mocks.redisDel })),
+  },
+}));
+
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: vi.fn(),
+}));
+
+interface AudioFileRow {
+  id: string;
+  storage_key: string;
+}
+
+function createSupabaseMock({
+  deletedAudioFiles = [],
+  error = null,
+  user = { email: 'user@example.com', id: 'user-1' },
+}: {
+  deletedAudioFiles?: AudioFileRow[];
+  error?: Error | null;
+  user?: { email: string; id: string } | null;
+}) {
+  const query = {
+    eq: vi.fn(),
+    select: vi.fn().mockResolvedValue({ data: deletedAudioFiles, error }),
+    update: vi.fn(),
+  };
+  query.eq.mockReturnValue(query);
+  query.update.mockReturnValue(query);
+
+  const supabase = {
+    auth: {
+      getUser: vi.fn().mockResolvedValue({ data: { user } }),
+    },
+    from: vi.fn().mockReturnValue(query),
+  };
+
+  return { query, supabase };
+}
+
+describe('history deletion actions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.redisDel.mockResolvedValue(0);
+  });
+
+  it('soft-deletes every active audio file owned by the user', async () => {
+    const deletedAudioFiles = [
+      { id: 'audio-1', storage_key: 'audio/one.mp3' },
+      { id: 'audio-2', storage_key: 'audio/two.mp3' },
+    ];
+    const { query, supabase } = createSupabaseMock({ deletedAudioFiles });
+    vi.mocked(createClient).mockResolvedValue(supabase as never);
+
+    await expect(handleDeleteAllAction()).resolves.toEqual({
+      deletedCount: 2,
+      success: true,
+    });
+
+    expect(supabase.from).toHaveBeenCalledWith('audio_files');
+    expect(query.update).toHaveBeenCalledWith({
+      deleted_at: expect.any(String),
+      status: 'deleted',
+    });
+    expect(query.eq).toHaveBeenCalledWith('user_id', 'user-1');
+    expect(query.eq).toHaveBeenCalledWith('status', 'active');
+    expect(query.eq).not.toHaveBeenCalledWith('id', expect.any(String));
+    expect(query.select).toHaveBeenCalledWith('id, storage_key');
+    expect(mocks.redisDel).toHaveBeenCalledWith(
+      'audio/one.mp3',
+      'audio/two.mp3',
+    );
+    expect(mocks.after).toHaveBeenCalledOnce();
+  });
+
+  it('keeps single-file deletion scoped to the requested file', async () => {
+    const { query, supabase } = createSupabaseMock({
+      deletedAudioFiles: [{ id: 'audio-1', storage_key: 'audio/one.mp3' }],
+    });
+    vi.mocked(createClient).mockResolvedValue(supabase as never);
+
+    await handleDeleteAction('audio-1');
+
+    expect(query.eq).toHaveBeenCalledWith('user_id', 'user-1');
+    expect(query.eq).toHaveBeenCalledWith('id', 'audio-1');
+  });
+
+  it('does not access audio files without an authenticated user', async () => {
+    const { supabase } = createSupabaseMock({ user: null });
+    vi.mocked(createClient).mockResolvedValue(supabase as never);
+
+    await expect(handleDeleteAllAction()).rejects.toThrow('User not found');
+
+    expect(supabase.from).not.toHaveBeenCalled();
+    expect(mocks.redisDel).not.toHaveBeenCalled();
+  });
+
+  it('does not turn a completed soft delete into a failure when Redis is down', async () => {
+    const cacheError = new Error('Redis unavailable');
+    const { supabase } = createSupabaseMock({
+      deletedAudioFiles: [{ id: 'audio-1', storage_key: 'audio/one.mp3' }],
+    });
+    vi.mocked(createClient).mockResolvedValue(supabase as never);
+    mocks.redisDel.mockRejectedValue(cacheError);
+
+    await expect(handleDeleteAllAction()).resolves.toEqual({
+      deletedCount: 1,
+      success: true,
+    });
+
+    expect(captureException).toHaveBeenCalledWith(
+      cacheError,
+      expect.objectContaining({ level: 'warning' }),
+    );
+  });
+});

--- a/apps/web/tests/history-actions.test.ts
+++ b/apps/web/tests/history-actions.test.ts
@@ -125,6 +125,19 @@ describe('history deletion actions', () => {
     expect(mocks.redisDel).not.toHaveBeenCalled();
   });
 
+  it('rejects a single delete when no active audio file matches', async () => {
+    const { adminSupabase, sessionSupabase } = createSupabaseMock({});
+    vi.mocked(createClient).mockResolvedValue(sessionSupabase as never);
+    vi.mocked(createAdminClient).mockReturnValue(adminSupabase as never);
+
+    await expect(handleDeleteAction('missing-audio')).rejects.toThrow(
+      'Audio file not found or unauthorized',
+    );
+
+    expect(mocks.redisDel).not.toHaveBeenCalled();
+    expect(mocks.after).not.toHaveBeenCalled();
+  });
+
   it('does not access audio files without an authenticated user', async () => {
     const { sessionSupabase } = createSupabaseMock({ user: null });
     vi.mocked(createClient).mockResolvedValue(sessionSupabase as never);

--- a/apps/web/tests/history-actions.test.ts
+++ b/apps/web/tests/history-actions.test.ts
@@ -105,6 +105,15 @@ describe('history deletion actions', () => {
     expect(query.eq).toHaveBeenCalledWith('id', 'audio-1');
   });
 
+  it('rejects an empty single-file ID before accessing the database', async () => {
+    await expect(handleDeleteAction('')).rejects.toThrow(
+      'Audio file not found or unauthorized',
+    );
+
+    expect(createClient).not.toHaveBeenCalled();
+    expect(mocks.redisDel).not.toHaveBeenCalled();
+  });
+
   it('does not access audio files without an authenticated user', async () => {
     const { supabase } = createSupabaseMock({ user: null });
     vi.mocked(createClient).mockResolvedValue(supabase as never);

--- a/apps/web/tests/history-actions.test.ts
+++ b/apps/web/tests/history-actions.test.ts
@@ -154,4 +154,22 @@ describe('history deletion actions', () => {
       expect.objectContaining({ level: 'warning' }),
     );
   });
+
+  it('deduplicates and batches cache invalidation for large histories', async () => {
+    const deletedAudioFiles = Array.from({ length: 102 }, (_, index) => ({
+      id: `audio-${index}`,
+      storage_key: `audio/${index === 101 ? 0 : index}.mp3`,
+    }));
+    const { adminSupabase, sessionSupabase } = createSupabaseMock({
+      deletedAudioFiles,
+    });
+    vi.mocked(createClient).mockResolvedValue(sessionSupabase as never);
+    vi.mocked(createAdminClient).mockReturnValue(adminSupabase as never);
+
+    await handleDeleteAllAction();
+
+    expect(mocks.redisDel).toHaveBeenCalledTimes(2);
+    expect(mocks.redisDel.mock.calls[0]).toHaveLength(100);
+    expect(mocks.redisDel.mock.calls[1]).toEqual(['audio/100.mp3']);
+  });
 });

--- a/apps/web/tests/history-actions.test.ts
+++ b/apps/web/tests/history-actions.test.ts
@@ -135,6 +135,24 @@ describe('history deletion actions', () => {
     expect(mocks.redisDel).not.toHaveBeenCalled();
   });
 
+  it('captures database failures with user and raw error context', async () => {
+    const databaseError = new Error('permission denied');
+    const { adminSupabase, sessionSupabase } = createSupabaseMock({
+      error: databaseError,
+    });
+    vi.mocked(createClient).mockResolvedValue(sessionSupabase as never);
+    vi.mocked(createAdminClient).mockReturnValue(adminSupabase as never);
+
+    await expect(handleDeleteAllAction()).rejects.toThrow(
+      'Failed to delete audio files',
+    );
+
+    expect(captureException).toHaveBeenCalledWith(databaseError, {
+      extra: { errorData: databaseError, scope: 'all' },
+      user: { email: 'user@example.com', id: 'user-1' },
+    });
+  });
+
   it('does not turn a completed soft delete into a failure when Redis is down', async () => {
     const cacheError = new Error('Redis unavailable');
     const { adminSupabase, sessionSupabase } = createSupabaseMock({

--- a/apps/web/tests/history-actions.test.ts
+++ b/apps/web/tests/history-actions.test.ts
@@ -153,6 +153,20 @@ describe('history deletion actions', () => {
     });
   });
 
+  it('does not invalidate cache or track analytics when no rows match', async () => {
+    const { adminSupabase, sessionSupabase } = createSupabaseMock({});
+    vi.mocked(createClient).mockResolvedValue(sessionSupabase as never);
+    vi.mocked(createAdminClient).mockReturnValue(adminSupabase as never);
+
+    await expect(handleDeleteAllAction()).resolves.toEqual({
+      deletedCount: 0,
+      success: true,
+    });
+
+    expect(mocks.redisDel).not.toHaveBeenCalled();
+    expect(mocks.after).not.toHaveBeenCalled();
+  });
+
   it('does not turn a completed soft delete into a failure when Redis is down', async () => {
     const cacheError = new Error('Redis unavailable');
     const { adminSupabase, sessionSupabase } = createSupabaseMock({

--- a/apps/web/tests/history-actions.test.ts
+++ b/apps/web/tests/history-actions.test.ts
@@ -47,10 +47,12 @@ function createSupabaseMock({
 }) {
   const query = {
     eq: vi.fn(),
+    match: vi.fn(),
     select: vi.fn().mockResolvedValue({ data: deletedAudioFiles, error }),
     update: vi.fn(),
   };
   query.eq.mockReturnValue(query);
+  query.match.mockReturnValue(query);
   query.update.mockReturnValue(query);
 
   const sessionSupabase = {
@@ -92,8 +94,10 @@ describe('history deletion actions', () => {
       deleted_at: expect.any(String),
       status: 'deleted',
     });
-    expect(query.eq).toHaveBeenCalledWith('user_id', 'user-1');
-    expect(query.eq).toHaveBeenCalledWith('status', 'active');
+    expect(query.match).toHaveBeenCalledWith({
+      status: 'active',
+      user_id: 'user-1',
+    });
     expect(query.eq).not.toHaveBeenCalledWith('id', expect.any(String));
     expect(query.select).toHaveBeenCalledWith('id, storage_key');
     expect(mocks.redisDel).toHaveBeenCalledWith(
@@ -112,7 +116,10 @@ describe('history deletion actions', () => {
 
     await handleDeleteAction('audio-1');
 
-    expect(query.eq).toHaveBeenCalledWith('user_id', 'user-1');
+    expect(query.match).toHaveBeenCalledWith({
+      status: 'active',
+      user_id: 'user-1',
+    });
     expect(query.eq).toHaveBeenCalledWith('id', 'audio-1');
   });
 


### PR DESCRIPTION
This lets users clear every audio entry from their generation history in one action, rather than deleting files individually.

The history toolbar now includes a responsive **Delete all** control with a confirmation dialog, loading feedback, and localized success and error messages. The authenticated server action soft-deletes every active audio row owned by the current user, clears the corresponding Redis regeneration keys, and intentionally leaves the R2 objects untouched for recovery.

The existing single-file delete flow now shares the same server-side behavior and uses localized dialog and toast copy. New action and component tests cover user scoping, confirmation, cache updates, failure handling, and the empty-history state.

https://sexyvoice.featurebase.app/p/delete-all-from-history

## Validation

- `pnpm fixall`
- `pnpm type-check`
- `pnpm check-translations`
- `pnpm test` — 61 files passed, 761 tests passed, 19 skipped
