### PR TITLE
Make Sentry client rendering errors actionable

### DIFF
--- a/apps/web/lib/sentry/client-filters.ts
+++ b/apps/web/lib/sentry/client-filters.ts
@@ -45,6 +45,7 @@ const nextClientFrameworkFramePattern =
 const thirdPartyScriptFramePattern = /posthog-recorder\.js|addEL_hook/i;
 const localAppFramePattern = /apps\/web|\/_next\/static\/chunks\/app\//i;
 const nextSharedChunkFramePattern = /\/_next\/static\/chunks\/(?!app\/)/i;
+const nextImmutableChunkFramePattern = /\/_next\/static\/immutable\/chunks\//i;
 const browserMediaNoisePattern =
   /Track has ended|WASM_OR_WORKER_NOT_READY|Wasm SIMD unsupported|Lock was stolen by another request/i;
 const opaqueBrowserEventRejectionPattern =
@@ -95,6 +96,10 @@ function frameMatchesLocalApp(frame: SentryStackFrame): boolean {
 
 function frameMatchesNextSharedChunk(frame: SentryStackFrame): boolean {
   return nextSharedChunkFramePattern.test(getFrameText(frame));
+}
+
+function frameMatchesNextImmutableChunk(frame: SentryStackFrame): boolean {
+  return nextImmutableChunkFramePattern.test(getFrameText(frame));
 }
 
 function frameMatchesProsemirror(frame: SentryStackFrame): boolean {
@@ -189,7 +194,9 @@ function isNextClientTransientException(exception: SentryException): boolean {
   const frames = exception.stacktrace?.frames ?? [];
   return (
     framesHaveNoLocalAppFrame(frames) &&
-    (frames.length === 0 || frames.some(frameMatchesNextClientFramework))
+    (frames.length === 0 ||
+      frames.some(frameMatchesNextClientFramework) ||
+      frames.every(frameMatchesNextImmutableChunk))
   );
 }
 

--- a/apps/web/lib/sentry/client-filters.ts
+++ b/apps/web/lib/sentry/client-filters.ts
@@ -35,6 +35,8 @@ const reactHydrationRecoverablePattern =
 const rscConnectionClosedPattern = /^Connection closed\.$/i;
 const nextClientTransientPattern =
   /^(?:Error\s+)?(Connection closed\.|An unexpected response was received from the server\.)$/i;
+const nextResponseFailurePattern =
+  /^(?:Error\s+)?An unexpected response was received from the server\.$/i;
 const reactRenderLifecycleNoisePattern =
   /Maximum update depth exceeded|Rendered more hooks than during the previous render/i;
 
@@ -192,11 +194,17 @@ function isNextClientTransientException(exception: SentryException): boolean {
   }
 
   const frames = exception.stacktrace?.frames ?? [];
+  if (!framesHaveNoLocalAppFrame(frames)) {
+    return false;
+  }
+
+  if (frames.length === 0 || frames.some(frameMatchesNextClientFramework)) {
+    return true;
+  }
+
   return (
-    framesHaveNoLocalAppFrame(frames) &&
-    (frames.length === 0 ||
-      frames.some(frameMatchesNextClientFramework) ||
-      frames.every(frameMatchesNextImmutableChunk))
+    nextResponseFailurePattern.test(exceptionText) &&
+    frames.every(frameMatchesNextImmutableChunk)
   );
 }
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "analyze": "next experimental-analyze",
     "prebuild": "pnpm run check-translations && pnpm run build:content",
-    "build": "next build",
+    "build": "next build --webpack",
     "build:content": "contentlayer2 build",
     "check:fix": "biome check ./app components hooks lib proxy.ts --write",
     "check-translations": "node scripts/check-translations.mjs",

--- a/apps/web/tests/build-script.test.ts
+++ b/apps/web/tests/build-script.test.ts
@@ -1,0 +1,16 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const packageJsonPath = fileURLToPath(
+  new URL('../package.json', import.meta.url),
+);
+const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8')) as {
+  scripts: Record<string, string>;
+};
+
+describe('production build', () => {
+  it('uses webpack so Sentry can upload client source maps', () => {
+    expect(packageJson.scripts.build).toBe('next build --webpack');
+  });
+});

