### PR TITLE
Keep auth redirects out of Server Actions

### DIFF
--- a/apps/web/app/[lang]/(auth)/protected/update-password/page.tsx
+++ b/apps/web/app/[lang]/(auth)/protected/update-password/page.tsx
@@ -1,7 +1,9 @@
+import { redirect } from 'next/navigation';
 import { getTranslations } from 'next-intl/server';
 
 import { Header } from '@/components/header';
 import type { Locale } from '@/lib/i18n/i18n-config';
+import { createClient } from '@/lib/supabase/server';
 import type { Message } from '../../reset-password/reset-password-form';
 import { UpdatePasswordForm } from './update-password-form';
 
@@ -13,6 +15,15 @@ export default async function UpdatePasswordPage(props: {
     props.params,
     props.searchParams,
   ]);
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect(`/${lang}`);
+  }
+
   const t = await getTranslations({
     locale: lang,
     namespace: 'auth.updatePassword',

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -145,11 +145,15 @@ export async function proxy(request: NextRequest) {
 
 export const config = {
   matcher: [
-    '/((?!api/|\\.well-known/|markdown-internal/|_next/static|_next/image|seguimiento|monitoring|favicon\\.ico|robots\\.txt|manifest\\.json|[a-z]{2}/tools/|.*\\.(?:svg|png|jpg|jpeg|gif|ico|webp|avif|mp3|xml)$).*)',
+    {
+      missing: [
+        { key: 'next-action', type: 'header' },
+        { key: 'next-router-prefetch', type: 'header' },
+        { key: 'purpose', type: 'header', value: 'prefetch' },
+      ],
+      source:
+        '/((?!api/|\\.well-known/|markdown-internal/|_next/static|_next/image|seguimiento|monitoring|favicon\\.ico|robots\\.txt|manifest\\.json|[a-z]{2}/tools/|.*\\.(?:svg|png|jpg|jpeg|gif|ico|webp|avif|mp3|xml)$).*)',
+    },
     // Note: api/ is excluded above so next-intl never locale-redirects fetch calls
-  ],
-  missing: [
-    { key: 'next-router-prefetch', type: 'header' },
-    { key: 'purpose', type: 'header', value: 'prefetch' },
   ],
 };

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -149,9 +149,9 @@ export const config = {
       // This header is client-controlled. Protected routes and Server Actions
       // must enforce their own authorization instead of relying on the Proxy.
       missing: [{ key: 'next-action', type: 'header' }],
+      // Exclude API routes so next-intl never locale-redirects fetch calls.
       source:
         '/((?!api/|\\.well-known/|markdown-internal/|_next/static|_next/image|seguimiento|monitoring|favicon\\.ico|robots\\.txt|manifest\\.json|[a-z]{2}/tools/|.*\\.(?:svg|png|jpg|jpeg|gif|ico|webp|avif|mp3|xml)$).*)',
     },
-    // Note: api/ is excluded above so next-intl never locale-redirects fetch calls
   ],
 };

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -146,11 +146,7 @@ export async function proxy(request: NextRequest) {
 export const config = {
   matcher: [
     {
-      missing: [
-        { key: 'next-action', type: 'header' },
-        { key: 'next-router-prefetch', type: 'header' },
-        { key: 'purpose', type: 'header', value: 'prefetch' },
-      ],
+      missing: [{ key: 'next-action', type: 'header' }],
       source:
         '/((?!api/|\\.well-known/|markdown-internal/|_next/static|_next/image|seguimiento|monitoring|favicon\\.ico|robots\\.txt|manifest\\.json|[a-z]{2}/tools/|.*\\.(?:svg|png|jpg|jpeg|gif|ico|webp|avif|mp3|xml)$).*)',
     },

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -146,6 +146,8 @@ export async function proxy(request: NextRequest) {
 export const config = {
   matcher: [
     {
+      // This header is client-controlled. Protected routes and Server Actions
+      // must enforce their own authorization instead of relying on the Proxy.
       missing: [{ key: 'next-action', type: 'header' }],
       source:
         '/((?!api/|\\.well-known/|markdown-internal/|_next/static|_next/image|seguimiento|monitoring|favicon\\.ico|robots\\.txt|manifest\\.json|[a-z]{2}/tools/|.*\\.(?:svg|png|jpg|jpeg|gif|ico|webp|avif|mp3|xml)$).*)',

--- a/apps/web/tests/components/audio-generator.test.tsx
+++ b/apps/web/tests/components/audio-generator.test.tsx
@@ -514,13 +514,16 @@ describe('AudioGenerator', () => {
 
     const fetchSpy = vi.spyOn(globalThis, 'fetch');
 
-    for (const _character of prompt) {
-      await user.keyboard('{Backspace}');
-    }
+    try {
+      for (const _character of prompt) {
+        await user.keyboard('{Backspace}');
+      }
 
-    expect(textarea).toHaveValue('');
-    expect(fetchSpy).not.toHaveBeenCalled();
-    fetchSpy.mockRestore();
+      expect(textarea).toHaveValue('');
+      expect(fetchSpy).not.toHaveBeenCalled();
+    } finally {
+      fetchSpy.mockRestore();
+    }
   });
 
   it('enables split mode for paid Replicate users and shows segment previews', async () => {

--- a/apps/web/tests/components/audio-generator.test.tsx
+++ b/apps/web/tests/components/audio-generator.test.tsx
@@ -500,6 +500,29 @@ describe('AudioGenerator', () => {
     ).not.toBeInTheDocument();
   });
 
+  it('keeps rapid native-textarea deletion local', async () => {
+    const user = userEvent.setup();
+
+    renderAudioGenerator();
+
+    const textarea = await screen.findByPlaceholderText(
+      baseDict.textAreaPlaceholder,
+    );
+    const prompt = 'Delete this quickly';
+
+    await user.type(textarea, prompt);
+
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+
+    for (const _character of prompt) {
+      await user.keyboard('{Backspace}');
+    }
+
+    expect(textarea).toHaveValue('');
+    expect(fetchSpy).not.toHaveBeenCalled();
+    fetchSpy.mockRestore();
+  });
+
   it('enables split mode for paid Replicate users and shows segment previews', async () => {
     const user = userEvent.setup();
     const longText = `${'A'.repeat(300)}. ${'B'.repeat(300)}.`;

--- a/apps/web/tests/components/grok-tts-editor.test.tsx
+++ b/apps/web/tests/components/grok-tts-editor.test.tsx
@@ -191,6 +191,32 @@ describe('GrokTTSEditor', () => {
     expect(screen.getByText('17 / 500')).toBeInTheDocument();
   });
 
+  it('keeps rapid Tiptap deletion local', async () => {
+    const onChange = vi.fn();
+    const prompt = 'Delete this quickly';
+
+    renderEditor({ onChange, value: prompt });
+
+    const editor = await findEditor();
+    const paragraph = editor.querySelector('p');
+
+    if (!paragraph) {
+      throw new Error('Expected editor to contain a paragraph');
+    }
+
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+
+    for (let remaining = prompt.length - 1; remaining >= 0; remaining--) {
+      paragraph.textContent = prompt.slice(0, remaining);
+      fireEvent.input(editor, { inputType: 'deleteContentBackward' });
+    }
+
+    await waitFor(() => expect(onChange).toHaveBeenLastCalledWith(''));
+    expect(editor).toHaveTextContent('');
+    expect(fetchSpy).not.toHaveBeenCalled();
+    fetchSpy.mockRestore();
+  });
+
   it('opens the effects popover and shows available effect actions', async () => {
     const user = userEvent.setup();
     const onChange = vi.fn();

--- a/apps/web/tests/components/grok-tts-editor.test.tsx
+++ b/apps/web/tests/components/grok-tts-editor.test.tsx
@@ -206,15 +206,18 @@ describe('GrokTTSEditor', () => {
 
     const fetchSpy = vi.spyOn(globalThis, 'fetch');
 
-    for (let remaining = prompt.length - 1; remaining >= 0; remaining--) {
-      paragraph.textContent = prompt.slice(0, remaining);
-      fireEvent.input(editor, { inputType: 'deleteContentBackward' });
-    }
+    try {
+      for (let remaining = prompt.length - 1; remaining >= 0; remaining--) {
+        paragraph.textContent = prompt.slice(0, remaining);
+        fireEvent.input(editor, { inputType: 'deleteContentBackward' });
+      }
 
-    await waitFor(() => expect(onChange).toHaveBeenLastCalledWith(''));
-    expect(editor).toHaveTextContent('');
-    expect(fetchSpy).not.toHaveBeenCalled();
-    fetchSpy.mockRestore();
+      await waitFor(() => expect(onChange).toHaveBeenLastCalledWith(''));
+      expect(editor).toHaveTextContent('');
+      expect(fetchSpy).not.toHaveBeenCalled();
+    } finally {
+      fetchSpy.mockRestore();
+    }
   });
 
   it('opens the effects popover and shows available effect actions', async () => {

--- a/apps/web/tests/proxy.test.ts
+++ b/apps/web/tests/proxy.test.ts
@@ -32,4 +32,14 @@ describe('proxy matcher', () => {
       }),
     ).toBe(true);
   });
+
+  it('still matches router prefetch requests', () => {
+    expect(
+      unstable_doesMiddlewareMatch({
+        config,
+        headers: { 'next-router-prefetch': '1' },
+        url: dashboardUrl,
+      }),
+    ).toBe(true);
+  });
 });

--- a/apps/web/tests/proxy.test.ts
+++ b/apps/web/tests/proxy.test.ts
@@ -32,14 +32,4 @@ describe('proxy matcher', () => {
       }),
     ).toBe(true);
   });
-
-  it('continues to skip router prefetch requests', () => {
-    expect(
-      unstable_doesMiddlewareMatch({
-        config,
-        headers: { 'next-router-prefetch': '1' },
-        url: dashboardUrl,
-      }),
-    ).toBe(false);
-  });
 });

--- a/apps/web/tests/proxy.test.ts
+++ b/apps/web/tests/proxy.test.ts
@@ -1,0 +1,45 @@
+import { unstable_doesMiddlewareMatch } from 'next/experimental/testing/server';
+import { describe, expect, it, vi } from 'vitest';
+
+import { config } from '@/proxy';
+
+vi.mock('next-intl/middleware', () => ({
+  default: () => () => undefined,
+}));
+
+vi.mock('@/lib/supabase/middleware', () => ({
+  updateSession: vi.fn(),
+}));
+
+describe('proxy matcher', () => {
+  const dashboardUrl = 'https://sexyvoice.ai/en/dashboard/generate';
+
+  it('skips Server Action requests', () => {
+    expect(
+      unstable_doesMiddlewareMatch({
+        config,
+        headers: { 'next-action': 'action-id' },
+        url: dashboardUrl,
+      }),
+    ).toBe(false);
+  });
+
+  it('still matches normal dashboard navigation', () => {
+    expect(
+      unstable_doesMiddlewareMatch({
+        config,
+        url: dashboardUrl,
+      }),
+    ).toBe(true);
+  });
+
+  it('continues to skip router prefetch requests', () => {
+    expect(
+      unstable_doesMiddlewareMatch({
+        config,
+        headers: { 'next-router-prefetch': '1' },
+        url: dashboardUrl,
+      }),
+    ).toBe(false);
+  });
+});

--- a/apps/web/tests/update-password-page.test.ts
+++ b/apps/web/tests/update-password-page.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import UpdatePasswordPage from '@/app/[lang]/(auth)/protected/update-password/page';
+import { createClient } from '@/lib/supabase/server';
+
+const navigationMocks = vi.hoisted(() => ({
+  redirect: vi.fn((url: string) => {
+    throw new Error(`NEXT_REDIRECT:${url}`);
+  }),
+}));
+
+vi.mock('next/navigation', () => ({
+  redirect: navigationMocks.redirect,
+}));
+
+vi.mock('next-intl/server', () => ({
+  getTranslations: vi.fn(async () => vi.fn((key: string) => key)),
+}));
+
+vi.mock('@/components/header', () => ({
+  Header: vi.fn(() => null),
+}));
+
+vi.mock(
+  '@/app/[lang]/(auth)/protected/update-password/update-password-form',
+  () => ({
+    UpdatePasswordForm: vi.fn(() => null),
+  }),
+);
+
+describe('UpdatePasswordPage auth guard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('redirects callers without a Supabase session', async () => {
+    vi.mocked(createClient).mockResolvedValue({
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: null },
+          error: null,
+        }),
+      },
+    } as never);
+
+    await expect(
+      UpdatePasswordPage({
+        params: Promise.resolve({ lang: 'en' }),
+        searchParams: Promise.resolve({ message: '' }),
+      }),
+    ).rejects.toThrow('NEXT_REDIRECT:/en');
+
+    expect(navigationMocks.redirect).toHaveBeenCalledWith('/en');
+  });
+});

