### PR TITLE
feat(seo): highlight real-time voice calls in site title and description

### DIFF
--- a/apps/web/app/[lang]/layout.tsx
+++ b/apps/web/app/[lang]/layout.tsx
@@ -36,7 +36,7 @@ export async function generateMetadata(
 
   if (!routing.locales.includes(lang)) {
     return {
-      title: 'SexyVoice.ai – Free AI Text-to-Speech & Voice Generator',
+      title: 'SexyVoice.ai – Free AI Text-to-Speech & Real-Time Voice Calls',
     };
   }
 

--- a/apps/web/app/[lang]/layout.tsx
+++ b/apps/web/app/[lang]/layout.tsx
@@ -36,7 +36,8 @@ export async function generateMetadata(
 
   if (!routing.locales.includes(lang)) {
     return {
-      title: 'SexyVoice.ai – Free AI Text-to-Speech & Real-Time Voice Calls',
+      title:
+        'SexyVoice.ai – Free AI Text-to-Speech, Voice Cloning & Real-Time Voice Calls',
     };
   }
 

--- a/apps/web/messages/da.json
+++ b/apps/web/messages/da.json
@@ -852,8 +852,8 @@
     "description": "Overvåg API-brug og anmodninger over tid."
   },
   "pages": {
-    "defaultTitle": "SexyVoice.ai – Gratis AI tekst-til-tale & stemmegenerator",
-    "description": "Generer udtryksfuld AI-tale med følelser på 24+ sprog. Prøv gratis tekst-til-tale med stemmekloning og naturlig talesyntese. Start med gratis credits – intet kort påkrævet.",
+    "defaultTitle": "SexyVoice.ai – Gratis AI tekst-til-tale & stemmeopkald i realtid",
+    "description": "Generer udtryksfuld AI-tale med følelser på 24+ sprog, eller tal i realtid med AI-karakterer. Gratis tekst-til-tale, stemmekloning og live stemmeopkald. Start med gratis credits – intet kort påkrævet.",
     "skipToMainContent": "Spring til hovedindhold",
     "descriptionLogin": "Log ind på SexyVoice.ai for at få adgang til dine AI-stemmeprojekter, administrere kreditter og generere udtryksfuld tale på flere sprog med avanceret stemmekloning.",
     "descriptionSignup": "Tilmeld dig SexyVoice.ai gratis - Få 10.000 kreditter til at skabe realistiske AI-stemmer med følelser. Avanceret tekst-til-tale og stemmekloning på 24 sprog.",

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -856,7 +856,7 @@
     "description": "API-Nutzung und Anfragen im Zeitverlauf überwachen."
   },
   "pages": {
-    "defaultTitle": "SexyVoice.ai – Kostenlose KI-Sprachausgabe & Echtzeit-Sprachanrufe",
+    "defaultTitle": "SexyVoice.ai – Kostenlose KI-Text-zu-Sprache & Echtzeit-Sprachanrufe",
     "description": "Generieren Sie ausdrucksstarke KI-Sprache mit Emotionen in 24+ Sprachen oder sprechen Sie in Echtzeit mit KI-Charakteren. Kostenlose Text-zu-Sprache, Stimmenklonung & Live-Sprachanrufe. Starten Sie mit kostenlosen Credits – keine Kreditkarte erforderlich.",
     "skipToMainContent": "Zum Hauptinhalt springen",
     "descriptionLogin": "Melden Sie sich bei SexyVoice.ai an, um auf Ihre KI-Sprachprojekte zuzugreifen, Credits zu verwalten und ausdrucksstarke Sprache in mehreren Sprachen zu generieren.",

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -856,8 +856,8 @@
     "description": "API-Nutzung und Anfragen im Zeitverlauf überwachen."
   },
   "pages": {
-    "defaultTitle": "SexyVoice.ai – Kostenloser KI-Text-zu-Sprache- & Stimmengenerator",
-    "description": "Generieren Sie ausdrucksstarke KI-Sprache mit Emotionen in 24+ Sprachen. Probieren Sie kostenlos Text-zu-Sprache mit Stimmenklonung und natürlicher Sprachsynthese aus. Starten Sie mit kostenlosen Credits – keine Kreditkarte erforderlich.",
+    "defaultTitle": "SexyVoice.ai – Kostenlose KI-Sprachausgabe & Echtzeit-Sprachanrufe",
+    "description": "Generieren Sie ausdrucksstarke KI-Sprache mit Emotionen in 24+ Sprachen oder sprechen Sie in Echtzeit mit KI-Charakteren. Kostenlose Text-zu-Sprache, Stimmenklonung & Live-Sprachanrufe. Starten Sie mit kostenlosen Credits – keine Kreditkarte erforderlich.",
     "skipToMainContent": "Zum Hauptinhalt springen",
     "descriptionLogin": "Melden Sie sich bei SexyVoice.ai an, um auf Ihre KI-Sprachprojekte zuzugreifen, Credits zu verwalten und ausdrucksstarke Sprache in mehreren Sprachen zu generieren.",
     "descriptionSignup": "Treten Sie SexyVoice.ai kostenlos bei - Erhalten Sie 10.000 Credits, um realistische KI-Stimmen mit Emotionen zu erstellen. Text-zu-Sprache in 24 Sprachen.",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -854,8 +854,8 @@
     "description": "Monitor API usage and requests over time."
   },
   "pages": {
-    "defaultTitle": "SexyVoice.ai – Free AI Text-to-Speech & Voice Generator",
-    "description": "Generate expressive AI speech with emotions in 24+ languages. Free to try text-to-speech with voice cloning, support & natural speech synthesis. Start with free credits – no card required.",
+    "defaultTitle": "SexyVoice.ai – Free AI Text-to-Speech & Real-Time Voice Calls",
+    "description": "Generate expressive AI speech with emotions in 24+ languages, or talk to AI characters in real time. Free AI voice generator, voice cloning & live voice calls. Start with free credits – no card required.",
     "skipToMainContent": "Skip to main content",
     "descriptionLogin": "Sign in to access your AI voice dashboard. Manage credits, generate speech with emotions, and clone voices in 24+ languages on SexyVoice.ai.",
     "descriptionSignup": "Create a free SexyVoice.ai account – get 10,000 credits instantly. Generate realistic AI voices with emotions, clone voices & create expressive speech in 24+ languages.",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -856,8 +856,8 @@
     "description": "Monitorea el uso de la API y las solicitudes a lo largo del tiempo."
   },
   "pages": {
-    "defaultTitle": "SexyVoice.ai – Generador de voz IA gratis y texto a voz",
-    "description": "Genera voz IA expresiva con emociones en 24+ idiomas. Prueba gratis texto a voz con clonación de voz y síntesis de habla natural. Empieza con créditos gratis – sin tarjeta requerida.",
+    "defaultTitle": "SexyVoice.ai – Texto a voz IA gratis y llamadas de voz en tiempo real",
+    "description": "Genera voz IA expresiva con emociones en 24+ idiomas o habla en tiempo real con personajes de IA. Generador de voz IA gratis, clonación de voz y llamadas de voz en vivo. Empieza con créditos gratis – sin tarjeta requerida.",
     "skipToMainContent": "Saltar al contenido principal",
     "descriptionLogin": "Inicia sesión en SexyVoice.ai para acceder a tus proyectos de voz IA, gestionar créditos y generar voz expresiva en múltiples idiomas con clonación avanzada.",
     "descriptionSignup": "Únete a SexyVoice.ai gratis - Recibe 10,000 créditos para crear voces IA realistas con emociones. Texto a voz avanzado y clonación de voz en 24 idiomas.",

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -856,7 +856,7 @@
     "description": "Surveillez l'utilisation de l'API et les requêtes au fil du temps."
   },
   "pages": {
-    "defaultTitle": "SexyVoice.ai – Synthèse vocale IA gratuite & appels en temps réel",
+    "defaultTitle": "SexyVoice.ai – Synthèse vocale IA gratuite & appels vocaux en temps réel",
     "description": "Générez une voix IA expressive avec des émotions dans plus de 24 langues ou parlez en temps réel avec des personnages IA. Synthèse vocale gratuite, clonage vocal et appels vocaux en direct. Commencez avec des crédits gratuits – aucune carte requise.",
     "skipToMainContent": "Aller au contenu principal",
     "descriptionLogin": "Connectez-vous à SexyVoice.ai pour accéder à vos projets vocaux IA, gérer vos crédits et générer de la parole expressive dans plusieurs langues avec clonage vocal avancé.",

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -856,8 +856,8 @@
     "description": "Surveillez l'utilisation de l'API et les requêtes au fil du temps."
   },
   "pages": {
-    "defaultTitle": "SexyVoice.ai – Synthèse vocale IA gratuite & générateur de voix",
-    "description": "Générez une voix IA expressive avec des émotions dans plus de 24 langues. Essayez gratuitement la synthèse vocale avec clonage vocal et synthèse naturelle de la parole. Commencez avec des crédits gratuits – aucune carte requise.",
+    "defaultTitle": "SexyVoice.ai – Synthèse vocale IA gratuite & appels en temps réel",
+    "description": "Générez une voix IA expressive avec des émotions dans plus de 24 langues ou parlez en temps réel avec des personnages IA. Synthèse vocale gratuite, clonage vocal et appels vocaux en direct. Commencez avec des crédits gratuits – aucune carte requise.",
     "skipToMainContent": "Aller au contenu principal",
     "descriptionLogin": "Connectez-vous à SexyVoice.ai pour accéder à vos projets vocaux IA, gérer vos crédits et générer de la parole expressive dans plusieurs langues avec clonage vocal avancé.",
     "descriptionSignup": "Rejoignez SexyVoice.ai gratuitement - Obtenez 10 000 crédits pour créer des voix IA réalistes avec des émotions. Synthèse vocale avancée et clonage vocal en 24 langues.",

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -856,8 +856,8 @@
     "description": "Monitora l'utilizzo dell'API e le richieste nel tempo."
   },
   "pages": {
-    "defaultTitle": "SexyVoice.ai – Sintesi vocale IA gratuita & generatore di voci",
-    "description": "Genera parlato IA espressivo con emozioni in oltre 24 lingue. Prova gratis la sintesi vocale con clonazione vocale e sintesi del parlato naturale. Inizia con crediti gratuiti – nessuna carta richiesta.",
+    "defaultTitle": "SexyVoice.ai – Sintesi vocale IA gratuita & chiamate in tempo reale",
+    "description": "Genera parlato IA espressivo con emozioni in oltre 24 lingue o parla in tempo reale con personaggi IA. Sintesi vocale gratuita, clonazione vocale e chiamate vocali dal vivo. Inizia con crediti gratuiti – nessuna carta richiesta.",
     "skipToMainContent": "Vai al contenuto principale",
     "descriptionLogin": "Accedi a SexyVoice.ai per accedere ai tuoi progetti vocali AI, gestire i crediti e generare parlato espressivo in più lingue con clonazione vocale avanzata.",
     "descriptionSignup": "Unisciti a SexyVoice.ai gratis - Ottieni 10.000 crediti per creare voci AI realistiche con emozioni. Sintesi vocale avanzata e clonazione vocale in 24 lingue.",

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -856,7 +856,7 @@
     "description": "Monitora l'utilizzo dell'API e le richieste nel tempo."
   },
   "pages": {
-    "defaultTitle": "SexyVoice.ai – Sintesi vocale IA gratuita & chiamate in tempo reale",
+    "defaultTitle": "SexyVoice.ai – Sintesi vocale IA gratuita & chiamate vocali in tempo reale",
     "description": "Genera parlato IA espressivo con emozioni in oltre 24 lingue o parla in tempo reale con personaggi IA. Sintesi vocale gratuita, clonazione vocale e chiamate vocali dal vivo. Inizia con crediti gratuiti – nessuna carta richiesta.",
     "skipToMainContent": "Vai al contenuto principale",
     "descriptionLogin": "Accedi a SexyVoice.ai per accedere ai tuoi progetti vocali AI, gestire i crediti e generare parlato espressivo in più lingue con clonazione vocale avanzata.",


### PR DESCRIPTION
Update the default HTML title and meta description in all six locales
(en, es, de, da, it, fr) so the real-time AI voice call feature is
surfaced alongside text-to-speech and voice cloning. Also update the
hardcoded fallback title used for unsupported locales.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015VE4LF4SawpViRbMuoenhz