### PR TITLE
feat(call): enable long-term memory by default for all calls

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -251,7 +251,7 @@ flowchart TD
     C --> D["Check minimum credits and free-user lifetime call limit"]
     D --> E["Validate configuration and normalize the call model"]
     E --> F["Resolve character prompt from PostgreSQL"]
-    F --> G["Authorize paid custom-character, scene, and memory features"]
+    F --> G["Authorize paid custom-character and scene features"]
     G --> H["Resolve voice ID"]
     H --> I["Mint LiveKit token with server-resolved metadata"]
     I --> J["Dispatch the sexycall agent"]
@@ -269,9 +269,11 @@ rate is 1,000 credits per minute.
 
 Public character prompt text never reaches the browser. The token route loads
 it with an admin query, chooses the requested localized prompt or English
-fallback, and places the result in LiveKit token metadata. Custom characters,
-custom scenes, and the long-term memory backend require a paid account. Memory
-is off by default, and its UI toggle is currently hidden.
+fallback, and places the result in LiveKit token metadata. Custom characters
+and custom scenes require a paid account. Long-term memory is on by default for
+every call on both free and paid plans; only a client that explicitly sends
+`memory: false` turns it off, and its UI toggle is currently hidden. Users can
+erase everything stored for them with `DELETE /api/memories`.
 
 ### Call Configuration
 
@@ -283,7 +285,7 @@ is off by default, and its UI toggle is currently hidden.
 | Max output tokens | Nullable; defaults to the agent's model behavior |
 | Instructions | Edge Config defaults for non-character calls; database prompts for characters |
 | Language | 20 supported call languages; English fallback |
-| Memory | Paid, opt-in backend; off by default |
+| Memory | On by default for all calls, free and paid; opt-out only |
 
 Completed calls of at least 120 seconds with a transcript are eligible for
 structured analysis. A Supabase Database Webhook authenticates to

--- a/apps/web/app/api/call-token/route.ts
+++ b/apps/web/app/api/call-token/route.ts
@@ -215,17 +215,6 @@ export async function POST(request: Request) {
       );
     }
 
-    // Long-term memory is a paid-only feature. Enforce server-side so a stale
-    // or tampered client can't enable it for a free user. Reuse the lazily
-    // resolved paid-status flag to avoid an extra query when possible.
-    let memoryEnabled = false;
-    if (memory) {
-      if (isPaidUser === undefined) {
-        isPaidUser = await hasUserPaid(user.id);
-      }
-      memoryEnabled = isPaidUser;
-    }
-
     const defaultSceneText = callScenes.find(
       (s) => s.id === selectedSceneId,
     )?.text;