--- a/apps/web/tests/update-password-page.test.ts
+++ b/apps/web/tests/update-password-page.test.ts
@@ -52,4 +52,24 @@ describe('UpdatePasswordPage auth guard', () => {
 
     expect(navigationMocks.redirect).toHaveBeenCalledWith('/en');
   });
+
+  it('renders for a caller with a Supabase session', async () => {
+    vi.mocked(createClient).mockResolvedValue({
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: { id: 'user-1' } },
+          error: null,
+        }),
+      },
+    } as never);
+
+    await expect(
+      UpdatePasswordPage({
+        params: Promise.resolve({ lang: 'en' }),
+        searchParams: Promise.resolve({ message: '' }),
+      }),
+    ).resolves.toBeDefined();
+
+    expect(navigationMocks.redirect).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
Sentry group SEXYVOICE-AI-C0 records Server Action POSTs receiving a normal HTML response, which the Next client rejects as “An unexpected response was received from the server.” The Generate replay showed rapid deletion, but both the native textarea and Grok Tiptap editor only update local text state during deletion.

The Proxy matcher now skips only requests carrying the `next-action` header, leaving authorization to each Server Action. Normal navigation and router prefetches still pass through the auth redirect. The protected password-update page also verifies its Supabase session directly. Turbopack remains unchanged.

Regression coverage exercises rapid deletion through both editor implementations, pins the Proxy matcher behavior, and verifies both rejected and authorized access to the password-update page.

Tests:
- `pnpm fixall`
- `pnpm type-check`
- `pnpm test` (65 files, 776 passed, 19 skipped)
- GitHub unit, Playwright E2E, CodeQL, Semgrep, Socket, GitGuardian, Vercel, Pullfrog, and Argos checks pass

Sentry: https://sexyvoiceai.sentry.io/issues/139882459/