### PR TITLE
refactor: centralize SHA-256 hashing

### DIFF
--- a/apps/web/app/api/clone-voice/route.ts
+++ b/apps/web/app/api/clone-voice/route.ts
@@ -30,6 +30,7 @@ import {
   isCloneTextOverLimit,
 } from '@/lib/clone/text-limits';
 import PostHogClient from '@/lib/posthog';
+import { sha256Hex } from '@/lib/sha256';
 import { uploadFileToR2 } from '@/lib/storage/upload';
 import { CLONING_FILE_MAX_SIZE } from '@/lib/supabase/constants';
 import {
@@ -272,16 +273,13 @@ const sanitizeFilename = (filename: string): string => {
     .replace(/[^a-zA-Z0-9.-]/g, '_'); // Replace special chars with underscore
 };
 
-async function generateBufferHash(buffer: Buffer): Promise<string> {
+function generateBufferHash(buffer: Buffer): Promise<string> {
   // Use a content-based SHA-256 hash so identical uploads produce the same cache key.
   // This allows R2/Redis entries to be reused deterministically instead of depending on timestamps.
   // `new Uint8Array(buffer)` creates a view over the existing Buffer data here, so it does not
   // materially increase memory usage beyond hashing the already in-memory upload.
   const data = new Uint8Array(buffer);
-  const hashBuffer = await crypto.subtle.digest('SHA-256', data);
-  const hashArray = Array.from(new Uint8Array(hashBuffer));
-
-  return hashArray.map((b) => b.toString(16).padStart(2, '0')).join('');
+  return sha256Hex(data);
 }
 
 // ============================================================================

--- a/apps/web/lib/audio.ts
+++ b/apps/web/lib/audio.ts
@@ -1,5 +1,7 @@
 import { parseBuffer } from 'music-metadata';
 
+import { sha256Hex } from '@/lib/sha256';
+
 interface WavConversionOptions {
   bitsPerSample: number;
   numChannels: number;
@@ -70,14 +72,8 @@ export function convertToWav(rawData: string, mimeType: string): Buffer {
 }
 
 export async function generateHash(input: string) {
-  const textEncoder = new TextEncoder();
-  const data = textEncoder.encode(input);
-  const hashBuffer = await crypto.subtle.digest('SHA-256', data);
-  const hashArray = Array.from(new Uint8Array(hashBuffer));
-  return hashArray
-    .map((b) => b.toString(16).padStart(2, '0'))
-    .join('')
-    .slice(0, 8);
+  const data = new TextEncoder().encode(input);
+  return (await sha256Hex(data)).slice(0, 8);
 }
 
 /**

--- a/apps/web/lib/sha256.ts
+++ b/apps/web/lib/sha256.ts
@@ -1,0 +1,7 @@
+export async function sha256Hex(input: BufferSource): Promise<string> {
+  const digest = await crypto.subtle.digest('SHA-256', input);
+
+  return Array.from(new Uint8Array(digest), (byte) =>
+    byte.toString(16).padStart(2, '0'),
+  ).join('');
+}

--- a/apps/web/tests/sha256.test.ts
+++ b/apps/web/tests/sha256.test.ts
@@ -1,0 +1,26 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { generateHash } from '@/lib/audio';
+import { sha256Hex } from '@/lib/sha256';
+
+describe('SHA-256 helpers', () => {
+  const digest = Uint8Array.from({ length: 32 }, (_, index) => index).buffer;
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('encodes the complete digest as lowercase hexadecimal', async () => {
+    vi.spyOn(crypto.subtle, 'digest').mockResolvedValue(digest);
+
+    await expect(sha256Hex(new Uint8Array([1, 2, 3]))).resolves.toBe(
+      '000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f',
+    );
+  });
+
+  it('preserves the shortened audio cache key', async () => {
+    vi.spyOn(crypto.subtle, 'digest').mockResolvedValue(digest);
+
+    await expect(generateHash('hello')).resolves.toBe('00010203');
+  });
+});


### PR DESCRIPTION
## Summary

- add a shared SHA-256-to-hex helper
- reuse it for voice-upload and audio cache hashing
- preserve the existing full and shortened cache-key formats
- add focused regression coverage

## Testing

- `pnpm fixall`
- `pnpm type-check`
- `cd apps/web && pnpm exec vitest run tests/sha256.test.ts tests/clone-voice.test.ts`
- `git diff --check`

Closes #515

AI assistance was used to investigate the duplication and prepare the initial patch. I reviewed the implementation and ran the repository checks.