@@ -243,10 +232,12 @@ export async function POST(request: Request) {
       instructions: resolvedInstructions,
       language: selectedLanguage,
       max_output_tokens: maxOutputTokens,
-      // Long-term memory opt-in (paid users only). Absent/false → the agent
-      // stores nothing. Scope is per-user only for now (sexycall defaults
-      // memory_scope to "user"); per-character scope is deferred.
-      memory: memoryEnabled,
+      // Long-term memory is on for every call, on free and paid plans alike.
+      // The schema defaults an absent flag to true, so only a client that
+      // explicitly sends `memory: false` makes the agent store nothing. Scope
+      // is per-user only for now (sexycall defaults memory_scope to "user");
+      // per-character scope is deferred.
+      memory,
       model,
       scene_id: selectedSceneId ?? null,
       scene_modified: sceneModified,

--- a/apps/web/components/call/configuration-form.tsx
+++ b/apps/web/components/call/configuration-form.tsx
@@ -280,36 +280,25 @@ export function ConfigurationForm({
           </div>
         )}
 
-        {/* Memory opt-in (paid users only) */}
-        {/*<Tooltip delayDuration={100}>
-          <TooltipTrigger asChild>
-            <div className="flex w-full items-center justify-between gap-4 border-separator1 border-b px-4 py-4 md:px-1">
-              <label className="flex flex-col gap-1" htmlFor="memory-toggle">
-                <span className="font-semibold text-neutral-400 text-xs uppercase tracking-widest">
-                  {t('memoryLabel')}
-                </span>
-                <span className="text-neutral-300 text-xs normal-case">
-                  {t('memoryDescription')}
-                </span>
-              </label>
-              <Switch
-                checked={isPaidUser && pgState.memory}
-                disabled={
-                  !isPaidUser || connectionState === ConnectionState.Connected
-                }
-                id="memory-toggle"
-                onCheckedChange={(checked) =>
-                  dispatch({ type: 'SET_MEMORY', payload: checked })
-                }
-              />
-            </div>
-          </TooltipTrigger>
-          {!isPaidUser && (
-            <TooltipContent className="TooltipContent">
-              <p>{t('memoryUpgradeTooltip')}</p>
-            </TooltipContent>
-          )}
-        </Tooltip>*/}
+        {/* Memory switch (on by default, free and paid alike) */}
+        {/*<div className="flex w-full items-center justify-between gap-4 border-separator1 border-b px-4 py-4 md:px-1">
+          <label className="flex flex-col gap-1" htmlFor="memory-toggle">
+            <span className="font-semibold text-neutral-400 text-xs uppercase tracking-widest">
+              {t('memoryLabel')}
+            </span>
+            <span className="text-neutral-300 text-xs normal-case">
+              {t('memoryDescription')}
+            </span>
+          </label>
+          <Switch
+            checked={pgState.memory}
+            disabled={connectionState === ConnectionState.Connected}
+            id="memory-toggle"
+            onCheckedChange={(checked) =>
+              dispatch({ type: 'SET_MEMORY', payload: checked })
+            }
+          />
+        </div>*/}
 
         {/* Character Selection */}
         <div className="w-full border-separator1 border-b px-4 py-6 md:px-1">

--- a/apps/web/data/playground-state.ts
+++ b/apps/web/data/playground-state.ts
@@ -79,8 +79,8 @@ export interface PlaygroundState {
   initialInstruction: string;
   instructions: string;
   language: CallLanguage;
-  /** Long-term memory opt-in. When true, the agent remembers distilled facts
-   * about the user across calls; off (default) stores nothing. */
+  /** Long-term memory. On by default: the agent remembers distilled facts
+   * about the user across calls. When switched off, nothing is stored. */
   memory: boolean;
   sceneInstructions: string;
   selectedPresetId: string | null;
@@ -99,7 +99,7 @@ export const defaultPlaygroundState: PlaygroundState = {
   sceneInstructions: '',
   instructions,
   language: defaultLanguage,
-  memory: false,
+  memory: true,
   initialInstruction,
   defaultPresets: [], // Now populated from DB via SSR props
 };

--- a/apps/web/lib/call-token-schema.ts
+++ b/apps/web/lib/call-token-schema.ts
@@ -40,10 +40,11 @@ export const callTokenPlaygroundStateSchema = z.object({
       'zh',
     ] as const)
     .optional(),
-  // Long-term memory (opt-in). When true, the agent (sexycall) preloads and
-  // stores distilled facts for this user across calls. Off/absent → nothing is
-  // stored.
-  memory: z.boolean().optional(),
+  // Long-term memory. On by default for every call: the agent (sexycall)
+  // preloads and stores distilled facts for this user across calls. An older
+  // client that omits the flag still gets memory; only an explicit `false`
+  // (the user switching it off) stops anything from being stored.
+  memory: z.boolean().default(true),
   sceneInstructions: z.string().nullable().optional(),
   selectedPresetId: z.uuid().nullable(),
   selectedSceneId: z

--- a/apps/web/messages/da.json
+++ b/apps/web/messages/da.json
@@ -157,8 +157,8 @@
           "description": "Hvert opkald krypteres undervejs. Intet menneske lytter til dine samtaler."
         },
         "forgotten": {
-          "title": "Glemt som standard",
-          "description": "Intet føres videre mellem opkald, medmindre du selv slår hukommelsen til."
+          "title": "Hukommelse, du styrer",
+          "description": "Karaktererne husker dig mellem opkald som standard. Slå hukommelsen fra når som helst, eller slet det hele fra din profil."
         }
       },
       "customCharacter": {
@@ -573,8 +573,7 @@
     "freeUserCallLimitExceeded": "Gratis brugere er begrænset til 5 minutters opkald. Opgrader venligst for at fortsætte.",
     "configurationTitle": "Konfiguration",
     "memoryLabel": "Hukommelse",
-    "memoryDescription": "Lad karaktererne huske dig mellem opkald. Der gemmes intet, medmindre det er slået til.",
-    "memoryUpgradeTooltip": "Opgrader til en betalt plan, så karaktererne kan huske dig mellem opkald.",
+    "memoryDescription": "Lad karaktererne huske dig mellem opkald. Slået til som standard – slå den fra, så gemmes der intet.",
     "languageLabel": "Sprog",
     "languagePlaceholder": "Vælg sprog",
     "sceneLabel": "Scene",
@@ -838,7 +837,7 @@
     },
     "memory": {
       "title": "Hukommelse for stemmeopkald",
-      "description": "Hvis du slår hukommelse til under opkald, husker karaktererne nogle få oplysninger om dig for at bevare sammenhængen. Du kan slette det hele her.",
+      "description": "Hukommelse er slået til som standard under opkald, så karaktererne husker nogle få oplysninger om dig for at bevare sammenhængen. Du kan slette det hele her.",
       "button": "Slet al hukommelse",
       "confirmTitle": "Slet al hukommelse fra stemmeopkald?",
       "confirmDescription": "Dette sletter permanent alt, hvad karaktererne har husket om dig fra tidligere opkald. Det kan ikke fortrydes.",

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -157,8 +157,8 @@
           "description": "Jeder Anruf wird bei der Übertragung verschlüsselt. Kein Mensch hört Ihre Gespräche mit."
         },
         "forgotten": {
-          "title": "Standardmäßig vergessen",
-          "description": "Zwischen den Anrufen bleibt nichts erhalten, solange Sie die Erinnerung nicht selbst aktivieren."
+          "title": "Erinnerung unter Ihrer Kontrolle",
+          "description": "Die Charaktere erinnern sich standardmäßig zwischen den Anrufen an Sie. Deaktivieren Sie die Erinnerung jederzeit oder löschen Sie alles in Ihrem Profil."
         }
       },
       "customCharacter": {
@@ -577,8 +577,7 @@
     "freeUserCallLimitExceeded": "Kostenlose Nutzer sind auf 5 minuten Anrufe begrenzt. Bitte upgraden Sie, um fortzufahren.",
     "configurationTitle": "Konfiguration",
     "memoryLabel": "Erinnerung",
-    "memoryDescription": "Lass die Charaktere sich zwischen Anrufen an dich erinnern. Es wird nichts gespeichert, sofern es nicht aktiviert ist.",
-    "memoryUpgradeTooltip": "Wechsle zu einem kostenpflichtigen Tarif, damit die Charaktere sich zwischen Anrufen an dich erinnern.",
+    "memoryDescription": "Lass die Charaktere sich zwischen Anrufen an dich erinnern. Standardmäßig aktiviert – schalte sie aus, und es wird nichts gespeichert.",
     "languageLabel": "Sprache",
     "languagePlaceholder": "Sprache wählen",
     "sceneLabel": "Szene",
@@ -842,7 +841,7 @@
     },
     "memory": {
       "title": "Sprachanruf-Erinnerung",
-      "description": "Wenn du die Erinnerungsfunktion während Anrufen aktivierst, merken sich die Charaktere einige Angaben über dich, um die Kontinuität zu wahren. Hier kannst du alles löschen.",
+      "description": "Die Erinnerungsfunktion ist bei Anrufen standardmäßig aktiviert, daher merken sich die Charaktere einige Angaben über dich, um die Kontinuität zu wahren. Hier kannst du alles löschen.",
       "button": "Alle Erinnerungen löschen",
       "confirmTitle": "Alle Sprachanruf-Erinnerungen löschen?",
       "confirmDescription": "Dadurch wird dauerhaft alles gelöscht, was sich die Charaktere aus früheren Anrufen über dich gemerkt haben. Dies kann nicht rückgängig gemacht werden.",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -157,8 +157,8 @@
           "description": "Every call is encrypted in transit. No human ever listens to your conversations."
         },
         "forgotten": {
-          "title": "Forgotten by default",
-          "description": "Nothing carries over between calls unless you switch memory on yourself."
+          "title": "Memory you control",
+          "description": "Characters remember you between calls by default. Switch memory off any time, or erase everything from your profile."
         }
       },
       "customCharacter": {
@@ -575,8 +575,7 @@
     "freeUserCallLimitExceeded": "Free users are limited to 5 minutes of calls. Please upgrade to continue.",
     "configurationTitle": "Configuration",
     "memoryLabel": "Memory",
-    "memoryDescription": "Let the characters remember you between calls. Nothing is stored unless it's on.",
-    "memoryUpgradeTooltip": "Upgrade to a paid plan to let the characters remember you between calls.",
+    "memoryDescription": "Let the characters remember you between calls. On by default — switch it off and nothing is stored.",
     "languageLabel": "Language",
     "languagePlaceholder": "Choose language",
     "sceneLabel": "Scene",
@@ -840,7 +839,7 @@
     },
     "memory": {
       "title": "Voice Call Memory",
-      "description": "If you turn on memory during calls, the characters remember a few details about you to keep continuity. You can erase all of it here.",
+      "description": "Memory is on by default during calls, so the characters remember a few details about you to keep continuity. You can erase all of it here.",
       "button": "Delete all memories",
       "confirmTitle": "Delete all voice call memories?",
       "confirmDescription": "This permanently erases everything the characters have remembered about you from past calls. This cannot be undone.",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -157,8 +157,8 @@
           "description": "Cada llamada se cifra en tránsito. Ninguna persona escucha tus conversaciones."
         },
         "forgotten": {
-          "title": "Olvidado por defecto",
-          "description": "No se guarda nada entre llamadas a menos que actives la memoria tú mismo."
+          "title": "Una memoria que controlas tú",
+          "description": "Los personajes te recuerdan entre llamadas de forma predeterminada. Desactiva la memoria cuando quieras o bórralo todo desde tu perfil."
         }
       },
       "customCharacter": {
@@ -577,8 +577,7 @@
     "freeUserCallLimitExceeded": "Los usuarios gratuitos están limitados a 5 minutos de llamadas. Por favor, actualiza tu cuenta para continuar.",
     "configurationTitle": "Configuración",
     "memoryLabel": "Memoria",
-    "memoryDescription": "Deja que los personajes te recuerden entre llamadas. No se guarda nada a menos que esté activado.",
-    "memoryUpgradeTooltip": "Actualiza a un plan de pago para que los personajes te recuerden entre llamadas.",
+    "memoryDescription": "Deja que los personajes te recuerden entre llamadas. Activada de forma predeterminada: desactívala y no se guarda nada.",
     "languageLabel": "Idioma",
     "languagePlaceholder": "Elige un idioma",
     "sceneLabel": "Escena",
@@ -842,7 +841,7 @@
     },
     "memory": {
       "title": "Memoria de llamadas de voz",
-      "description": "Si activas la memoria durante las llamadas, los personajes recuerdan algunos datos sobre ti para mantener la continuidad. Aquí puedes borrarlo todo.",
+      "description": "La memoria está activada de forma predeterminada durante las llamadas, así que los personajes recuerdan algunos datos sobre ti para mantener la continuidad. Aquí puedes borrarlo todo.",
       "button": "Eliminar todas las memorias",
       "confirmTitle": "¿Eliminar todas las memorias de las llamadas de voz?",
       "confirmDescription": "Esto borra de forma permanente todo lo que los personajes han recordado sobre ti en llamadas anteriores. No se puede deshacer.",

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -157,8 +157,8 @@
           "description": "Chaque appel est chiffré pendant son transit. Aucun humain n'écoute vos conversations."
         },
         "forgotten": {
-          "title": "Oublié par défaut",
-          "description": "Rien ne subsiste d'un appel à l'autre, sauf si vous activez vous-même la mémoire."
+          "title": "Une mémoire que vous contrôlez",
+          "description": "Par défaut, les personnages se souviennent de vous d'un appel à l'autre. Désactivez la mémoire quand vous voulez ou effacez tout depuis votre profil."
         }
       },
       "customCharacter": {
@@ -577,8 +577,7 @@
     "freeUserCallLimitExceeded": "Les utilisateurs gratuits sont limités à 5 minutes d'appels. Veuillez passer à un forfait supérieur pour continuer.",
     "configurationTitle": "Configuration",
     "memoryLabel": "Mémoire",
-    "memoryDescription": "Laissez les personnages se souvenir de vous d’un appel à l’autre. Rien n’est enregistré sauf si c’est activé.",
-    "memoryUpgradeTooltip": "Passez à une offre payante pour que les personnages se souviennent de vous d’un appel à l’autre.",
+    "memoryDescription": "Laissez les personnages se souvenir de vous d’un appel à l’autre. Activée par défaut : désactivez-la et rien n’est enregistré.",
     "languageLabel": "Langue",
     "languagePlaceholder": "Choisir une langue",
     "sceneLabel": "Scène",
@@ -842,7 +841,7 @@
     },
     "memory": {
       "title": "Mémoire des appels vocaux",
-      "description": "Si vous activez la mémoire pendant les appels, les personnages retiennent quelques informations sur vous pour assurer la continuité. Vous pouvez tout effacer ici.",
+      "description": "La mémoire est activée par défaut pendant les appels : les personnages retiennent quelques informations sur vous pour assurer la continuité. Vous pouvez tout effacer ici.",
       "button": "Supprimer toutes les mémoires",
       "confirmTitle": "Supprimer toutes les mémoires des appels vocaux ?",
       "confirmDescription": "Cela efface définitivement tout ce que les personnages ont retenu de vous lors des appels précédents. Cette action est irréversible.",

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -157,8 +157,8 @@
           "description": "Ogni chiamata è crittografata in transito. Nessuna persona ascolta le tue conversazioni."
         },
         "forgotten": {
-          "title": "Dimenticato per impostazione predefinita",
-          "description": "Non resta nulla da una chiamata all'altra, a meno che non attivi tu stesso la memoria."
+          "title": "Una memoria che controlli tu",
+          "description": "Per impostazione predefinita i personaggi ti ricordano da una chiamata all'altra. Disattiva la memoria quando vuoi o cancella tutto dal tuo profilo."
         }
       },
       "customCharacter": {
@@ -577,8 +577,7 @@
     "freeUserCallLimitExceeded": "Gli utenti gratuiti sono limitati a 5 minuti di chiamate. Effettua l'upgrade per continuare.",
     "configurationTitle": "Configurazione",
     "memoryLabel": "Memoria",
-    "memoryDescription": "Lascia che i personaggi ti ricordino tra una chiamata e l’altra. Non viene memorizzato nulla a meno che non sia attivo.",
-    "memoryUpgradeTooltip": "Passa a un piano a pagamento per far sì che i personaggi ti ricordino tra una chiamata e l’altra.",
+    "memoryDescription": "Lascia che i personaggi ti ricordino tra una chiamata e l’altra. Attiva per impostazione predefinita: disattivala e non viene memorizzato nulla.",
     "languageLabel": "Lingua",
     "languagePlaceholder": "Scegli la lingua",
     "sceneLabel": "Scena",
@@ -842,7 +841,7 @@
     },
     "memory": {
       "title": "Memoria delle chiamate vocali",
-      "description": "Se attivi la memoria durante le chiamate, i personaggi ricordano alcuni dettagli su di te per mantenere la continuità. Qui puoi cancellare tutto.",
+      "description": "La memoria è attiva per impostazione predefinita durante le chiamate, così i personaggi ricordano alcuni dettagli su di te per mantenere la continuità. Qui puoi cancellare tutto.",
       "button": "Elimina tutte le memorie",
       "confirmTitle": "Eliminare tutte le memorie delle chiamate vocali?",
       "confirmDescription": "Questa operazione cancella in modo permanente tutto ciò che i personaggi hanno ricordato di te dalle chiamate precedenti. Non può essere annullata.",

--- a/apps/web/tests/call-token.test.ts
+++ b/apps/web/tests/call-token.test.ts
@@ -132,7 +132,7 @@ describe('call-token API validation', () => {
       expect(result.success).toBe(true);
     });
 
-    it('should accept the optional memory opt-in flag', () => {
+    it('should keep an explicit memory flag as sent', () => {
       const base = {
         instructions: 'Test',
         selectedPresetId: null,
@@ -144,15 +144,33 @@ describe('call-token API validation', () => {
         },
       };
 
-      // Present (true/false) and absent are all valid; the paid-only gating is
-      // enforced server-side in the route, not by the schema.
-      for (const memory of [true, false, undefined]) {
+      for (const memory of [true, false]) {
         const result = playgroundStateSchema.safeParse({ ...base, memory });
         expect(result.success).toBe(true);
         if (result.success) {
           expect(result.data.memory).toBe(memory);
         }
       }
+    });
+
+    it('should default memory to on when the flag is absent', () => {
+      // Memory is on for every call. An older client (or a payload built
+      // before the flag existed) must still get memory, so only an explicit
+      // `false` opts out.
+      const payload = {
+        instructions: 'Test',
+        selectedPresetId: null,
+        sessionConfig: {
+          maxOutputTokens: null,
+          model: 'grok-voice-think-fast-1.0',
+          temperature: 0.8,
+          voice: 'Ara',
+        },
+      };
+
+      const result = playgroundStateSchema.safeParse(payload);
+      expect(result.success).toBe(true);
+      expect(result.data?.memory).toBe(true);
     });
 
     it('should reject a non-boolean memory flag', () => {

--- a/apps/web/tests/playground-state-memory.test.ts
+++ b/apps/web/tests/playground-state-memory.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+
+import { defaultPlaygroundState } from '@/data/playground-state';
+import { callTokenPlaygroundStateSchema } from '@/lib/call-token-schema';
+import { createPlaygroundStateHelpers } from '@/lib/playground-state-helpers';
+
+// Memory is on for every call. These tests pin the client side of that
+// default: the initial state, and the payload the call page posts to
+// /api/call-token.
+describe('playground state memory default', () => {
+  const helpers = createPlaygroundStateHelpers();
+
+  it('starts with memory on', () => {
+    expect(defaultPlaygroundState.memory).toBe(true);
+  });
+
+  it('sends memory on in the call-token payload', () => {
+    const payload = helpers.getStateWithFullInstructions({
+      ...defaultPlaygroundState,
+    });
+
+    expect(payload.memory).toBe(true);
+
+    const result = callTokenPlaygroundStateSchema.safeParse(payload);
+    expect(result.success).toBe(true);
+    expect(result.data?.memory).toBe(true);
+  });
+
+  it('keeps an explicit opt-out in the call-token payload', () => {
+    const payload = helpers.getStateWithFullInstructions({
+      ...defaultPlaygroundState,
+      memory: false,
+    });
+
+    expect(payload.memory).toBe(false);
+
+    const result = callTokenPlaygroundStateSchema.safeParse(payload);
+    expect(result.success).toBe(true);
+    expect(result.data?.memory).toBe(false);
+  });
+});

--- a/apps/web/tests/utils/preset-selector-mocks.tsx
+++ b/apps/web/tests/utils/preset-selector-mocks.tsx
@@ -232,7 +232,7 @@ export function createDefaultPgState(
     sceneInstructions: '',
     instructions: 'test instructions',
     language: 'en' as const,
-    memory: false,
+    memory: true,
     initialInstruction: 'Say hi',
     defaultPresets: defaultPresetsFixture,
     ...overrides,


### PR DESCRIPTION
Memory was an opt-in, paid-only feature that defaulted to off, and its UI toggle was hidden, so no calls ever ran with memory enabled. Turn it on by default for every call on free and paid plans alike:

- defaultPlaygroundState.memory is now true
- call-token schema defaults an absent memory flag to true, so clients that omit it still get memory; only an explicit false opts out
- /api/call-token no longer gates memory on paid status
- update the hidden memory switch to drop the paid gating
- refresh localized copy in all 6 locales (memory is no longer off by default or paid-only) and remove the now unused memoryUpgradeTooltip
- document the new behavior in ARCHITECTURE.md

Closes #525
