### PR TITLE
Translate rejected call instructions

### DIFF
--- a/apps/web/hooks/use-agent.tsx
+++ b/apps/web/hooks/use-agent.tsx
@@ -124,6 +124,8 @@ export function AgentProvider({ children }: { children: React.ReactNode }) {
           toast.error(t('activeCallError'));
         } else if (errorData.error === 'insufficient_credits') {
           toast.error(t('notEnoughCredits', { count: CREDITS_PER_MINUTE }));
+        } else if (errorData.error === 'instructions_rejected') {
+          toast.error(t('instructionsRejected'));
         } else {
           toast.error(errorData.message || 'An error occurred');
         }

--- a/apps/web/messages/da.json
+++ b/apps/web/messages/da.json
@@ -590,6 +590,7 @@
     "configurationUpdateError": "Fejl ved opdatering af konfiguration",
     "agentUnavailable": "Agenten er ikke tilgængelig",
     "activeCallError": "Du har allerede et aktivt opkald i gang",
+    "instructionsRejected": "Opkaldet kunne ikke starte, fordi karakteren eller scenen ikke bestod AI-udbyderens sikkerhedstjek. Rediger karakteren eller scenen, og prøv igen.",
     "microphonePermissionDenied": "Mikrofonadgang nægtet. Tillad venligst mikrofonadgang og prøv igen.",
     "disconnected": "Afbrudt",
     "chooseCharacter": "Hvem vil du tale med?",

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -594,6 +594,7 @@
     "configurationUpdateError": "Fehler beim Aktualisieren der Konfiguration",
     "agentUnavailable": "Agent nicht verfügbar",
     "activeCallError": "Du hast bereits einen aktiven Anruf",
+    "instructionsRejected": "Dieser Anruf konnte nicht gestartet werden, weil der Charakter oder die Szene die Sicherheitsprüfungen des KI-Anbieters nicht bestanden haben. Bearbeite den Charakter oder die Szene und versuche es erneut.",
     "microphonePermissionDenied": "Mikrofonzugriff verweigert. Bitte erlaube den Mikrofonzugriff und versuche es erneut.",
     "disconnected": "Getrennt",
     "chooseCharacter": "Mit wem möchtest du sprechen?",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -592,6 +592,7 @@
     "configurationUpdateError": "Error updating configuration",
     "agentUnavailable": "Agent unavailable",
     "activeCallError": "You already have an active call in progress",
+    "instructionsRejected": "This call couldn't start because the character or scene didn't pass the AI provider's safety checks. Edit the character or scene and try again.",
     "microphonePermissionDenied": "Microphone access denied. Please allow microphone access and try again.",
     "disconnected": "Disconnected",
     "chooseCharacter": "Who do you want to talk to?",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -594,6 +594,7 @@
     "configurationUpdateError": "Error al actualizar la configuración",
     "agentUnavailable": "Agente no disponible",
     "activeCallError": "Ya tienes una llamada activa en curso",
+    "instructionsRejected": "Esta llamada no pudo iniciarse porque el personaje o la escena no superaron las comprobaciones de seguridad del proveedor de IA. Edita el personaje o la escena e inténtalo de nuevo.",
     "microphonePermissionDenied": "Acceso al micrófono denegado. Por favor, permite el acceso al micrófono e inténtalo de nuevo.",
     "disconnected": "Desconectado",
     "chooseCharacter": "¿Con quién quieres hablar?",

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -594,6 +594,7 @@
     "configurationUpdateError": "Erreur lors de la mise à jour de la configuration",
     "agentUnavailable": "Agent indisponible",
     "activeCallError": "Vous avez déjà un appel actif en cours",
+    "instructionsRejected": "Cet appel n’a pas pu démarrer, car le personnage ou la scène n’ont pas passé les contrôles de sécurité du fournisseur d’IA. Modifiez le personnage ou la scène, puis réessayez.",
     "microphonePermissionDenied": "Accès au microphone refusé. Veuillez autoriser l'accès au microphone et réessayer.",
     "disconnected": "Déconnecté",
     "chooseCharacter": "À qui voulez-vous parler ?",

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -594,6 +594,7 @@
     "configurationUpdateError": "Errore durante l'aggiornamento della configurazione",
     "agentUnavailable": "Agente non disponibile",
     "activeCallError": "Hai già una chiamata attiva in corso",