--- a/apps/web/tests/sentry-client-filters.test.ts
+++ b/apps/web/tests/sentry-client-filters.test.ts
@@ -191,6 +191,31 @@ describe('shouldDropClientSentryEvent', () => {
     ).toBe(true);
   });
 
+  it('drops Next response failures from opaque immutable chunks', () => {
+    expect(
+      shouldDropClientSentryEvent({
+        exception: {
+          values: [
+            {
+              type: 'Error',
+              value: 'An unexpected response was received from the server.',
+              stacktrace: {
+                frames: [
+                  {
+                    filename:
+                      'app:///_next/static/immutable/chunks/3lowvp2xns3dx.js',
+                    function: 'M',
+                    module: 'immutable/chunks/3lowvp2xns3dx',
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      }),
+    ).toBe(true);
+  });
+
   it('keeps Next client transient exceptions with app frames', () => {
     expect(
       shouldDropClientSentryEvent({

--- a/apps/web/tests/sentry-client-filters.test.ts
+++ b/apps/web/tests/sentry-client-filters.test.ts
@@ -191,7 +191,7 @@ describe('shouldDropClientSentryEvent', () => {
     ).toBe(true);
   });
 
-  it('drops Next response failures from opaque immutable chunks', () => {
+  it('only drops Next response failures from opaque immutable chunks', () => {
     expect(
       shouldDropClientSentryEvent({
         exception: {
@@ -214,6 +214,29 @@ describe('shouldDropClientSentryEvent', () => {
         },
       }),
     ).toBe(true);
+
+    expect(
+      shouldDropClientSentryEvent({
+        exception: {
+          values: [
+            {
+              type: 'Error',
+              value: 'Connection closed.',
+              stacktrace: {
+                frames: [
+                  {
+                    filename:
+                      'app:///_next/static/immutable/chunks/3lowvp2xns3dx.js',
+                    function: 'M',
+                    module: 'immutable/chunks/3lowvp2xns3dx',
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      }),
+    ).toBe(false);
   });
 
   it('keeps Next client transient exceptions with app frames', () => {

--- a/docs/devops.md
+++ b/docs/devops.md
@@ -408,6 +408,13 @@ pnpm run generate-supabase-types
 - Sentry is configured in `next.config.js` via `@sentry/nextjs`
 - Client errors are tunneled through `/monitoring` to bypass ad-blockers
 - Source maps are uploaded only in production (`VERCEL_ENV=production`)
+- Web production builds use Webpack (`next build --webpack`) so Sentry can
+  produce and upload client source maps. Local development still uses
+  Turbopack.
+- Keep the Webpack override until Sentry supports client source maps for
+  Next.js Turbopack builds and a deployed test event resolves to application
+  source. Track support in the
+  [Sentry JavaScript issue](https://github.com/getsentry/sentry-javascript/issues/8105).
 
 ### CLI setup
 


### PR DESCRIPTION
Sentry client-rendering issues remain hard to act on because Next.js 16 production builds use Turbopack, while the affected C1 and C0 events contain only opaque client chunks. C0 also bypasses the existing transient RSC filter because its only frame uses Next’s immutable chunk namespace.

This changes the production build to Webpack so Sentry can upload usable client source maps, and narrowly filters the exact C0 response failure only when every opaque frame belongs to Next immutable chunks. Events with an application frame remain reportable.

SEXYVOICE-AI-4P was assessed separately. Its sole event is a Sentry Replay hydration detector occurrence with no exception, message, or stack, so there is no safe application-level filter target; it has not recurred since August 12.

Latest related automation fix: #456 (`b4c95256`), merged July 6. C1, C0, and 4P all last occurred after that merge.

Verification:
- `pnpm --filter @sexyvoice/web test --run tests/build-script.test.ts`
- `pnpm --filter @sexyvoice/web test --run tests/sentry-client-filters.test.ts` (19 passed)
- `pnpm type-check`
- `pnpm fixall` (passes with five existing namespace-import warnings)
- Next.js Webpack production compilation completes; local page-data collection then stops because Stripe and Upstash production secrets are absent
- Full web suite: 62 files / 733 tests pass; two unrelated localStorage suites fail under local Node 26, while the repository requires Node 24