+    "instructionsRejected": "Impossibile avviare la chiamata perché il personaggio o la scena non hanno superato i controlli di sicurezza del provider di IA. Modifica il personaggio o la scena e riprova.",
     "microphonePermissionDenied": "Accesso al microfono negato. Consenti l'accesso al microfono e riprova.",
     "disconnected": "Disconnesso",
     "chooseCharacter": "Con chi vuoi parlare?",

--- a/apps/web/tests/hooks/use-agent.test.tsx
+++ b/apps/web/tests/hooks/use-agent.test.tsx
@@ -1,0 +1,98 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest';
+import { act, render, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { AgentProvider } from '@/hooks/use-agent';
+
+const mocks = vi.hoisted(() => {
+  const rpcHandlers = new Map<string, (data: { payload: string }) => Promise<string>>();
+
+  return {
+    disconnect: vi.fn(async () => undefined),
+    room: {
+      off: vi.fn(),
+      on: vi.fn(),
+      registerByteStreamHandler: vi.fn(),
+      registerRpcMethod: vi.fn(
+        (
+          method: string,
+          handler: (data: { payload: string }) => Promise<string>,
+        ) => {
+          rpcHandlers.set(method, handler);
+        },
+      ),
+      unregisterByteStreamHandler: vi.fn(),
+      unregisterRpcMethod: vi.fn(),
+    },
+    rpcHandlers,
+    toastError: vi.fn(),
+  };
+});
+
+vi.mock('@livekit/components-react', () => ({
+  useMaybeRoomContext: () => mocks.room,
+  useVoiceAssistant: () => ({ agent: undefined }),
+}));
+
+vi.mock('livekit-client', () => ({
+  RoomEvent: { TranscriptionReceived: 'transcriptionReceived' },
+}));
+
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => {
+    const messages: Record<string, string> = {
+      instructionsRejected: 'Localized instruction rejection',
+    };
+    return messages[key] ?? key;
+  },
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: mocks.toastError,
+    info: vi.fn(),
+    success: vi.fn(),
+    warning: vi.fn(),
+  },
+}));
+
+vi.mock('@/hooks/use-connection', () => ({
+  useConnection: () => ({
+    disconnect: mocks.disconnect,
+    shouldConnect: false,
+  }),
+}));
+
+describe('AgentProvider errors', () => {
+  afterEach(() => {
+    mocks.rpcHandlers.clear();
+    vi.clearAllMocks();
+  });
+
+  it('translates an instruction rejection code before disconnecting', async () => {
+    render(
+      <AgentProvider>
+        <div />
+      </AgentProvider>,
+    );
+
+    await waitFor(() => {
+      expect(mocks.rpcHandlers.has('pg.error')).toBe(true);
+    });
+
+    await act(async () => {
+      await mocks.rpcHandlers.get('pg.error')?.({
+        payload: JSON.stringify({
+          error: 'instructions_rejected',
+          message: 'Server fallback',
+        }),
+      });
+    });
+
+    expect(mocks.toastError).toHaveBeenCalledWith(
+      'Localized instruction rejection',
+    );
+    expect(mocks.disconnect).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
Callers need a localized explanation when the agent reports that a character or scene failed the AI provider's safety checks.

This change maps `instructions_rejected` to frontend copy in all six supported locales, shows the translated toast, and keeps the existing disconnect behavior. It adds coverage for the RPC-to-translation path.

## Validation

- `pnpm --filter @sexyvoice/web test --run` (754 passed, 19 skipped)
- `pnpm --filter @sexyvoice/web type-check`
- `pnpm --filter @sexyvoice/web lint`
- `pnpm --filter @sexyvoice/web format`
- `pnpm --filter @sexyvoice/web check-translations`