### PR TITLE
Add safe R2 audio maintenance tools

### DIFF
--- a/.agents/notes/implemented/operations/2026-08-22-r2-orphan-audio-cleanup.md
+++ b/.agents/notes/implemented/operations/2026-08-22-r2-orphan-audio-cleanup.md
@@ -1,0 +1,38 @@
+# R2 orphan audio cleanup
+
+## State
+
+The cleanup command and shared script helpers are implemented. The approved plan is
+`docs/plans/2026-08-22-r2-orphan-audio-cleanup.md`.
+
+## Decisions
+
+- Inventory and action runs stay separate. An action always consumes a manifest.
+- Each allowed location records a mutually exclusive funnel: younger than the cutoff, old and database-referenced, or an orphan candidate. Zero-object locations remain visible.
+- R2 has no aggregate bucket-size response. Inventory lists all object metadata once per configured bucket and sums object count and bytes. Objects outside the cleanup prefixes contribute only to bucket totals.
+- Candidate checks use one set of live `audio_files.storage_key` values across both R2 buckets.
+- The command scans only the three approved bucket and prefix pairs.
+- Normal deletion requires a verified local file. `--force` skips only that backup check.
+- Existing local files are never overwritten. Finalization uses an atomic no-clobber hard link, with exclusive copy as a fallback for filesystems without hard links. POSIX `rename` can replace an existing destination.
+- Objects with opaque or multipart ETags may be downloaded, but they remain ineligible for normal deletion because the local copy cannot be verified against an MD5 checksum.
+- Downloads send `If-Match` and stop writing if R2 exceeds the manifest size. This keeps changed objects from consuming the rest of the drive.
+- Deletion handles one object at a time. It verifies the local checksum first, then performs an exact database key lookup and a fresh `HeadObject` immediately before the delete request.
+- R2 documents conditional reads but not conditional deletes. A replacement or new database reference can still appear in the short gap between the final checks and deletion. Removing that race requires a server-side conditional delete or a coordinated retention state in the database.
+- Shared script modules stay narrow: environment loading, Supabase client creation, and R2 cleanup logic.
+
+## Findings
+
+- `scripts/.gitignore` already ignores `*.json`, so inventory manifests and action reports under `scripts/backups/` need no new ignore rule.
+- `scripts/tsconfig.json` type-checks the TypeScript maintenance commands and their shared modules.
+- `reset-freeloader-credits.mts` is the only migrated command that enables Supabase session persistence.
+
+## Verification
+
+- `pnpm --filter @sexyvoice/scripts test` passes 23 tests.
+- `pnpm --filter @sexyvoice/scripts type-check` passes.
+- The focused Biome check for the cleanup command, helpers, and tests passes.
+- `pnpm fixall` passes with five existing Sentry namespace-import warnings.
+- `pnpm type-check` passes for all packages.
+- The normal `pnpm test` run passes all 63 web test files and all script tests, then waits in Vitest watch mode until the command timeout.
+- `CI=1 pnpm test` exits but fails the 35 Stripe webhook tests because the shared Redis connection closes. The Stripe webhook file passes all 35 tests when run alone.
+- Read-only inventory completed against both configured buckets. `sv-audio-files` contained 29,290 objects and 34,825,931,807 bytes. `sv-api-speech-audio-files` contained 5,132 objects and 2,226,824,512 bytes. The free prefixes contained only objects younger than 45 days, and the manifest contained zero orphan candidates.

--- a/.agents/notes/implemented/operations/2026-08-22-r2-orphan-audio-cleanup.md
+++ b/.agents/notes/implemented/operations/2026-08-22-r2-orphan-audio-cleanup.md
@@ -16,6 +16,7 @@ The cleanup command and shared script helpers are implemented. The approved plan
 - Existing local files are never overwritten. Finalization uses an atomic no-clobber hard link, with exclusive copy as a fallback for filesystems without hard links. POSIX `rename` can replace an existing destination.
 - Objects with opaque or multipart ETags may be downloaded, but they remain ineligible for normal deletion because the local copy cannot be verified against an MD5 checksum.
 - Downloads send `If-Match` and stop writing if R2 exceeds the manifest size. This keeps changed objects from consuming the rest of the drive.
+- Download actions require an existing writable and traversable root before reading the manifest or touching R2. A missing removable volume cannot be replaced by a directory on the internal disk.
 - Deletion handles one object at a time. It verifies the local checksum first, then performs an exact database key lookup and a fresh `HeadObject` immediately before the delete request.
 - R2 documents conditional reads but not conditional deletes. A replacement or new database reference can still appear in the short gap between the final checks and deletion. Removing that race requires a server-side conditional delete or a coordinated retention state in the database.
 - Shared script modules stay narrow: environment loading, Supabase client creation, and R2 cleanup logic.
@@ -28,7 +29,7 @@ The cleanup command and shared script helpers are implemented. The approved plan
 
 ## Verification
 
-- `pnpm --filter @sexyvoice/scripts test` passes 23 tests.
+- `pnpm --filter @sexyvoice/scripts test` passes 51 tests.
 - `pnpm --filter @sexyvoice/scripts type-check` passes.
 - The focused Biome check for the cleanup command, helpers, and tests passes.
 - `pnpm fixall` passes with five existing Sentry namespace-import warnings.

--- a/.agents/notes/implemented/operations/2026-08-23-r2-audio-backup.md
+++ b/.agents/notes/implemented/operations/2026-08-23-r2-audio-backup.md
@@ -43,8 +43,8 @@ Implement the approved design in `docs/plans/2026-08-23-r2-audio-backup-design.m
 - Shared extraction: cleanup tests pass, scripts type-check passes, and focused Biome checks pass.
 - Backup implementation: 39 offline tests pass, scripts type-check passes, and focused Biome checks pass.
 - Repository gates: `pnpm fixall` passes with five existing Sentry namespace-import warnings. `pnpm type-check` passes.
-- Full tests: all 39 scripts tests and 62 of 63 web test files pass. The 35 Stripe webhook tests fail on the existing closed Redis connection in `tests/utils/redis-test-utils.ts`; the focused file fails for the same reason.
+- Full tests: all 45 scripts tests and 62 of 63 web test files pass. The 35 Stripe webhook tests fail on the existing closed Redis connection in `tests/utils/redis-test-utils.ts`; the focused file fails for the same reason.
 - Production dry run: `sv-api-speech-audio-files/generated-audio/` lists 5,132 objects and 2.1 GiB, selects all objects without downloading, and writes the ignored report.
-- Review fix: 43 scripts tests pass, scripts type-check passes, focused Biome checks pass, and `Redis.fromEnv()` accepts the project's `KV_REST_API_URL` and `KV_REST_API_TOKEN` variables.
+- Review fixes: 45 scripts tests pass, repository type-check passes, focused Biome checks pass, and `Redis.fromEnv()` accepts the project's `KV_REST_API_URL` and `KV_REST_API_TOKEN` variables.
 
 Do not run a full backup.

--- a/.agents/notes/implemented/operations/2026-08-23-r2-audio-backup.md
+++ b/.agents/notes/implemented/operations/2026-08-23-r2-audio-backup.md
@@ -38,6 +38,7 @@ Implement the approved design in `docs/plans/2026-08-23-r2-audio-backup-design.m
 - Each destructive candidate has an outer error boundary. Unexpected per-object errors become `deletion-failure`, later candidates continue, and the final report retains earlier confirmed deletions.
 - Cleanup deletion stays sequential by design. Batching would widen the gap between each final database check and its R2 deletion.
 - Effect result order is load-bearing because report entries map outcomes back to selected objects by index; tests force out-of-order completion and assert input-order results.
+- Checksum tests include equal-size wrong-content files because this MD5 branch controls cleanup deletion eligibility.
 
 ## Verification record
 

--- a/.agents/notes/implemented/operations/2026-08-23-r2-audio-backup.md
+++ b/.agents/notes/implemented/operations/2026-08-23-r2-audio-backup.md
@@ -33,5 +33,8 @@ Implement the approved design in `docs/plans/2026-08-23-r2-audio-backup-design.m
 
 - Shared extraction: cleanup tests pass, scripts type-check passes, and focused Biome checks pass.
 - Backup implementation: 39 offline tests pass, scripts type-check passes, and focused Biome checks pass.
+- Repository gates: `pnpm fixall` passes with five existing Sentry namespace-import warnings. `pnpm type-check` passes.
+- Full tests: all 39 scripts tests and 62 of 63 web test files pass. The 35 Stripe webhook tests fail on the existing closed Redis connection in `tests/utils/redis-test-utils.ts`; the focused file fails for the same reason.
+- Production dry run: `sv-api-speech-audio-files/generated-audio/` lists 5,132 objects and 2.1 GiB, selects all objects without downloading, and writes the ignored report.
 
 Do not run a full backup.

--- a/.agents/notes/implemented/operations/2026-08-23-r2-audio-backup.md
+++ b/.agents/notes/implemented/operations/2026-08-23-r2-audio-backup.md
@@ -32,6 +32,7 @@ Implement the approved design in `docs/plans/2026-08-23-r2-audio-backup-design.m
 - The cleanup entry point is import-safe. `runAction()` accepts injected R2, database, cache, clock, logging, and report dependencies so tests cover destructive ordering and backup eligibility.
 - Soft-deleted `audio_files` rows remain references. Cleanup must not add an active-status filter because user-deleted history still protects its R2 key.
 - Database inventory orders by `storage_key` and then `id` so duplicate content-derived keys cannot make offset pages ambiguous.
+- `runBackup()` treats every defined transfer cap as a cap, so a direct caller cannot turn zero into an uncapped run.
 
 ## Verification record
 

--- a/.agents/notes/implemented/operations/2026-08-23-r2-audio-backup.md
+++ b/.agents/notes/implemented/operations/2026-08-23-r2-audio-backup.md
@@ -28,6 +28,7 @@ Implement the approved design in `docs/plans/2026-08-23-r2-audio-backup-design.m
 - `effective-progress@0.12.0` does not support `mode: 'result'` on `Progress.forEach`. It supports that mode on `Progress.all`. Use `Progress.all` for TTY runs and `Effect.all` for non-TTY runs so all downloads finish and the progress bar reports success and failure counts accurately.
 - The approved spec was moved by the user from `docs/superpowers/specs/` to `docs/plans/`; preserve the move.
 - Effect's optional `msgpackr-extract` dependency does not need native acceleration for this command, so its install script is disabled in `allowBuilds`.
+- Main-bucket cleanup deletion evicts the object's Redis URL cache key after R2 confirms deletion. Cache eviction failures return a nonzero result because a stale URL would break repeated generation requests.
 
 ## Verification record
 
@@ -36,5 +37,6 @@ Implement the approved design in `docs/plans/2026-08-23-r2-audio-backup-design.m
 - Repository gates: `pnpm fixall` passes with five existing Sentry namespace-import warnings. `pnpm type-check` passes.
 - Full tests: all 39 scripts tests and 62 of 63 web test files pass. The 35 Stripe webhook tests fail on the existing closed Redis connection in `tests/utils/redis-test-utils.ts`; the focused file fails for the same reason.
 - Production dry run: `sv-api-speech-audio-files/generated-audio/` lists 5,132 objects and 2.1 GiB, selects all objects without downloading, and writes the ignored report.
+- Review fix: 41 scripts tests pass, scripts type-check passes, focused Biome checks pass, and `Redis.fromEnv()` accepts the project's `KV_REST_API_URL` and `KV_REST_API_TOKEN` variables.
 
 Do not run a full backup.

--- a/.agents/notes/implemented/operations/2026-08-23-r2-audio-backup.md
+++ b/.agents/notes/implemented/operations/2026-08-23-r2-audio-backup.md
@@ -29,6 +29,7 @@ Implement the approved design in `docs/plans/2026-08-23-r2-audio-backup-design.m
 - The approved spec was moved by the user from `docs/superpowers/specs/` to `docs/plans/`; preserve the move.
 - Effect's optional `msgpackr-extract` dependency does not need native acceleration for this command, so its install script is disabled in `allowBuilds`.
 - Main-bucket cleanup deletion evicts the object's Redis URL cache key after R2 confirms deletion. Cache eviction failures return a nonzero result because a stale URL would break repeated generation requests.
+- The cleanup entry point is import-safe. `runAction()` accepts injected R2, database, cache, clock, logging, and report dependencies so tests cover destructive ordering and backup eligibility.
 
 ## Verification record
 
@@ -37,6 +38,6 @@ Implement the approved design in `docs/plans/2026-08-23-r2-audio-backup-design.m
 - Repository gates: `pnpm fixall` passes with five existing Sentry namespace-import warnings. `pnpm type-check` passes.
 - Full tests: all 39 scripts tests and 62 of 63 web test files pass. The 35 Stripe webhook tests fail on the existing closed Redis connection in `tests/utils/redis-test-utils.ts`; the focused file fails for the same reason.
 - Production dry run: `sv-api-speech-audio-files/generated-audio/` lists 5,132 objects and 2.1 GiB, selects all objects without downloading, and writes the ignored report.
-- Review fix: 41 scripts tests pass, scripts type-check passes, focused Biome checks pass, and `Redis.fromEnv()` accepts the project's `KV_REST_API_URL` and `KV_REST_API_TOKEN` variables.
+- Review fix: 43 scripts tests pass, scripts type-check passes, focused Biome checks pass, and `Redis.fromEnv()` accepts the project's `KV_REST_API_URL` and `KV_REST_API_TOKEN` variables.
 
 Do not run a full backup.

--- a/.agents/notes/implemented/operations/2026-08-23-r2-audio-backup.md
+++ b/.agents/notes/implemented/operations/2026-08-23-r2-audio-backup.md
@@ -50,6 +50,6 @@ Implement the approved design in `docs/plans/2026-08-23-r2-audio-backup-design.m
 - Repository gates: `pnpm fixall` passes with five existing Sentry namespace-import warnings. `pnpm type-check` passes.
 - Full tests: all 45 scripts tests and 62 of 63 web test files pass. The 35 Stripe webhook tests fail on the existing closed Redis connection in `tests/utils/redis-test-utils.ts`; the focused file fails for the same reason.
 - Production dry run: `sv-api-speech-audio-files/generated-audio/` lists 5,132 objects and 2.1 GiB, selects all objects without downloading, and writes the ignored report.
-- Review fixes: 50 scripts tests pass, repository type-check passes, focused Biome checks pass, and `Redis.fromEnv()` accepts the project's `KV_REST_API_URL` and `KV_REST_API_TOKEN` variables.
+- Review fixes: 51 scripts tests pass, repository type-check passes, focused Biome checks pass, and `Redis.fromEnv()` accepts the project's `KV_REST_API_URL` and `KV_REST_API_TOKEN` variables.
 
 Do not run a full backup.

--- a/.agents/notes/implemented/operations/2026-08-23-r2-audio-backup.md
+++ b/.agents/notes/implemented/operations/2026-08-23-r2-audio-backup.md
@@ -47,6 +47,6 @@ Implement the approved design in `docs/plans/2026-08-23-r2-audio-backup-design.m
 - Repository gates: `pnpm fixall` passes with five existing Sentry namespace-import warnings. `pnpm type-check` passes.
 - Full tests: all 45 scripts tests and 62 of 63 web test files pass. The 35 Stripe webhook tests fail on the existing closed Redis connection in `tests/utils/redis-test-utils.ts`; the focused file fails for the same reason.
 - Production dry run: `sv-api-speech-audio-files/generated-audio/` lists 5,132 objects and 2.1 GiB, selects all objects without downloading, and writes the ignored report.
-- Review fixes: 45 scripts tests pass, repository type-check passes, focused Biome checks pass, and `Redis.fromEnv()` accepts the project's `KV_REST_API_URL` and `KV_REST_API_TOKEN` variables.
+- Review fixes: 46 scripts tests pass, repository type-check passes, focused Biome checks pass, and `Redis.fromEnv()` accepts the project's `KV_REST_API_URL` and `KV_REST_API_TOKEN` variables.
 
 Do not run a full backup.

--- a/.agents/notes/implemented/operations/2026-08-23-r2-audio-backup.md
+++ b/.agents/notes/implemented/operations/2026-08-23-r2-audio-backup.md
@@ -36,6 +36,7 @@ Implement the approved design in `docs/plans/2026-08-23-r2-audio-backup-design.m
 - Manifest path resolution checks access without reading the document; validation performs the only full manifest read.
 - Cleanup manifests are approval artifacts, not editable candidate lists. Derived totals make any hand-edited subset invalid.
 - Each destructive candidate has an outer error boundary. Unexpected per-object errors become `deletion-failure`, later candidates continue, and the final report retains earlier confirmed deletions.
+- Cleanup deletion stays sequential by design. Batching would widen the gap between each final database check and its R2 deletion.
 
 ## Verification record
 

--- a/.agents/notes/implemented/operations/2026-08-23-r2-audio-backup.md
+++ b/.agents/notes/implemented/operations/2026-08-23-r2-audio-backup.md
@@ -35,6 +35,7 @@ Implement the approved design in `docs/plans/2026-08-23-r2-audio-backup-design.m
 - `runBackup()` treats every defined transfer cap as a cap, so a direct caller cannot turn zero into an uncapped run.
 - Manifest path resolution checks access without reading the document; validation performs the only full manifest read.
 - Cleanup manifests are approval artifacts, not editable candidate lists. Derived totals make any hand-edited subset invalid.
+- Each destructive candidate has an outer error boundary. Unexpected per-object errors become `deletion-failure`, later candidates continue, and the final report retains earlier confirmed deletions.
 
 ## Verification record
 

--- a/.agents/notes/implemented/operations/2026-08-23-r2-audio-backup.md
+++ b/.agents/notes/implemented/operations/2026-08-23-r2-audio-backup.md
@@ -39,6 +39,7 @@ Implement the approved design in `docs/plans/2026-08-23-r2-audio-backup-design.m
 - Cleanup deletion stays sequential by design. Batching would widen the gap between each final database check and its R2 deletion.
 - Effect result order is load-bearing because report entries map outcomes back to selected objects by index; tests force out-of-order completion and assert input-order results.
 - Checksum tests include equal-size wrong-content files because this MD5 branch controls cleanup deletion eligibility.
+- `runAction()` validates its options at the exported orchestration boundary so direct callers cannot bypass the CLI's destructive gates.
 
 ## Verification record
 
@@ -47,6 +48,6 @@ Implement the approved design in `docs/plans/2026-08-23-r2-audio-backup-design.m
 - Repository gates: `pnpm fixall` passes with five existing Sentry namespace-import warnings. `pnpm type-check` passes.
 - Full tests: all 45 scripts tests and 62 of 63 web test files pass. The 35 Stripe webhook tests fail on the existing closed Redis connection in `tests/utils/redis-test-utils.ts`; the focused file fails for the same reason.
 - Production dry run: `sv-api-speech-audio-files/generated-audio/` lists 5,132 objects and 2.1 GiB, selects all objects without downloading, and writes the ignored report.
-- Review fixes: 46 scripts tests pass, repository type-check passes, focused Biome checks pass, and `Redis.fromEnv()` accepts the project's `KV_REST_API_URL` and `KV_REST_API_TOKEN` variables.
+- Review fixes: 47 scripts tests pass, repository type-check passes, focused Biome checks pass, and `Redis.fromEnv()` accepts the project's `KV_REST_API_URL` and `KV_REST_API_TOKEN` variables.
 
 Do not run a full backup.

--- a/.agents/notes/implemented/operations/2026-08-23-r2-audio-backup.md
+++ b/.agents/notes/implemented/operations/2026-08-23-r2-audio-backup.md
@@ -30,6 +30,7 @@ Implement the approved design in `docs/plans/2026-08-23-r2-audio-backup-design.m
 - Effect's optional `msgpackr-extract` dependency does not need native acceleration for this command, so its install script is disabled in `allowBuilds`.
 - Main-bucket cleanup deletion evicts the object's Redis URL cache key after R2 confirms deletion. Cache eviction failures return a nonzero result because a stale URL would break repeated generation requests.
 - The cleanup entry point is import-safe. `runAction()` accepts injected R2, database, cache, clock, logging, and report dependencies so tests cover destructive ordering and backup eligibility.
+- Soft-deleted `audio_files` rows remain references. Cleanup must not add an active-status filter because user-deleted history still protects its R2 key.
 
 ## Verification record
 

--- a/.agents/notes/implemented/operations/2026-08-23-r2-audio-backup.md
+++ b/.agents/notes/implemented/operations/2026-08-23-r2-audio-backup.md
@@ -37,6 +37,7 @@ Implement the approved design in `docs/plans/2026-08-23-r2-audio-backup-design.m
 - Cleanup manifests are approval artifacts, not editable candidate lists. Derived totals make any hand-edited subset invalid.
 - Each destructive candidate has an outer error boundary. Unexpected per-object errors become `deletion-failure`, later candidates continue, and the final report retains earlier confirmed deletions.
 - Cleanup deletion stays sequential by design. Batching would widen the gap between each final database check and its R2 deletion.
+- Effect result order is load-bearing because report entries map outcomes back to selected objects by index; tests force out-of-order completion and assert input-order results.
 
 ## Verification record
 

--- a/.agents/notes/implemented/operations/2026-08-23-r2-audio-backup.md
+++ b/.agents/notes/implemented/operations/2026-08-23-r2-audio-backup.md
@@ -31,6 +31,7 @@ Implement the approved design in `docs/plans/2026-08-23-r2-audio-backup-design.m
 - Main-bucket cleanup deletion evicts the object's Redis URL cache key after R2 confirms deletion. Cache eviction failures return a nonzero result because a stale URL would break repeated generation requests.
 - The cleanup entry point is import-safe. `runAction()` accepts injected R2, database, cache, clock, logging, and report dependencies so tests cover destructive ordering and backup eligibility.
 - Soft-deleted `audio_files` rows remain references. Cleanup must not add an active-status filter because user-deleted history still protects its R2 key.
+- Database inventory orders by `storage_key` and then `id` so duplicate content-derived keys cannot make offset pages ambiguous.
 
 ## Verification record
 

--- a/.agents/notes/implemented/operations/2026-08-23-r2-audio-backup.md
+++ b/.agents/notes/implemented/operations/2026-08-23-r2-audio-backup.md
@@ -40,7 +40,7 @@ Implement the approved design in `docs/plans/2026-08-23-r2-audio-backup-design.m
 - Effect result order is load-bearing because report entries map outcomes back to selected objects by index; tests force out-of-order completion and assert input-order results.
 - Checksum tests include equal-size wrong-content files because this MD5 branch controls cleanup deletion eligibility.
 - `runAction()` validates its options at the exported orchestration boundary so direct callers cannot bypass the CLI's destructive gates.
-- Real backup runs create and check the download directory before listing R2. Dry runs remain non-mutating.
+- Real backup runs require and check an existing download directory before listing R2. This prevents an unmounted removable volume from being replaced by a directory on the internal disk. Dry runs remain non-mutating.
 - Run the interactive backup with `NODE_ENV=production`. Ink 7.1.1 otherwise uses React's development reconciler, which retains performance measurements on every render and can exhaust the V8 heap during long transfers.
 
 ## Verification record

--- a/.agents/notes/implemented/operations/2026-08-23-r2-audio-backup.md
+++ b/.agents/notes/implemented/operations/2026-08-23-r2-audio-backup.md
@@ -40,6 +40,8 @@ Implement the approved design in `docs/plans/2026-08-23-r2-audio-backup-design.m
 - Effect result order is load-bearing because report entries map outcomes back to selected objects by index; tests force out-of-order completion and assert input-order results.
 - Checksum tests include equal-size wrong-content files because this MD5 branch controls cleanup deletion eligibility.
 - `runAction()` validates its options at the exported orchestration boundary so direct callers cannot bypass the CLI's destructive gates.
+- Real backup runs create and check the download directory before listing R2. Dry runs remain non-mutating.
+- Run the interactive backup with `NODE_ENV=production`. Ink 7.1.1 otherwise uses React's development reconciler, which retains performance measurements on every render and can exhaust the V8 heap during long transfers.
 
 ## Verification record
 
@@ -48,6 +50,6 @@ Implement the approved design in `docs/plans/2026-08-23-r2-audio-backup-design.m
 - Repository gates: `pnpm fixall` passes with five existing Sentry namespace-import warnings. `pnpm type-check` passes.
 - Full tests: all 45 scripts tests and 62 of 63 web test files pass. The 35 Stripe webhook tests fail on the existing closed Redis connection in `tests/utils/redis-test-utils.ts`; the focused file fails for the same reason.
 - Production dry run: `sv-api-speech-audio-files/generated-audio/` lists 5,132 objects and 2.1 GiB, selects all objects without downloading, and writes the ignored report.
-- Review fixes: 47 scripts tests pass, repository type-check passes, focused Biome checks pass, and `Redis.fromEnv()` accepts the project's `KV_REST_API_URL` and `KV_REST_API_TOKEN` variables.
+- Review fixes: 50 scripts tests pass, repository type-check passes, focused Biome checks pass, and `Redis.fromEnv()` accepts the project's `KV_REST_API_URL` and `KV_REST_API_TOKEN` variables.
 
 Do not run a full backup.

--- a/.agents/notes/implemented/operations/2026-08-23-r2-audio-backup.md
+++ b/.agents/notes/implemented/operations/2026-08-23-r2-audio-backup.md
@@ -34,6 +34,7 @@ Implement the approved design in `docs/plans/2026-08-23-r2-audio-backup-design.m
 - Database inventory orders by `storage_key` and then `id` so duplicate content-derived keys cannot make offset pages ambiguous.
 - `runBackup()` treats every defined transfer cap as a cap, so a direct caller cannot turn zero into an uncapped run.
 - Manifest path resolution checks access without reading the document; validation performs the only full manifest read.
+- Cleanup manifests are approval artifacts, not editable candidate lists. Derived totals make any hand-edited subset invalid.
 
 ## Verification record
 

--- a/.agents/notes/implemented/operations/2026-08-23-r2-audio-backup.md
+++ b/.agents/notes/implemented/operations/2026-08-23-r2-audio-backup.md
@@ -33,6 +33,7 @@ Implement the approved design in `docs/plans/2026-08-23-r2-audio-backup-design.m
 - Soft-deleted `audio_files` rows remain references. Cleanup must not add an active-status filter because user-deleted history still protects its R2 key.
 - Database inventory orders by `storage_key` and then `id` so duplicate content-derived keys cannot make offset pages ambiguous.
 - `runBackup()` treats every defined transfer cap as a cap, so a direct caller cannot turn zero into an uncapped run.
+- Manifest path resolution checks access without reading the document; validation performs the only full manifest read.
 
 ## Verification record
 

--- a/.agents/notes/proposed/operations/2026-08-23-r2-audio-backup.md
+++ b/.agents/notes/proposed/operations/2026-08-23-r2-audio-backup.md
@@ -1,0 +1,32 @@
+# R2 audio backup implementation
+
+## Scope
+
+Implement the approved design in `docs/plans/2026-08-23-r2-audio-backup-design.md` without changing the cleanup command's deletion policy.
+
+## Invariants
+
+- Backup never reads Supabase or deletes remote or local data.
+- Existing local paths are verified but never replaced.
+- Cleanup keeps its bucket/prefix allowlist, 45-day cutoff, manifest validation, database checks, and fresh pre-delete R2 check.
+- Opaque ETags count as size-verified for backup but remain insufficient to authorize cleanup deletion.
+- Shared R2 modules stay Promise-based. Effect remains in the backup command.
+
+## Implementation sequence
+
+1. Extract the AWS SDK adapter and generic transfer helpers. Keep cleanup tests green.
+2. Add source parsing, planning, downloads, reports, and offline tests for the backup command.
+3. Add `effective-progress@0.12.0` and `effect@4.0.0-rc.111`, wire the root command, and document operation.
+4. Run focused checks, repository checks, and one narrow production dry run.
+
+## Decisions and learnings
+
+- Shared metadata stores normalized ETags. The AWS adapter adds quotes for `If-Match`.
+- The adapter classifies conditional GET failures as `changed` or `missing`; other failures reject.
+- Safe path resolution must inspect existing components with `lstat`, not only reject lexical traversal.
+- `effective-progress@0.12.0` does not support `mode: 'result'` on `Progress.forEach`. It supports that mode on `Progress.all`. Use `Progress.all` for TTY runs and `Effect.all` for non-TTY runs so all downloads finish and the progress bar reports success and failure counts accurately.
+- The approved spec was moved by the user from `docs/superpowers/specs/` to `docs/plans/`; preserve the move.
+
+## Verification record
+
+Record focused and repository checks here as each work chunk lands. Do not run a full backup.

--- a/.agents/notes/proposed/operations/2026-08-23-r2-audio-backup.md
+++ b/.agents/notes/proposed/operations/2026-08-23-r2-audio-backup.md
@@ -23,12 +23,15 @@ Implement the approved design in `docs/plans/2026-08-23-r2-audio-backup-design.m
 
 - Shared metadata stores normalized ETags. The AWS adapter adds quotes for `If-Match`.
 - The adapter classifies conditional GET failures as `changed` or `missing`; other failures reject.
-- Safe path resolution must inspect existing components with `lstat`, not only reject lexical traversal.
+- Safe path resolution inspects existing components with `lstat` and rejects keys with empty or dot segments or backslashes because filesystem normalization could collapse distinct R2 keys.
+- Node does not expose an `openat`-style API for no-follow directory traversal. The command rechecks path components before writes and finalization, but it assumes no hostile process mutates the destination tree during a run.
 - `effective-progress@0.12.0` does not support `mode: 'result'` on `Progress.forEach`. It supports that mode on `Progress.all`. Use `Progress.all` for TTY runs and `Effect.all` for non-TTY runs so all downloads finish and the progress bar reports success and failure counts accurately.
 - The approved spec was moved by the user from `docs/superpowers/specs/` to `docs/plans/`; preserve the move.
+- Effect's optional `msgpackr-extract` dependency does not need native acceleration for this command, so its install script is disabled in `allowBuilds`.
 
 ## Verification record
 
 - Shared extraction: cleanup tests pass, scripts type-check passes, and focused Biome checks pass.
+- Backup implementation: 39 offline tests pass, scripts type-check passes, and focused Biome checks pass.
 
 Do not run a full backup.

--- a/.agents/notes/proposed/operations/2026-08-23-r2-audio-backup.md
+++ b/.agents/notes/proposed/operations/2026-08-23-r2-audio-backup.md
@@ -29,4 +29,6 @@ Implement the approved design in `docs/plans/2026-08-23-r2-audio-backup-design.m
 
 ## Verification record
 
-Record focused and repository checks here as each work chunk lands. Do not run a full backup.
+- Shared extraction: cleanup tests pass, scripts type-check passes, and focused Biome checks pass.
+
+Do not run a full backup.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -195,7 +195,9 @@ Routes under `apps/web/app/api/v1/*` are API-key authenticated except
 - For Gemini TTS error or credit complaints, follow
   `skills/investigate-gemini-tts-credit-report/SKILL.md`; keep the investigation
   read-only and require separate human approval for any refund.
-- Dashboard TTS may use Redis URL caching; external API speech must not.
+- Dashboard TTS may use Redis URL caching; external API speech must not. R2
+  cleanup deletion must evict the matching dashboard Redis cache key after it
+  deletes a main-bucket object.
 - Dashboard audio uses `R2_BUCKET_NAME`; external API audio uses
   `R2_SPEECH_API_BUCKET_NAME` and `R2_SPEECH_API_PUBLIC_URL`.
 - Voice generation can involve Replicate, Google Gemini TTS (models `gpro` for

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -73,7 +73,7 @@
     "@tiptap/starter-kit": "^3.22.4",
     "@tiptap/suggestion": "^3.22.4",
     "@upstash/ratelimit": "^2.0.8",
-    "@upstash/redis": "1.37.0",
+    "@upstash/redis": "catalog:",
     "@vercel/analytics": "^1.6.1",
     "@vercel/edge-config": "^1.4.3",
     "@vercel/speed-insights": "2.0.0",

--- a/docs/devops.md
+++ b/docs/devops.md
@@ -155,6 +155,7 @@ Used for:
 - caching
 - rate limiting
 - fast lookups
+- evicting dashboard audio URL cache entries after R2 cleanup deletion
 
 ### Cloudflare R2
 

--- a/docs/plans/2026-08-22-r2-orphan-audio-cleanup.md
+++ b/docs/plans/2026-08-22-r2-orphan-audio-cleanup.md
@@ -1,0 +1,314 @@
+# R2 orphan audio cleanup
+
+## Status
+
+Proposed for review. Inventory must run before deletion. A human must inspect the
+manifest before using it.
+
+## Problem
+
+The free-account retention cron deletes `public.audio_files` rows after 45 days.
+It does not delete R2 objects.
+
+The main R2 bucket expires `generated-audio-free/` and `cloned-audio-free/`
+after 30 days. The API speech bucket has no audio expiration rule. Most useful
+findings will probably come from the API bucket or from objects missed by a
+lifecycle rule.
+
+Once the cron deletes a row, its `storage_key` is gone. The script cannot prove
+why an unreferenced object exists. It will call these objects "orphan
+candidates," not confirmed cron deletions.
+
+## Candidate rules
+
+Scan only these locations:
+
+- `R2_BUCKET_NAME/generated-audio-free/`
+- `R2_BUCKET_NAME/cloned-audio-free/`
+- `R2_SPEECH_API_BUCKET_NAME/generated-audio-free/`
+
+Never scan paid prefixes, `clone-voice-input/`, or an unknown prefix.
+
+An object is a candidate when:
+
+1. it belongs to one of the bucket and prefix pairs above;
+2. R2 says it is at least 45 days old; and
+3. no `public.audio_files` row has the same `storage_key`.
+
+Fetch every current `storage_key`, including active and soft-deleted rows. Use
+one set of keys for both buckets. This may keep an object when two buckets share
+a key, which is safer than deleting the wrong object.
+
+The script reads Supabase. It never writes to it.
+
+## Command
+
+Add this root command, delegated to `@sexyvoice/scripts`:
+
+```bash
+pnpm cleanup-orphaned-r2-audio -- [options]
+```
+
+The command has two steps. Inventory creates evidence. An action run consumes
+that evidence and checks live state again.
+
+### Inventory
+
+```bash
+pnpm cleanup-orphaned-r2-audio
+```
+
+Inventory writes
+`scripts/backups/r2-orphan-candidates-<timestamp>.json`. The manifest contains:
+
+- a schema version and creation time;
+- the 45-day cutoff;
+- configured bucket names;
+- each candidate's bucket, prefix, key, size, `LastModified`, and ETag; and
+- counts and bytes grouped by bucket and prefix.
+
+The manifest contains no credentials.
+
+### Download
+
+```bash
+pnpm cleanup-orphaned-r2-audio -- \
+  --manifest scripts/backups/r2-orphan-candidates-<timestamp>.json \
+  --download \
+  --download-dir /Volumes/ExternalHD/sexyvoice-r2-bucket \
+  --max-download-size 20GB
+```
+
+`--download` requires `--manifest`, `--download-dir`, and
+`--max-download-size`. Reject `--download-dir` and `--max-download-size` when
+`--download` is absent.
+
+Accept decimal units `KB`, `MB`, `GB`, and `TB`, plus binary units `KiB`, `MiB`,
+`GiB`, and `TiB`.
+
+Sort candidates from oldest to newest. Select whole files until the download
+cap is full. If one file does not fit, defer it and continue looking for smaller
+files. Defer any single file larger than the cap.
+
+An existing verified file needs no transfer and does not count against the cap.
+Never overwrite an existing file.
+
+Keep the bucket and R2 key in the local path:
+
+```text
+<download-dir>/
+├── <R2_BUCKET_NAME>/generated-audio-free/...
+└── <R2_SPEECH_API_BUCKET_NAME>/generated-audio-free/...
+```
+
+Reject any key whose resolved path escapes its bucket directory.
+
+Stream a new download to a temporary file beside its destination. Check the
+byte count. When R2 returns a simple ETag, compare it with the local MD5. Treat
+multipart and other opaque ETags as unverifiable. Rename the temporary file
+only when the destination does not exist.
+
+For an existing file, compare its size and any usable checksum. A mismatch
+blocks deletion. A downloaded object without a usable remote checksum remains
+in the report, but normal deletion cannot remove its R2 copy.
+
+### Delete after download
+
+```bash
+pnpm cleanup-orphaned-r2-audio -- \
+  --manifest scripts/backups/r2-orphan-candidates-<timestamp>.json \
+  --download \
+  --download-dir /Volumes/ExternalHD/sexyvoice-r2-bucket \
+  --max-download-size 20GB \
+  --delete \
+  --yes
+```
+
+Normal deletion removes only selected objects with verified local copies.
+Deferred files, checksum failures, download failures, and local mismatches stay
+in R2.
+
+### Delete without download
+
+```bash
+pnpm cleanup-orphaned-r2-audio -- \
+  --manifest scripts/backups/r2-orphan-candidates-<timestamp>.json \
+  --delete \
+  --force \
+  --yes
+```
+
+`--force` skips downloading and local verification. It does not skip the
+manifest check, prefix allowlist, 45-day cutoff, database lookup, or R2 metadata
+check.
+
+If `--download` and `--force` appear together, follow the download path and
+ignore `--force`. Reject `--delete` unless either `--download` or `--force` is
+present. Every deletion requires `--yes`; destructive runs do not prompt.
+
+## Checks before an action
+
+Validate the manifest before reading or deleting an object. Then fetch current
+Supabase and R2 state.
+
+For every manifest entry:
+
+1. Match the bucket to `R2_BUCKET_NAME` or `R2_SPEECH_API_BUCKET_NAME`.
+2. Match the key to the allowed prefixes for that bucket.
+3. Skip the object if a current database row references its key.
+4. Call `HeadObject`. Treat an absent object as skipped, not failed.
+5. Confirm the object is still at least 45 days old.
+6. Confirm size, ETag, and `LastModified` still match the manifest.
+
+These checks prevent a stale manifest from deleting a replacement object.
+Delete in bounded batches and record each R2 result. Do not retry successful
+items after a partial failure.
+
+## Reports and exit codes
+
+Write an action report next to the inventory manifest. Give each object one
+final status, such as:
+
+- verified download;
+- verified existing file;
+- deferred by the size cap;
+- referenced by the database;
+- changed in R2;
+- missing from R2;
+- local mismatch;
+- unverifiable checksum;
+- deleted;
+- download failure; or
+- deletion failure.
+
+Print counts and bytes by bucket and prefix. Exit with a nonzero code after
+writing the report if a requested download or deletion failed.
+
+Never print secrets or signed R2 requests.
+
+## Shared script code
+
+The `.mts` scripts contain five copies of the Supabase admin-client factory:
+
+- `backfill-free-call.mts`
+- `batch-refund-credits.mts`
+- `compile-dispute-evidence.mts`
+- `refund-credits.mts`
+- `reset-freeloader-credits.mts`
+
+They also repeat the same dotenv setup. Add two narrow modules:
+
+- `scripts/lib/env.mts` exports `loadScriptEnv()`;
+- `scripts/lib/supabase.mts` exports `createScriptAdminClient()`.
+
+`loadScriptEnv()` loads `.env` and `.env.local` without replacing variables
+already set by the shell. `createScriptAdminClient()` checks
+`NEXT_PUBLIC_SUPABASE_URL` and `SUPABASE_SECRET_KEY`, disables token refresh,
+and accepts a `persistSession` option. Its default is `false`.
+
+Move the five scripts to these helpers without changing their database work.
+`reset-freeloader-credits.mts` must pass `persistSession: true` to preserve its
+current setting. Keep local-versus-production warnings in each command because
+their placement and wording differ.
+
+Several scripts also contain the same three-line `promptUser()` wrapper. Do not
+extract it in this change. The R2 command is noninteractive, and a generic
+prompt helper would add an import without giving us one place for meaningful
+safety rules. Extract confirmation handling when two commands need the same
+confirmation policy.
+
+Document one rule in `scripts/README.md`: new TypeScript maintenance scripts
+must use the shared environment and Supabase helpers. This prevents the copy
+from returning.
+
+## Files
+
+Add:
+
+- `scripts/cleanup-orphaned-r2-audio.mts`
+- `scripts/lib/env.mts`
+- `scripts/lib/supabase.mts`
+- `scripts/lib/r2-orphan-audio-cleanup.mts`
+- `scripts/r2-orphan-audio-cleanup.test.mts`
+
+Update:
+
+- the five `.mts` scripts listed above;
+- `scripts/package.json`;
+- the root `package.json`;
+- `scripts/README.md`;
+- `pnpm-lock.yaml`; and
+- `scripts/.gitignore` only if its existing `*.json` rule does not cover the
+  reports.
+
+Use `@aws-sdk/client-s3` at the version already used by `apps/web`.
+
+The R2 command reads these variables:
+
+- `NEXT_PUBLIC_SUPABASE_URL`
+- `SUPABASE_SECRET_KEY`
+- `R2_ENDPOINT`
+- `R2_ACCESS_KEY_ID`
+- `R2_SECRET_ACCESS_KEY`
+- `R2_BUCKET_NAME`
+- `R2_SPEECH_API_BUCKET_NAME`
+
+R2 credentials need list, read, head, and delete access for deletion mode.
+
+## Tests
+
+Use Node's test runner through `tsx`. Cover:
+
+- decimal and binary size parsing;
+- invalid and zero download limits;
+- the 45-day boundary;
+- database key protection across both buckets;
+- bucket and prefix allowlists;
+- oldest-first selection under the byte cap;
+- fitting a later small file after deferring a large one;
+- manifest validation;
+- path traversal rejection;
+- CLI option dependencies;
+- no-overwrite behavior;
+- simple and opaque ETags;
+- paginated Supabase and R2 reads;
+- changed and missing R2 objects; and
+- partial deletion failures.
+
+Use small client interfaces so tests do not contact Supabase or R2.
+
+## Validation
+
+Run focused checks first:
+
+```bash
+pnpm --filter @sexyvoice/scripts test
+pnpm --filter @sexyvoice/scripts type-check
+pnpm exec biome check scripts/cleanup-orphaned-r2-audio.mts \
+  scripts/lib/*.mts \
+  scripts/r2-orphan-audio-cleanup.test.mts
+```
+
+Then run the repository checks:
+
+```bash
+pnpm fixall
+pnpm type-check
+pnpm test
+```
+
+Run inventory against the configured buckets and inspect the JSON. Do not run
+`--download` or `--delete` as part of automated validation.
+
+## Done when
+
+- Inventory writes a complete manifest and makes no remote changes.
+- The command never scans a paid, clone-input, or unknown prefix.
+- Any current database row protects its key in both buckets.
+- Downloads stay within the requested cap and never replace a local file.
+- Normal deletion requires a verified local copy.
+- `--delete --force --yes` skips only the backup requirement.
+- Every attempted action appears in the report.
+- The five existing `.mts` scripts use the shared environment and Supabase
+  modules without behavior changes.
+- Focused tests, `pnpm fixall`, `pnpm type-check`, and `pnpm test` pass.

--- a/docs/plans/2026-08-22-r2-orphan-audio-cleanup.md
+++ b/docs/plans/2026-08-22-r2-orphan-audio-cleanup.md
@@ -83,6 +83,11 @@ pnpm cleanup-orphaned-r2-audio -- \
 `--max-download-size`. Reject `--download-dir` and `--max-download-size` when
 `--download` is absent.
 
+Require the exact download directory to exist with write and traversal access
+before reading the manifest or touching R2. Do not create the download root.
+This makes an unmounted removable volume fail at startup instead of creating
+its mount path on the internal disk.
+
 Accept decimal units `KB`, `MB`, `GB`, and `TB`, plus binary units `KiB`, `MiB`,
 `GiB`, and `TiB`.
 

--- a/docs/plans/2026-08-23-r2-audio-backup-design.md
+++ b/docs/plans/2026-08-23-r2-audio-backup-design.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Approved design. Implementation requires a separate plan and review.
+Implemented.
 
 ## Problem
 
@@ -23,7 +23,8 @@ Add this root command, delegated to `@sexyvoice/scripts`:
 pnpm backup-r2-audio -- [options]
 ```
 
-A normal backup requires a destination:
+A normal backup requires an existing destination directory with write and
+traversal access:
 
 ```bash
 pnpm backup-r2-audio -- \
@@ -54,7 +55,7 @@ same object from being listed, checked, downloaded, and reported twice.
 Support these options:
 
 ```text
---download-dir <path>       Required local backup directory
+--download-dir <path>       Required destination; must exist for downloads
 --source <locations>        Comma-separated bucket or bucket/prefix sources
 --max-download-size <size>  Optional cap for new transfers
 --dry-run                   Scan and compare without downloading
@@ -72,6 +73,12 @@ When `--source` is present, require `R2_ENDPOINT`, `R2_ACCESS_KEY_ID`, and
 The command has no deletion or force flags.
 
 ## Local layout and safety
+
+Before a normal run lists R2, require the exact download directory to exist and
+check its write and traversal access. Do not create the download root. This
+makes an unmounted removable volume fail at startup instead of creating its
+mount path on the internal disk. A dry run does not create or require the
+root directory.
 
 Preserve the literal bucket name and complete R2 key:
 
@@ -188,6 +195,11 @@ Progress.all(objects.map(downloadObject), {
 and failed object counts. Use the built-in progress bar, elapsed time, and ETA.
 Include the total selected bytes in the description. Do not add nested per-file
 tasks, custom columns, or manual per-chunk progress.
+
+Run the backup package command with `NODE_ENV=production` so Ink loads React's
+production reconciler. React's development reconciler retains performance
+measurements on every Ink render and can exhaust the V8 heap during a long
+transfer.
 
 Mount the Ink renderer only when `process.stdout.isTTY` is true. For redirected
 output and CI, run the same effects with `Effect.all()` at concurrency four and
@@ -318,6 +330,7 @@ filesystem interfaces. Cover:
 - partial download cleanup;
 - four-object concurrency;
 - dry-run behavior;
+- missing and read-only download roots that fail before R2 listing;
 - listing failures that prevent all downloads;
 - mixed download results that continue processing;
 - report totals and exit-code decisions; and
@@ -368,6 +381,8 @@ pnpm backup-r2-audio -- \
 - An optional cap limits new transfer bytes and prioritizes older objects.
 - Interactive runs use `effective-progress`; redirected output has no Ink
   rendering.
+- Normal runs require an existing writable and traversable download root before
+  R2 listing.
 - Every listed object receives one final report status.
 - The cleanup command keeps its allowlist, database, age, manifest, and deletion
   protections after generic R2 code moves out.

--- a/docs/plans/2026-08-23-r2-audio-backup-design.md
+++ b/docs/plans/2026-08-23-r2-audio-backup-design.md
@@ -170,26 +170,27 @@ Before downloading, print total objects and bytes for each source. Then print
 counts and bytes for existing, missing, deferred, and selected objects.
 
 Use `effective-progress` for an interactive download run. Wrap each Promise
-based download with `Effect.tryPromise()` and run the effects through
-`Progress.forEach()`:
+based download with `Effect.tryPromise()`, build one effect per object, and run
+the effects through `Progress.all()`:
 
 ```ts
-Progress.forEach(objects, downloadObject, {
+Progress.all(objects.map(downloadObject), {
   concurrency: 4,
   description: 'Downloading R2 objects',
   mode: 'result',
 });
 ```
 
-`mode: 'result'` runs every download and displays successful and failed object
-counts. Use the built-in progress bar, elapsed time, and ETA. Include the total
-selected bytes in the description. Do not add nested per-file tasks, custom
-columns, or manual per-chunk progress.
+`effective-progress@0.12.0` supports `mode: 'result'` on `Progress.all()`, not
+`Progress.forEach()`. Result mode runs every download and displays successful
+and failed object counts. Use the built-in progress bar, elapsed time, and ETA.
+Include the total selected bytes in the description. Do not add nested per-file
+tasks, custom columns, or manual per-chunk progress.
 
 Mount the Ink renderer only when `process.stdout.isTTY` is true. For redirected
-output and CI, run the same effects with `Effect.forEach()` at concurrency four.
-Print the plan, individual failures, and completion summary without ANSI
-rendering.
+output and CI, run the same effects with `Effect.all()` at concurrency four and
+`mode: 'result'`. Print the plan, individual failures, and completion summary
+without ANSI rendering.
 
 At completion, print:
 

--- a/docs/plans/2026-08-23-r2-audio-backup-design.md
+++ b/docs/plans/2026-08-23-r2-audio-backup-design.md
@@ -84,9 +84,11 @@ Preserve the literal bucket name and complete R2 key:
 A prefix limits the remote listing. It does not get removed from the local
 path.
 
-Reject an empty key, absolute key, `..` segment, path that escapes its bucket
-directory, or symlinked path component beneath that directory. This check must
-run before reading or writing the destination.
+Reject an empty key, absolute key, empty or `.` or `..` segment, backslash,
+path that escapes its bucket directory, or symlinked path component beneath
+that directory. Empty segments include repeated and trailing slashes. These
+keys cannot map to a local path without normalization or platform-dependent
+collisions. Run this check before reading or writing the destination.
 
 Never overwrite an existing local path. A mismatch is an error for the user to
 resolve.

--- a/docs/superpowers/specs/2026-08-23-r2-audio-backup-design.md
+++ b/docs/superpowers/specs/2026-08-23-r2-audio-backup-design.md
@@ -1,0 +1,371 @@
+# R2 audio backup
+
+## Status
+
+Approved design. Implementation requires a separate plan and review.
+
+## Problem
+
+The orphan cleanup command downloads only old, unreferenced free-user audio from
+a reviewed manifest. It cannot back up complete R2 buckets, and adding a mode
+that bypasses its database, age, prefix, and deletion rules would make that
+command harder to trust.
+
+Add a separate one-way backup command. It downloads remote objects that have no
+matching verified local file. It never deletes from R2, deletes local backups,
+or overwrites a local file.
+
+## Command
+
+Add this root command, delegated to `@sexyvoice/scripts`:
+
+```bash
+pnpm backup-r2-audio -- [options]
+```
+
+A normal backup requires a destination:
+
+```bash
+pnpm backup-r2-audio -- \
+  --download-dir /Volumes/ExternalHD/sexyvoice-r2-bucket
+```
+
+When `--source` is absent, back up both complete buckets named by
+`R2_BUCKET_NAME` and `R2_SPEECH_API_BUCKET_NAME`.
+
+`--source` accepts a comma-separated list of R2 locations. Each location uses
+`<bucket>[/<key-prefix>]`:
+
+```bash
+pnpm backup-r2-audio -- \
+  --download-dir /Volumes/ExternalHD/sexyvoice-r2-bucket \
+  --source sv-audio-files/generated-audio/,sv-api-speech-audio-files
+```
+
+Split each source at the first `/`. The rest is an exact R2 key prefix, not a
+filesystem directory. For example, `audio` matches `audio-old/file.wav`, while
+`audio/` does not.
+
+Trim source values and remove exact duplicates. Reject empty sources and
+sources that overlap. A complete bucket and one of its prefixes overlap, as do
+two prefixes when one starts with the other. Rejecting overlap prevents the
+same object from being listed, checked, downloaded, and reported twice.
+
+Support these options:
+
+```text
+--download-dir <path>       Required local backup directory
+--source <locations>        Comma-separated bucket or bucket/prefix sources
+--max-download-size <size>  Optional cap for new transfers
+--dry-run                   Scan and compare without downloading
+-h, --help                  Show help
+```
+
+Accept decimal units `KB`, `MB`, `GB`, and `TB`, plus binary units `KiB`, `MiB`,
+`GiB`, and `TiB`. Reject zero, negative, fractional-byte, and unsafe integer
+results.
+
+When `--source` is present, require `R2_ENDPOINT`, `R2_ACCESS_KEY_ID`, and
+`R2_SECRET_ACCESS_KEY`. When it is absent, also require `R2_BUCKET_NAME` and
+`R2_SPEECH_API_BUCKET_NAME`.
+
+The command has no deletion or force flags.
+
+## Local layout and safety
+
+Preserve the literal bucket name and complete R2 key:
+
+```text
+<download-dir>/
+├── <bucket-one>/<complete-r2-key>
+└── <bucket-two>/<complete-r2-key>
+```
+
+A prefix limits the remote listing. It does not get removed from the local
+path.
+
+Reject an empty key, absolute key, `..` segment, path that escapes its bucket
+directory, or symlinked path component beneath that directory. This check must
+run before reading or writing the destination.
+
+Never overwrite an existing local path. A mismatch is an error for the user to
+resolve.
+
+## Backup flow
+
+### List every source
+
+Paginate `ListObjectsV2` for every source and record each object's bucket,
+requested prefix, complete key, size, ETag, and `LastModified` value.
+
+Finish listing all sources before downloading. If any listing fails, write a
+source failure report and make no downloads. A partial listing must not look
+like a complete backup.
+
+Sort the combined object list from oldest to newest. This gives objects closest
+to lifecycle expiration priority when a transfer cap applies.
+
+### Compare local files
+
+Resolve each object to its local path and classify it:
+
+- `missing` when no local file exists;
+- `existing-checksum` when size and a simple ETag MD5 match;
+- `existing-size` when an opaque ETag and local size match;
+- `local-mismatch` when size or a usable checksum differs;
+- `local-read-failure` when the path cannot be inspected; or
+- `unsafe-path` when the key cannot map safely to the destination.
+
+A simple ETag is exactly 32 hexadecimal characters after removing surrounding
+quotes. Treat multipart and other ETags as opaque.
+
+This backup is stateless. For opaque ETags, equal size is the only available
+comparison. A five-object production sample from
+`sv-api-speech-audio-files/generated-audio/` had simple ETags, and every ETag
+matched the downloaded file's MD5. That sample does not prove that all objects
+in either bucket have simple ETags.
+
+### Select transfers
+
+Existing files do not count against `--max-download-size`. Apply the cap only
+to missing objects, from oldest to newest. If one object does not fit, defer it
+and continue looking for smaller objects. Without the option, select every
+missing object.
+
+A deferred object is not a failure because a later run can resume the backup.
+
+### Download
+
+Download up to four objects concurrently. For each object:
+
+1. create its parent directory;
+2. request it with `If-Match` set to the listed ETag;
+3. stream it to a uniquely named temporary file beside the destination;
+4. stop if the stream exceeds the listed size;
+5. reject a stream that finishes short;
+6. compare local MD5 when the ETag is simple;
+7. accept exact size when the ETag is opaque; and
+8. move the temporary file into place only if the destination still does not
+   exist.
+
+Remove the temporary file after a handled failure. A process kill may leave a
+`.partial-<uuid>` file. Later runs ignore partial files and never treat them as
+completed backups.
+
+Classify download outcomes as `downloaded-checksum`, `downloaded-size`,
+`changed-in-r2`, `missing-from-r2`, or `download-failure`. An `If-Match` failure
+means the object changed after listing. Do not retry it against stale metadata.
+The AWS SDK may perform its normal bounded request retries.
+
+Continue after individual download failures so the report accounts for every
+listed object. Return a nonzero exit code for unsafe paths, local mismatches,
+local read failures, changed or missing remote objects, and download failures.
+
+`--dry-run` performs source listing, local comparison, transfer selection, and
+reporting. It does not create destination directories or download objects.
+
+## Progress and summaries
+
+Before downloading, print total objects and bytes for each source. Then print
+counts and bytes for existing, missing, deferred, and selected objects.
+
+Use `effective-progress` for an interactive download run. Wrap each Promise
+based download with `Effect.tryPromise()` and run the effects through
+`Progress.forEach()`:
+
+```ts
+Progress.forEach(objects, downloadObject, {
+  concurrency: 4,
+  description: 'Downloading R2 objects',
+  mode: 'result',
+});
+```
+
+`mode: 'result'` runs every download and displays successful and failed object
+counts. Use the built-in progress bar, elapsed time, and ETA. Include the total
+selected bytes in the description. Do not add nested per-file tasks, custom
+columns, or manual per-chunk progress.
+
+Mount the Ink renderer only when `process.stdout.isTTY` is true. For redirected
+output and CI, run the same effects with `Effect.forEach()` at concurrency four.
+Print the plan, individual failures, and completion summary without ANSI
+rendering.
+
+At completion, print:
+
+- downloaded objects and bytes;
+- checksum-verified objects and bytes;
+- size-verified objects and bytes;
+- failed objects and bytes;
+- elapsed time and average transfer rate; and
+- the report path.
+
+A dry run prints source totals and the transfer plan without mounting the
+progress renderer.
+
+Pin these dependencies in the workspace catalog because `effective-progress`
+is pre-1.0 and Effect v4 is a release candidate:
+
+```yaml
+effective-progress: 0.12.0
+effect: 4.0.0-rc.111
+```
+
+Consume both with `catalog:` in `scripts/package.json`. Keep Effect and
+`effective-progress` in `backup-r2-audio.mts`; shared R2 modules remain
+Promise-based. Ink and React stay transitive dependencies of
+`effective-progress`.
+
+## Reports
+
+Write `scripts/backups/r2-audio-backup-<timestamp>.json`. It contains:
+
+- a schema version and creation time;
+- requested and resolved sources;
+- dry-run and transfer-cap settings;
+- source object and byte totals;
+- one final status for every listed object;
+- local destination paths relative to `--download-dir`;
+- failure reasons; and
+- counts and bytes grouped by source, bucket, and status.
+
+The report contains no credentials, authorization headers, or signed requests.
+A listing failure report names the failed source and error but cannot contain a
+complete object inventory.
+
+## Shared code
+
+Add `scripts/lib/r2-client.mts` for the AWS SDK adapter:
+
+- environment validation and `S3Client` construction;
+- list, get, and head requests; and
+- batch deletion used by the cleanup command.
+
+Add `scripts/lib/r2-transfer.mts` for Promise-based transfer rules:
+
+- R2 object metadata and client interfaces;
+- pagination;
+- byte-size parsing and formatting;
+- transfer-cap selection;
+- safe local path resolution;
+- ETag normalization and simple MD5 detection;
+- local file verification;
+- streaming download and byte-count enforcement; and
+- no-overwrite finalization.
+
+Keep cleanup policy in `scripts/lib/r2-orphan-audio-cleanup.mts`:
+
+- free-user bucket and prefix allowlists;
+- the 45-day cutoff;
+- database-reference protection;
+- candidate analysis and manifests;
+- stale-object rechecks;
+- deletion eligibility; and
+- cleanup reports.
+
+The command files coordinate these modules:
+
+- `cleanup-orphaned-r2-audio.mts` combines Supabase, cleanup policy, and shared
+  R2 code;
+- `backup-r2-audio.mts` combines source selection, local comparison, progress,
+  and shared R2 code.
+
+## Files
+
+Add:
+
+- `scripts/backup-r2-audio.mts`
+- `scripts/r2-audio-backup.test.mts`
+- `scripts/lib/r2-client.mts`
+- `scripts/lib/r2-transfer.mts`
+
+Update:
+
+- `scripts/cleanup-orphaned-r2-audio.mts`
+- `scripts/lib/r2-orphan-audio-cleanup.mts`
+- `scripts/r2-orphan-audio-cleanup.test.mts`
+- `scripts/package.json`
+- root `package.json`
+- `pnpm-workspace.yaml`
+- `pnpm-lock.yaml`
+- `scripts/README.md`
+
+Update `scripts/.gitignore` only if its current JSON rule does not cover backup
+reports.
+
+## Tests
+
+Use Node's test runner through `tsx`. Keep tests offline with small R2 and
+filesystem interfaces. Cover:
+
+- default environment sources;
+- bucket and exact-prefix source parsing;
+- duplicate normalization and overlapping-source rejection;
+- paginated listing;
+- path traversal and symlink rejection;
+- decimal and binary size parsing;
+- oldest-first transfer selection;
+- fitting a later small object after deferring a larger one;
+- simple ETag MD5 verification;
+- opaque ETag size verification;
+- local mismatch and local read failures;
+- no-overwrite finalization;
+- conditional downloads;
+- changed and missing remote objects;
+- partial download cleanup;
+- four-object concurrency;
+- dry-run behavior;
+- listing failures that prevent all downloads;
+- mixed download results that continue processing;
+- report totals and exit-code decisions; and
+- existing orphan cleanup and deletion behavior after extraction.
+
+Do not snapshot Ink output. Put progress orchestration behind a narrow function
+and test its selected inputs and returned results.
+
+## Validation
+
+Run focused checks first:
+
+```bash
+pnpm --filter @sexyvoice/scripts test
+pnpm --filter @sexyvoice/scripts type-check
+pnpm exec biome check scripts/backup-r2-audio.mts \
+  scripts/cleanup-orphaned-r2-audio.mts \
+  scripts/lib/*.mts \
+  scripts/*r2*.test.mts
+```
+
+Then run the repository checks:
+
+```bash
+pnpm fixall
+pnpm type-check
+pnpm test
+```
+
+Run a production read-only dry run against a narrow source. Do not start the
+full backup as automated validation:
+
+```bash
+pnpm backup-r2-audio -- \
+  --download-dir /Volumes/ExternalHD/sexyvoice-r2-bucket \
+  --source sv-api-speech-audio-files/generated-audio/ \
+  --dry-run
+```
+
+## Done when
+
+- The default command covers both configured complete buckets.
+- `--source` accepts any accessible bucket or exact key prefix without duplicate
+  work.
+- Repeated runs skip matching local files and never overwrite a local path.
+- Simple ETags receive MD5 verification and opaque ETags receive explicit
+  size-only verification.
+- An optional cap limits new transfer bytes and prioritizes older objects.
+- Interactive runs use `effective-progress`; redirected output has no Ink
+  rendering.
+- Every listed object receives one final report status.
+- The cleanup command keeps its allowlist, database, age, manifest, and deletion
+  protections after generic R2 code moves out.
+- Focused tests, `pnpm fixall`, `pnpm type-check`, and `pnpm test` pass.

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "analyze-free-users": "pnpm --filter @sexyvoice/scripts analyze-free-users",
     "backfill-call-analysis": "pnpm --filter @sexyvoice/scripts backfill-call-analysis",
     "backfill-free-call": "pnpm --filter @sexyvoice/scripts backfill-free-call",
+    "backup-r2-audio": "pnpm --filter @sexyvoice/scripts backup-r2-audio",
     "build": "turbo run build",
     "build:content": "turbo run build:content --filter=@sexyvoice/web",
     "check": "ultracite check",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "check": "ultracite check",
     "check-translations": "turbo run check-translations --filter=@sexyvoice/web",
     "clean": "turbo run clean",
+    "cleanup-orphaned-r2-audio": "pnpm --filter @sexyvoice/scripts cleanup-orphaned-r2-audio",
     "compile-dispute-evidence": "pnpm --filter @sexyvoice/scripts compile-dispute-evidence",
     "dev": "turbo run dev --filter=@sexyvoice/web",
     "fix": "ultracite fix",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -540,6 +540,9 @@ importers:
       '@ai-sdk/xai':
         specifier: 3.0.96
         version: 3.0.96(zod@4.3.6)
+      '@aws-sdk/client-s3':
+        specifier: 3.1011.0
+        version: 3.1011.0
       '@google/genai':
         specifier: 1.19.0
         version: 1.19.0(supports-color@8.1.1)
@@ -556,9 +559,15 @@ importers:
         specifier: ^16.6.1
         version: 16.6.1
     devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.10.4
       tsx:
         specifier: 'catalog:'
         version: 4.19.3
+      typescript:
+        specifier: 'catalog:'
+        version: 7.0.2
 
 packages:
 
@@ -5882,9 +5891,6 @@ packages:
 
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
-
-  '@types/mdx@2.0.13':
-    resolution: {integrity: sha512-+OWZQfAYyio6YkJb3HLxDrvnx6SWWDbC0zVPfBRzUk0/nqoDyf6dNxQi3eArPe8rJ473nobTMQ/8Zk+LxJ+Yuw==}
 
   '@types/mdx@2.0.14':
     resolution: {integrity: sha512-T48PeuJtvLosNTPVhfnIp3i/n3a4g4Bad7YCq5k64D4u7NwDrAotikQ+5+sjtUvBmxCMlbo3dVL+C2dP0rWHzg==}
@@ -11873,7 +11879,7 @@ snapshots:
       '@types/estree': 1.0.9
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.5
-      '@types/mdx': 2.0.13
+      '@types/mdx': 2.0.14
       acorn: 8.17.0
       collapse-white-space: 2.1.0
       devlop: 1.1.0
@@ -15878,8 +15884,6 @@ snapshots:
   '@types/mdast@4.0.4':
     dependencies:
       '@types/unist': 3.0.3
-
-  '@types/mdx@2.0.13': {}
 
   '@types/mdx@2.0.14': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,12 @@ catalogs:
     ai:
       specifier: 6.0.116
       version: 6.0.116
+    effect:
+      specifier: 4.0.0-rc.111
+      version: 4.0.0-rc.111
+    effective-progress:
+      specifier: 0.12.0
+      version: 0.12.0
     next:
       specifier: 16.3.0
       version: 16.3.0
@@ -558,6 +564,12 @@ importers:
       dotenv:
         specifier: ^16.6.1
         version: 16.6.1
+      effect:
+        specifier: 'catalog:'
+        version: 4.0.0-rc.111
+      effective-progress:
+        specifier: 'catalog:'
+        version: 0.12.0(@types/react@19.2.16)(effect@4.0.0-rc.111)
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -626,6 +638,10 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
+
+  '@alcalzone/ansi-tokenize@0.3.0':
+    resolution: {integrity: sha512-p+CMKJ93HFmLkjXKlXiVGlMQEuRb6H0MokBSwUsX+S6BRX8eV5naFZpQJFfJHjRZY0Hmnqy1/r6UWl3x+19zYA==}
+    engines: {node: '>=18'}
 
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
@@ -2143,6 +2159,36 @@ packages:
   '@msgpack/msgpack@3.1.2':
     resolution: {integrity: sha512-JEW4DEtBzfe8HvUYecLU9e6+XJnKDlUAIve8FvPzF3Kzs6Xo/KuZkZJsDH0wJXl/qEZbeeE7edxDNY3kMs39hQ==}
     engines: {node: '>= 18'}
+
+  '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.4':
+    resolution: {integrity: sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.4':
+    resolution: {integrity: sha512-zExlW9zUJKZH/tOtVMttwjKa4Xm/3KcNjnE3dPN92uCktwavMxpgCA3MoJK/DOnTWsQgo224OaST27/mPNAf+w==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.4':
+    resolution: {integrity: sha512-dgX0P/9wGPJeHFBG+ZmhgE6bmtMt7NP5CRBGyyktpopdk/mW4POnrpQsSLtKI1dwpc+pPLuXHDh6vvskyQE/sw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm@3.0.4':
+    resolution: {integrity: sha512-Tg3yX65f5GbtXLkrYEHE5oibZG9epyYWas7FogTTEJeDEF9JlXJzKgXaNhT3UXlTOeA+AfZpYZYZ0uPj7Cfquw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@msgpackr-extract/msgpackr-extract-linux-x64@3.0.4':
+    resolution: {integrity: sha512-8TNXMEjJc3QEy7R/x1INhgiU+XakDAFUzBhaz7+Rbrs8NH5UQeHQxxmzsSBJGyV6I1jW79undiQm8tOI+D+8FQ==}
+    cpu: [x64]
+    os: [linux]
+
+  '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.4':
+    resolution: {integrity: sha512-CmCXPQrkbwExx3j946/PtHWHbYJiCRBRDl4BlkRQcJB/YOwQxJRTpoo7aTsortjgoJ1x7opzTSxn7C+ASSLVjQ==}
+    cpu: [x64]
+    os: [win32]
 
   '@mswjs/interceptors@0.41.3':
     resolution: {integrity: sha512-cXu86tF4VQVfwz8W1SPbhoRyHJkti6mjH/XJIxp40jhO4j2k1m4KYrEykxqWPkFF3vrK4rgQppBh//AwyGSXPA==}
@@ -6441,12 +6487,20 @@ packages:
   ajv@8.20.0:
     resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
+  ansi-escapes@7.3.0:
+    resolution: {integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==}
+    engines: {node: '>=18'}
+
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
 
   ansi-regex@6.1.0:
     resolution: {integrity: sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==}
+    engines: {node: '>=12'}
+
+  ansi-regex@6.3.0:
+    resolution: {integrity: sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==}
     engines: {node: '>=12'}
 
   ansi-styles@4.3.0:
@@ -6459,6 +6513,10 @@ packages:
 
   ansi-styles@6.2.1:
     resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
+    engines: {node: '>=12'}
+
+  ansi-styles@6.2.3:
+    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
 
   anymatch@3.1.3:
@@ -6488,6 +6546,10 @@ packages:
   astring@1.9.0:
     resolution: {integrity: sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==}
     hasBin: true
+
+  auto-bind@5.0.1:
+    resolution: {integrity: sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   autoprefixer@10.4.27:
     resolution: {integrity: sha512-NP9APE+tO+LuJGn7/9+cohklunJsXWiaWEfV3si4Gi/XHDwVNgkwr1J3RQYFIvPy76GmJ9/bW8vyoU1LcxwKHA==}
@@ -6653,6 +6715,22 @@ packages:
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
 
+  cli-boxes@4.0.1:
+    resolution: {integrity: sha512-5IOn+jcCEHEraYolBPs/sT4BxYCe2nHg374OPiItB1O96KZFseS2gthU4twyYzeDcFew4DaUM/xwc5BQf08JJw==}
+    engines: {node: '>=18.20 <19 || >=20.10'}
+
+  cli-cursor@4.0.0:
+    resolution: {integrity: sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  cli-spinners@3.4.0:
+    resolution: {integrity: sha512-bXfOC4QcT1tKXGorxL3wbJm6XJPDqEnij2gQ2m7ESQuE+/z9YFIWnl/5RpTiKWbMq3EVKR4fRLJGn6DVfu0mpw==}
+    engines: {node: '>=18.20'}
+
+  cli-truncate@6.1.1:
+    resolution: {integrity: sha512-06p9vyLahLa4zkGcgsGxU6iEkSOiuI4fhCH6Emhe2lPAcoUv73n72DnODsnHA+5wwXGnV0n9M9/qOQJSjYhFhw==}
+    engines: {node: '>=22'}
+
   cli-width@4.1.0:
     resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
     engines: {node: '>= 12'}
@@ -6680,6 +6758,10 @@ packages:
   cnfast@0.1.0:
     resolution: {integrity: sha512-rH0jBKeLkVrK7NsZ5Ba2l7WdMBmm1k0FMpABeXUU1PgTUxbz3261gEuCSsrYuXo4BwAe3yCcIbQ93YyS52lOGQ==}
     hasBin: true
+
+  code-excerpt@4.0.0:
+    resolution: {integrity: sha512-xxodCmBen3iy2i0WtAK8FlFNrRzjUqjRsMfho58xT/wvZU1YTM3fCnRjcy1gJPMepaRlgm/0e6w8SpWHpn3/cA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   codec-parser@2.5.0:
     resolution: {integrity: sha512-Ru9t80fV8B0ZiixQl8xhMTLru+dzuis/KQld32/x5T/+3LwZb0/YvQdSKytX9JqCnRdiupvAvyYJINKrXieziQ==}
@@ -6736,6 +6818,10 @@ packages:
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  convert-to-spaces@2.0.1:
+    resolution: {integrity: sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   convict@6.2.5:
     resolution: {integrity: sha512-JtXpxqDqJ8P0UwEHwhxLzCIXQy97vlYBZR222Sbzb1q1Erex9ASrztJ29SyhWFQjod1AeFBaPzEEC8YvtZMIYg==}
@@ -6956,6 +7042,15 @@ packages:
   ecdsa-sig-formatter@1.0.11:
     resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
+  effect@4.0.0-rc.111:
+    resolution: {integrity: sha512-ASd5L58EIR0CUNueZNKKjSsyOCd+2alxOAIaTcHaqkJkPsaYSsw5Cg/cfANk5K4Jr2YsX756xvX11shzqsreWA==}
+
+  effective-progress@0.12.0:
+    resolution: {integrity: sha512-CLTUDirKVckMr1FgqFgmRXf8OHmdlhUdEFrrZRLc2FQzRfZiCXbuW52LTNm67kLJc5UGcsVTf5Ij1jE3Axfk9Q==}
+    engines: {node: '>=20.12.0'}
+    peerDependencies:
+      effect: ^4.0.0-beta.100
+
   electron-to-chromium@1.5.267:
     resolution: {integrity: sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw==}
 
@@ -6992,6 +7087,10 @@ packages:
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
+
+  environment@1.1.0:
+    resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
+    engines: {node: '>=18'}
 
   es-define-property@1.0.1:
     resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
@@ -7036,6 +7135,10 @@ packages:
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
+
+  escape-string-regexp@2.0.0:
+    resolution: {integrity: sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==}
+    engines: {node: '>=8'}
 
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
@@ -7161,6 +7264,10 @@ packages:
     resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}
     engines: {node: '>= 10.17.0'}
     hasBin: true
+
+  fast-check@4.9.0:
+    resolution: {integrity: sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg==}
+    engines: {node: '>=12.17.0'}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -7503,6 +7610,10 @@ packages:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
 
+  get-east-asian-width@1.6.0:
+    resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
+    engines: {node: '>=18'}
+
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
@@ -7744,12 +7855,29 @@ packages:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
 
+  indent-string@5.0.0:
+    resolution: {integrity: sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==}
+    engines: {node: '>=12'}
+
   inflection@3.0.2:
     resolution: {integrity: sha512-+Bg3+kg+J6JUWn8J6bzFmOWkTQ6L/NHfDRSYU+EVvuKHDxUDHAXgqixHfVlzuBQaPOTac8hn43aPhMNk6rMe3g==}
     engines: {node: '>=18.0.0'}
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ink@7.1.1:
+    resolution: {integrity: sha512-Y43xxa1ZSPvpmfLHcN5o+OdP8Rf8ykkNJEuKYOUNZKT8wXVNLFTtEm1nSDMQkfBH+YANF4Xuu0hhZ4ejqAtN2w==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      '@types/react': '>=19.2.0'
+      react: '>=19.2.0'
+      react-devtools-core: '>=6.1.2'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      react-devtools-core:
+        optional: true
 
   inline-style-parser@0.2.4:
     resolution: {integrity: sha512-0aO8FkhNZlj/ZIbNi7Lxxr12obT7cL1moPfE4tg1LkX7LlLfC6DeX4l2ZEud1ukP9jNQyNnfzQVqwbwmAATY4Q==}
@@ -7834,12 +7962,21 @@ packages:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
 
+  is-fullwidth-code-point@5.1.0:
+    resolution: {integrity: sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==}
+    engines: {node: '>=18'}
+
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
 
   is-hexadecimal@2.0.1:
     resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
+
+  is-in-ci@2.0.0:
+    resolution: {integrity: sha512-cFeerHriAnhrQSbpAxL37W1wcJKUUX07HyLWZCW1URJT/ra3GyUTzBgUnh24TMVfNTV2Hij2HLxkPHFZfOZy5w==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   is-node-process@1.2.0:
     resolution: {integrity: sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==}
@@ -8399,6 +8536,10 @@ packages:
     resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
     engines: {node: '>=18'}
 
+  mimic-fn@2.1.0:
+    resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
+    engines: {node: '>=6'}
+
   min-indent@1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
@@ -8488,6 +8629,13 @@ packages:
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  msgpackr-extract@3.0.4:
+    resolution: {integrity: sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw==}
+    hasBin: true
+
+  msgpackr@2.0.5:
+    resolution: {integrity: sha512-cef05H/dSYpLpqp3sj/qyZh5vhUYCalnaLO7j1yOmpsR0y/XwLVtK7r5gn+U/F7CTEfMowcGhlUQJDLcLf7jcA==}
 
   msw@2.15.0:
     resolution: {integrity: sha512-2wQAmKkQKxRuXvYJxVhPGG0wZNBQyD06oJvxqw90XqLvptdqxdlHrFUfEteKkpaNORX3Xzc+HtEl/q0nfmN2wQ==}
@@ -8613,6 +8761,10 @@ packages:
     resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
+  node-gyp-build-optional-packages@5.2.2:
+    resolution: {integrity: sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==}
+    hasBin: true
+
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
 
@@ -8648,6 +8800,10 @@ packages:
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  onetime@5.1.2:
+    resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
+    engines: {node: '>=6'}
 
   oniguruma-parser@0.12.1:
     resolution: {integrity: sha512-8Unqkvk1RYc6yq2WBYRj4hdnsAxVze8i7iPfQr8e4uSP3tRv0rpZcbGUDvxfQQcdwHt/e9PrMvGCsa8OqG9X3w==}
@@ -8748,6 +8904,10 @@ packages:
 
   pascal-case@3.1.2:
     resolution: {integrity: sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==}
+
+  patch-console@2.0.0:
+    resolution: {integrity: sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
@@ -8945,6 +9105,9 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
+  pure-rand@8.4.2:
+    resolution: {integrity: sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng==}
+
   qs@6.15.3:
     resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
     engines: {node: '>=0.6'}
@@ -8988,6 +9151,12 @@ packages:
 
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
+
+  react-reconciler@0.33.0:
+    resolution: {integrity: sha512-KetWRytFv1epdpJc3J4G75I4WrplZE5jOL7Yq0p34+OVOKF4Se7WrdIdVC45XsSSmUTlht2FM/fM1FZb1mfQeA==}
+    engines: {node: '>=0.10.0'}
+    peerDependencies:
+      react: ^19.2.0
 
   react-redux@9.3.0:
     resolution: {integrity: sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==}
@@ -9180,6 +9349,10 @@ packages:
     engines: {node: '>= 0.4'}
     hasBin: true
 
+  restore-cursor@4.0.0:
+    resolution: {integrity: sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   rettime@0.11.11:
     resolution: {integrity: sha512-ILJRqVWBCTlg9r42fFgwVZx1gnFAcQF8mRoMkbgQfIrjEDf9nbBFDFx00oloOa+Q869FUtaYDXZvEfnecQSCoQ==}
 
@@ -9354,6 +9527,10 @@ packages:
     resolution: {integrity: sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==}
     engines: {node: '>=14.16'}
 
+  slice-ansi@9.0.0:
+    resolution: {integrity: sha512-SO/3iYL5S3W57LLEniscOGPZgOqZUPCx6d3dB+52B80yJ0XstzsC/eV8gnA4tM3MHDrKz+OCFSLNjswdSC+/bA==}
+    engines: {node: '>=22'}
+
   smol-toml@1.6.1:
     resolution: {integrity: sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==}
     engines: {node: '>= 18'}
@@ -9388,6 +9565,10 @@ packages:
   sprintf-js@1.1.3:
     resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
 
+  stack-utils@2.0.6:
+    resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
+    engines: {node: '>=10'}
+
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
@@ -9420,6 +9601,10 @@ packages:
     resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
     engines: {node: '>=12'}
 
+  string-width@8.2.2:
+    resolution: {integrity: sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==}
+    engines: {node: '>=20'}
+
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
 
@@ -9432,6 +9617,10 @@ packages:
 
   strip-ansi@7.1.0:
     resolution: {integrity: sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==}
+    engines: {node: '>=12'}
+
+  strip-ansi@7.2.0:
+    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
     engines: {node: '>=12'}
 
   strip-bom-string@1.0.0:
@@ -9536,6 +9725,10 @@ packages:
 
   temporal-spec@0.2.4:
     resolution: {integrity: sha512-lDMFv4nKQrSjlkHKAlHVqKrBG4DyFfa9F74cmBZ3Iy3ed8yvWnlWSIdi4IKfSqwmazAohBNwiN64qGx4y5Q3IQ==}
+
+  terminal-size@4.0.1:
+    resolution: {integrity: sha512-avMLDQpUI9I5XFrklECw1ZEUPJhqzcwSWsyyI8blhRLT+8N1jLJWLWWYQpB2q2xthq8xDvjZPISVh53T/+CLYQ==}
+    engines: {node: '>=18'}
 
   terser-webpack-plugin@5.6.1:
     resolution: {integrity: sha512-201R5j+sJpK8nFWwKVyNfZot8FaJbLZDq5evriVzbV1wDtSXDjRUDRfJzHpAaxFDMEhsZL1QkeqM61wgsS3KaQ==}
@@ -10036,12 +10229,20 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  widest-line@6.0.0:
+    resolution: {integrity: sha512-U89AsyEeAsyoF0zVJBkG9zBgekjgjK7yk9sje3F4IQpXBJ10TF6ByLlIfjMhcmHMJgHZI4KHt4rdNfktzxIAMA==}
+    engines: {node: '>=20'}
+
   win-guid@0.2.1:
     resolution: {integrity: sha512-gEIQU4mkgl2OPeoNrWflcJFJ3Ae2BPd4eCsHHA/XikslkIVms/nHhvnvzIZV7VLmBvtFlDOzLt9rrZT+n6D67A==}
 
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
+
+  wrap-ansi@10.0.1:
+    resolution: {integrity: sha512-M0N4xzyzosiIok3svYlEo1sdLZts/8FPgYH/GPC3wvlmPoRvnoManGMrE54waYj3tISA8w6lsdesfVv67qSr8Q==}
+    engines: {node: '>=20'}
 
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
@@ -10134,6 +10335,9 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  yoga-layout@3.2.1:
+    resolution: {integrity: sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==}
 
   yuku-analyzer@0.8.3:
     resolution: {integrity: sha512-u/kRdlS/Hcqo78pevGoKCcjM4ymcquFlw2qxZgZy6TPkyoExJLww8pnbR8Yck8wO7f9fQ4ymjCdFlhJ1VTzzBw==}
@@ -10251,6 +10455,11 @@ snapshots:
       '@ai-sdk/provider': 3.0.10
       '@ai-sdk/provider-utils': 4.0.30(zod@4.4.3)
       zod: 4.4.3
+
+  '@alcalzone/ansi-tokenize@0.3.0':
+    dependencies:
+      ansi-styles: 6.2.1
+      is-fullwidth-code-point: 5.1.0
 
   '@alloc/quick-lru@5.2.0': {}
 
@@ -11914,6 +12123,24 @@ snapshots:
       - utf-8-validate
 
   '@msgpack/msgpack@3.1.2': {}
+
+  '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.4':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.4':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.4':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm@3.0.4':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-linux-x64@3.0.4':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.4':
+    optional: true
 
   '@mswjs/interceptors@0.41.3':
     dependencies:
@@ -16367,9 +16594,15 @@ snapshots:
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
+  ansi-escapes@7.3.0:
+    dependencies:
+      environment: 1.1.0
+
   ansi-regex@5.0.1: {}
 
   ansi-regex@6.1.0: {}
+
+  ansi-regex@6.3.0: {}
 
   ansi-styles@4.3.0:
     dependencies:
@@ -16378,6 +16611,8 @@ snapshots:
   ansi-styles@5.2.0: {}
 
   ansi-styles@6.2.1: {}
+
+  ansi-styles@6.2.3: {}
 
   anymatch@3.1.3:
     dependencies:
@@ -16407,6 +16642,8 @@ snapshots:
       js-tokens: 10.0.0
 
   astring@1.9.0: {}
+
+  auto-bind@5.0.1: {}
 
   autoprefixer@10.4.27(postcss@8.5.23):
     dependencies:
@@ -16559,6 +16796,19 @@ snapshots:
     dependencies:
       clsx: 2.1.1
 
+  cli-boxes@4.0.1: {}
+
+  cli-cursor@4.0.0:
+    dependencies:
+      restore-cursor: 4.0.0
+
+  cli-spinners@3.4.0: {}
+
+  cli-truncate@6.1.1:
+    dependencies:
+      slice-ansi: 9.0.0
+      string-width: 8.2.2
+
   cli-width@4.1.0: {}
 
   client-only@0.0.1: {}
@@ -16578,6 +16828,10 @@ snapshots:
   cluster-key-slot@1.1.2: {}
 
   cnfast@0.1.0: {}
+
+  code-excerpt@4.0.0:
+    dependencies:
+      convert-to-spaces: 2.0.1
 
   codec-parser@2.5.0: {}
 
@@ -16630,6 +16884,8 @@ snapshots:
       - supports-color
 
   convert-source-map@2.0.0: {}
+
+  convert-to-spaces@2.0.1: {}
 
   convict@6.2.5:
     dependencies:
@@ -16834,6 +17090,25 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
+  effect@4.0.0-rc.111:
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      fast-check: 4.9.0
+      msgpackr: 2.0.5
+
+  effective-progress@0.12.0(@types/react@19.2.16)(effect@4.0.0-rc.111):
+    dependencies:
+      cli-spinners: 3.4.0
+      effect: 4.0.0-rc.111
+      fast-string-width: 3.0.2
+      ink: 7.1.1(@types/react@19.2.16)(react@19.2.7)
+      react: 19.2.7
+    transitivePeerDependencies:
+      - '@types/react'
+      - bufferutil
+      - react-devtools-core
+      - utf-8-validate
+
   electron-to-chromium@1.5.267: {}
 
   embla-carousel-react@8.6.0(react@19.2.7):
@@ -16864,6 +17139,8 @@ snapshots:
   entities@4.5.0: {}
 
   entities@6.0.1: {}
+
+  environment@1.1.0: {}
 
   es-define-property@1.0.1: {}
 
@@ -16954,6 +17231,8 @@ snapshots:
       '@esbuild/win32-x64': 0.28.1
 
   escalade@3.2.0: {}
+
+  escape-string-regexp@2.0.0: {}
 
   escape-string-regexp@4.0.0: {}
 
@@ -17101,6 +17380,10 @@ snapshots:
       '@types/yauzl': 2.10.3
     transitivePeerDependencies:
       - supports-color
+
+  fast-check@4.9.0:
+    dependencies:
+      pure-rand: 8.4.2
 
   fast-deep-equal@3.1.3: {}
 
@@ -17443,6 +17726,8 @@ snapshots:
   gensync@1.0.0-beta.2: {}
 
   get-caller-file@2.0.5: {}
+
+  get-east-asian-width@1.6.0: {}
 
   get-intrinsic@1.3.0:
     dependencies:
@@ -17794,9 +18079,45 @@ snapshots:
 
   indent-string@4.0.0: {}
 
+  indent-string@5.0.0: {}
+
   inflection@3.0.2: {}
 
   inherits@2.0.4: {}
+
+  ink@7.1.1(@types/react@19.2.16)(react@19.2.7):
+    dependencies:
+      '@alcalzone/ansi-tokenize': 0.3.0
+      ansi-escapes: 7.3.0
+      ansi-styles: 6.2.3
+      auto-bind: 5.0.1
+      chalk: 5.6.2
+      cli-boxes: 4.0.1
+      cli-cursor: 4.0.0
+      cli-truncate: 6.1.1
+      code-excerpt: 4.0.0
+      es-toolkit: 1.50.0
+      indent-string: 5.0.0
+      is-in-ci: 2.0.0
+      patch-console: 2.0.0
+      react: 19.2.7
+      react-reconciler: 0.33.0(react@19.2.7)
+      scheduler: 0.27.0
+      signal-exit: 3.0.7
+      slice-ansi: 9.0.0
+      stack-utils: 2.0.6
+      string-width: 8.2.2
+      terminal-size: 4.0.1
+      type-fest: 5.8.0
+      widest-line: 6.0.0
+      wrap-ansi: 10.0.1
+      ws: 8.21.1
+      yoga-layout: 3.2.1
+    optionalDependencies:
+      '@types/react': 19.2.16
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   inline-style-parser@0.2.4: {}
 
@@ -17879,11 +18200,17 @@ snapshots:
 
   is-fullwidth-code-point@3.0.0: {}
 
+  is-fullwidth-code-point@5.1.0:
+    dependencies:
+      get-east-asian-width: 1.6.0
+
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
 
   is-hexadecimal@2.0.1: {}
+
+  is-in-ci@2.0.0: {}
 
   is-node-process@1.2.0: {}
 
@@ -18713,6 +19040,8 @@ snapshots:
     dependencies:
       mime-db: 1.54.0
 
+  mimic-fn@2.1.0: {}
+
   min-indent@1.0.1: {}
 
   minimalistic-assert@1.0.1: {}
@@ -18783,6 +19112,22 @@ snapshots:
   mrmime@2.0.1: {}
 
   ms@2.1.3: {}
+
+  msgpackr-extract@3.0.4:
+    dependencies:
+      node-gyp-build-optional-packages: 5.2.2
+    optionalDependencies:
+      '@msgpackr-extract/msgpackr-extract-darwin-arm64': 3.0.4
+      '@msgpackr-extract/msgpackr-extract-darwin-x64': 3.0.4
+      '@msgpackr-extract/msgpackr-extract-linux-arm': 3.0.4
+      '@msgpackr-extract/msgpackr-extract-linux-arm64': 3.0.4
+      '@msgpackr-extract/msgpackr-extract-linux-x64': 3.0.4
+      '@msgpackr-extract/msgpackr-extract-win32-x64': 3.0.4
+    optional: true
+
+  msgpackr@2.0.5:
+    optionalDependencies:
+      msgpackr-extract: 3.0.4
 
   msw@2.15.0(@types/node@24.10.4)(typescript@7.0.2):
     dependencies:
@@ -18938,6 +19283,11 @@ snapshots:
       fetch-blob: 3.2.0
       formdata-polyfill: 4.0.10
 
+  node-gyp-build-optional-packages@5.2.2:
+    dependencies:
+      detect-libc: 2.1.2
+    optional: true
+
   node-releases@2.0.27: {}
 
   normalize-path@3.0.0: {}
@@ -18970,6 +19320,10 @@ snapshots:
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
+
+  onetime@5.1.2:
+    dependencies:
+      mimic-fn: 2.1.0
 
   oniguruma-parser@0.12.1: {}
 
@@ -19127,6 +19481,8 @@ snapshots:
     dependencies:
       no-case: 3.0.4
       tslib: 2.8.1
+
+  patch-console@2.0.0: {}
 
   path-exists@4.0.0: {}
 
@@ -19350,6 +19706,8 @@ snapshots:
 
   punycode@2.3.1: {}
 
+  pure-rand@8.4.2: {}
+
   qs@6.15.3:
     dependencies:
       es-define-property: 1.0.1
@@ -19436,6 +19794,11 @@ snapshots:
   react-is@17.0.2: {}
 
   react-is@18.3.1: {}
+
+  react-reconciler@0.33.0(react@19.2.7):
+    dependencies:
+      react: 19.2.7
+      scheduler: 0.27.0
 
   react-redux@9.3.0(@types/react@19.2.16)(react@19.2.7)(redux@5.0.1):
     dependencies:
@@ -19720,6 +20083,11 @@ snapshots:
       is-core-module: 2.16.1
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
+
+  restore-cursor@4.0.0:
+    dependencies:
+      onetime: 5.1.2
+      signal-exit: 3.0.7
 
   rettime@0.11.11: {}
 
@@ -20007,6 +20375,11 @@ snapshots:
 
   slash@5.1.0: {}
 
+  slice-ansi@9.0.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      is-fullwidth-code-point: 5.1.0
+
   smol-toml@1.6.1: {}
 
   sonner@2.0.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
@@ -20030,6 +20403,10 @@ snapshots:
   sprintf-js@1.0.3: {}
 
   sprintf-js@1.1.3: {}
+
+  stack-utils@2.0.6:
+    dependencies:
+      escape-string-regexp: 2.0.0
 
   stackback@0.0.2: {}
 
@@ -20059,6 +20436,11 @@ snapshots:
       emoji-regex: 9.2.2
       strip-ansi: 7.1.0
 
+  string-width@8.2.2:
+    dependencies:
+      get-east-asian-width: 1.6.0
+      strip-ansi: 7.2.0
+
   string_decoder@1.3.0:
     dependencies:
       safe-buffer: 5.2.1
@@ -20076,6 +20458,10 @@ snapshots:
   strip-ansi@7.1.0:
     dependencies:
       ansi-regex: 6.1.0
+
+  strip-ansi@7.2.0:
+    dependencies:
+      ansi-regex: 6.3.0
 
   strip-bom-string@1.0.0: {}
 
@@ -20176,6 +20562,8 @@ snapshots:
       temporal-spec: 0.2.4
 
   temporal-spec@0.2.4: {}
+
+  terminal-size@4.0.1: {}
 
   terser-webpack-plugin@5.6.1(@swc/core@1.15.33)(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.23)(webpack@5.99.9(@swc/core@1.15.33)(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.23)):
     dependencies:
@@ -20659,9 +21047,18 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
+  widest-line@6.0.0:
+    dependencies:
+      string-width: 8.2.2
+
   win-guid@0.2.1: {}
 
   word-wrap@1.2.5: {}
+
+  wrap-ansi@10.0.1:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 8.2.2
 
   wrap-ansi@7.0.0:
     dependencies:
@@ -20725,6 +21122,8 @@ snapshots:
       fd-slicer: 1.1.0
 
   yocto-queue@0.1.0: {}
+
+  yoga-layout@3.2.1: {}
 
   yuku-analyzer@0.8.3:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,9 @@ catalogs:
     '@types/react-dom':
       specifier: 19.2.3
       version: 19.2.3
+    '@upstash/redis':
+      specifier: 1.37.0
+      version: 1.37.0
     ai:
       specifier: 6.0.116
       version: 6.0.116
@@ -324,7 +327,7 @@ importers:
         specifier: ^2.0.8
         version: 2.0.8(@upstash/redis@1.37.0)
       '@upstash/redis':
-        specifier: 1.37.0
+        specifier: 'catalog:'
         version: 1.37.0
       '@vercel/analytics':
         specifier: ^1.6.1
@@ -555,6 +558,9 @@ importers:
       '@supabase/supabase-js':
         specifier: 'catalog:'
         version: 2.99.2
+      '@upstash/redis':
+        specifier: 'catalog:'
+        version: 1.37.0
       ai:
         specifier: 'catalog:'
         version: 6.0.116(zod@4.4.3)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -53,6 +53,7 @@ catalog:
   "@types/node": "24.10.4"
   "@types/react": "19.2.16"
   "@types/react-dom": "19.2.3"
+  "@upstash/redis": "1.37.0"
   "ai": "6.0.116"
   "effective-progress": "0.12.0"
   "effect": "4.0.0-rc.111"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -54,6 +54,8 @@ catalog:
   "@types/react": "19.2.16"
   "@types/react-dom": "19.2.3"
   "ai": "6.0.116"
+  "effective-progress": "0.12.0"
+  "effect": "4.0.0-rc.111"
   "next": "16.3.0"
   "postcss": "8.5.23"
   "react": "19.2.7"
@@ -88,6 +90,7 @@ allowBuilds:
   core-js: true
   core-js-pure: true
   esbuild: true
+  msgpackr-extract: false
   msw: true
   onnxruntime-node: false
   protobufjs: true

--- a/scripts/.gitignore
+++ b/scripts/.gitignore
@@ -10,5 +10,6 @@ generated-speech/
 
 *.json
 !package.json
+!tsconfig.json
 
 dispute*.md

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -87,8 +87,10 @@ The command requires:
 - `KV_REST_API_TOKEN` (deletion mode)
 
 R2 credentials need list, read, and head access. Deletion mode also needs delete
-access. After deleting an object from the main dashboard bucket, the command
-evicts the matching Redis URL cache entry.
+access. The destructive loop rechecks and deletes one object at a time to keep
+the gap between the final database check and deletion small. After deleting an
+object from the main dashboard bucket, the command evicts the matching Redis URL
+cache entry.
 
 ## TypeScript maintenance scripts
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -79,9 +79,12 @@ The command requires:
 - `R2_SECRET_ACCESS_KEY`
 - `R2_BUCKET_NAME`
 - `R2_SPEECH_API_BUCKET_NAME`
+- `KV_REST_API_URL` (deletion mode)
+- `KV_REST_API_TOKEN` (deletion mode)
 
 R2 credentials need list, read, and head access. Deletion mode also needs delete
-access.
+access. After deleting an object from the main dashboard bucket, the command
+evicts the matching Redis URL cache entry.
 
 ## TypeScript maintenance scripts
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -67,6 +67,12 @@ R2 has no aggregate bucket-size response. Inventory paginates all object metadat
 to calculate bucket totals. It does not download object contents, and objects
 outside the cleanup prefixes can never become candidates.
 
+A cleanup action with `--download` requires the exact download directory to
+exist with write and traversal access. Mount the external volume and prepare
+that directory before running the action. Cleanup checks it before reading the
+manifest or touching R2, so a missing volume cannot become a backup on the
+internal disk.
+
 Download one bounded batch to an external drive with:
 
 ```bash

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -68,7 +68,9 @@ pnpm cleanup-orphaned-r2-audio -- \
 Add `--delete --yes` to delete only objects with verified local copies. To
 delete without downloading, use `--delete --force --yes`. `--force` skips only
 the local backup check. The command still validates the manifest, checks the
-allowlist, refetches database keys, and compares live R2 metadata.
+allowlist, refetches database keys, and compares live R2 metadata. Soft-deleted
+`audio_files` rows intentionally remain references and continue to protect their
+R2 objects.
 
 The command requires:
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,5 +1,39 @@
 # Scripts
 
+## R2 audio backup
+
+This command copies missing R2 objects to a local drive. It never deletes R2
+objects or local files, and it never overwrites an existing local path.
+
+Back up both complete configured buckets:
+
+```bash
+pnpm backup-r2-audio -- \
+  --download-dir /Volumes/ExternalHD/sexyvoice-r2-bucket
+```
+
+Limit the scan to one or more exact bucket prefixes:
+
+```bash
+pnpm backup-r2-audio -- \
+  --download-dir /Volumes/ExternalHD/sexyvoice-r2-bucket \
+  --source sv-audio-files/generated-audio/,sv-api-speech-audio-files
+```
+
+Use `--dry-run` to list, compare, and report without downloading. Use
+`--max-download-size 20GB` to cap new transfers. The command selects missing
+objects from oldest to newest and can fit a later small object when an older
+object exceeds the remaining cap.
+
+Files keep their full bucket and key under the destination. Existing files with
+a simple ETag receive size and MD5 verification. Files with opaque or multipart
+ETags receive size-only verification. A mismatch is reported and left untouched.
+
+The command writes `scripts/backups/r2-audio-backup-<timestamp>.json`. It
+requires `R2_ENDPOINT`, `R2_ACCESS_KEY_ID`, and `R2_SECRET_ACCESS_KEY`. Default
+sources also require `R2_BUCKET_NAME` and `R2_SPEECH_API_BUCKET_NAME`. The R2
+credentials need list and read access.
+
 ## R2 orphan audio cleanup
 
 This command inventories free-user audio objects that are at least 45 days old

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -46,10 +46,12 @@ Create an inventory manifest first:
 pnpm cleanup-orphaned-r2-audio
 ```
 
-Review the JSON under `scripts/backups/`. The inventory reports total objects and
-bytes for each configured bucket. It also reports scanned objects, objects younger
-than 45 days, old objects still referenced by the database, and orphan candidates
-for every allowed cleanup prefix.
+Review the JSON under `scripts/backups/` without editing it. The action command
+validates the candidate list and all derived totals, so use the manifest as
+generated or reject the run. The inventory reports total objects and bytes for
+each configured bucket. It also reports scanned objects, objects younger than 45
+days, old objects still referenced by the database, and orphan candidates for
+every allowed cleanup prefix.
 
 R2 has no aggregate bucket-size response. Inventory paginates all object metadata
 to calculate bucket totals. It does not download object contents, and objects

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -5,6 +5,12 @@
 This command copies missing R2 objects to a local drive. It never deletes R2
 objects or local files, and it never overwrites an existing local path.
 
+A normal run requires the exact download directory to exist with write and
+traversal access. Mount the external volume and create the backup directory
+before running the command. The startup check happens before R2 listing, so a
+missing volume cannot become a directory on the internal disk. A dry run does
+not create or require the download directory.
+
 Back up both complete configured buckets:
 
 ```bash
@@ -24,6 +30,10 @@ Use `--dry-run` to list, compare, and report without downloading. Use
 `--max-download-size 20GB` to cap new transfers. The command selects missing
 objects from oldest to newest and can fit a later small object when an older
 object exceeds the remaining cap.
+
+The package command sets `NODE_ENV=production` before loading Ink. React's
+development reconciler retains performance measurements on every Ink render and
+can exhaust the V8 heap during long transfers.
 
 Files keep their full bucket and key under the destination. Existing files with
 a simple ETag receive size and MD5 verification. Files with opaque or multipart

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,5 +1,61 @@
 # Scripts
 
+## R2 orphan audio cleanup
+
+This command inventories free-user audio objects that are at least 45 days old
+and have no matching `audio_files.storage_key`. It scans only the configured
+`generated-audio-free/` and `cloned-audio-free/` locations.
+
+Create an inventory manifest first:
+
+```bash
+pnpm cleanup-orphaned-r2-audio
+```
+
+Review the JSON under `scripts/backups/`. The inventory reports total objects and
+bytes for each configured bucket. It also reports scanned objects, objects younger
+than 45 days, old objects still referenced by the database, and orphan candidates
+for every allowed cleanup prefix.
+
+R2 has no aggregate bucket-size response. Inventory paginates all object metadata
+to calculate bucket totals. It does not download object contents, and objects
+outside the cleanup prefixes can never become candidates.
+
+Download one bounded batch to an external drive with:
+
+```bash
+pnpm cleanup-orphaned-r2-audio -- \
+  --manifest scripts/backups/r2-orphan-candidates-<timestamp>.json \
+  --download \
+  --download-dir /Volumes/ExternalHD/sexyvoice-r2-bucket \
+  --max-download-size 20GB
+```
+
+Add `--delete --yes` to delete only objects with verified local copies. To
+delete without downloading, use `--delete --force --yes`. `--force` skips only
+the local backup check. The command still validates the manifest, checks the
+allowlist, refetches database keys, and compares live R2 metadata.
+
+The command requires:
+
+- `NEXT_PUBLIC_SUPABASE_URL`
+- `SUPABASE_SECRET_KEY`
+- `R2_ENDPOINT`
+- `R2_ACCESS_KEY_ID`
+- `R2_SECRET_ACCESS_KEY`
+- `R2_BUCKET_NAME`
+- `R2_SPEECH_API_BUCKET_NAME`
+
+R2 credentials need list, read, and head access. Deletion mode also needs delete
+access.
+
+## TypeScript maintenance scripts
+
+New TypeScript maintenance scripts must call `loadScriptEnv()` from
+`lib/env.mts` and create privileged Supabase clients with
+`createScriptAdminClient()` from `lib/supabase.mts`. Keep command-specific
+warnings and confirmation policy in the command.
+
 ## Generate Gemini Speech Samples Script
 
 Generates speech samples through the public `/api/v1/speech` endpoint and saves

--- a/scripts/backfill-free-call.mts
+++ b/scripts/backfill-free-call.mts
@@ -1,13 +1,10 @@
 import { stdin as input, stdout as output } from 'node:process';
 import { createInterface } from 'node:readline/promises';
 import { parseArgs } from 'node:util';
-import { createClient } from '@supabase/supabase-js';
-import { config } from 'dotenv';
+import { loadScriptEnv } from './lib/env.mts';
+import { createScriptAdminClient as createAdminClient } from './lib/supabase.mts';
 
-// Load environment variables
-config({
-  path: ['.env', '.env.local'],
-});
+loadScriptEnv();
 
 // ---------------------------------------------------------------------------
 // Types
@@ -40,30 +37,6 @@ interface UpdateResult {
   previousValue: boolean | null;
   startedAt: string;
   userId: string;
-}
-
-// ---------------------------------------------------------------------------
-// Supabase admin client
-// ---------------------------------------------------------------------------
-
-function createAdminClient() {
-  if (!process.env.NEXT_PUBLIC_SUPABASE_URL) {
-    throw new Error('Missing env.NEXT_PUBLIC_SUPABASE_URL');
-  }
-  if (!process.env.SUPABASE_SECRET_KEY) {
-    throw new Error('Missing env.SUPABASE_SECRET_KEY');
-  }
-
-  return createClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL,
-    process.env.SUPABASE_SECRET_KEY,
-    {
-      auth: {
-        autoRefreshToken: false,
-        persistSession: false,
-      },
-    },
-  );
 }
 
 // ---------------------------------------------------------------------------

--- a/scripts/backup-r2-audio.mts
+++ b/scripts/backup-r2-audio.mts
@@ -223,7 +223,6 @@ export async function runBackup(
   }
 
   if (!options.dryRun) {
-    await mkdir(options.downloadDir, { recursive: true });
     await access(options.downloadDir, constants.W_OK);
     await access(options.downloadDir, constants.X_OK);
   }

--- a/scripts/backup-r2-audio.mts
+++ b/scripts/backup-r2-audio.mts
@@ -1,0 +1,767 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { parseArgs } from 'node:util';
+import { Effect, Result } from 'effect';
+import { all as progressAll } from 'effective-progress';
+
+import { loadScriptEnv } from './lib/env.mts';
+import { createR2Client } from './lib/r2-client.mts';
+import {
+  assertR2BucketName,
+  compareR2ObjectsOldestFirst,
+  type DownloadResult,
+  downloadWithoutOverwrite,
+  formatBytes,
+  listAllObjects,
+  parseByteSize,
+  type R2Client,
+  type R2Location,
+  type R2ObjectMetadata,
+  resolveLocalObjectPath,
+  selectByDownloadLimit,
+  UnsafeLocalPathError,
+  verifyLocalFile,
+} from './lib/r2-transfer.mts';
+
+const SCRIPT_DIRECTORY = path.dirname(fileURLToPath(import.meta.url));
+const REPOSITORY_ROOT = path.resolve(SCRIPT_DIRECTORY, '..');
+const REPORT_SCHEMA_VERSION = 1;
+const DOWNLOAD_CONCURRENCY = 4;
+
+export interface BackupCliOptions {
+  downloadDir?: string;
+  dryRun: boolean;
+  help: boolean;
+  maxDownloadBytes?: number;
+  source?: string;
+}
+
+export type BackupStatus =
+  | 'changed-in-r2'
+  | 'deferred-by-size-cap'
+  | 'download-failure'
+  | 'downloaded-checksum'
+  | 'downloaded-size'
+  | 'existing-checksum'
+  | 'existing-size'
+  | 'local-mismatch'
+  | 'local-read-failure'
+  | 'missing-from-r2'
+  | 'selected-for-download'
+  | 'unsafe-path';
+
+export interface BackupResult extends R2ObjectMetadata {
+  destination?: string;
+  reason?: string;
+  status: BackupStatus;
+}
+
+interface ListingFailure extends R2Location {
+  reason: string;
+}
+
+interface ReportTotals {
+  bytes: number;
+  count: number;
+}
+
+interface SourceStatusSummary extends R2Location, ReportTotals {
+  status: BackupStatus;
+}
+
+interface BucketStatusSummary extends ReportTotals {
+  bucket: string;
+  status: BackupStatus;
+}
+
+interface StatusSummary extends ReportTotals {
+  status: BackupStatus;
+}
+
+export interface BackupReport {
+  createdAt: string;
+  listingFailures: ListingFailure[];
+  requested: {
+    dryRun: boolean;
+    maxDownloadBytes?: number;
+    source?: string;
+  };
+  resolvedSources: R2Location[];
+  results: BackupResult[];
+  schemaVersion: 1;
+  sourceTotals: Array<R2Location & { bytes: number; count: number }>;
+  summary: {
+    byBucket: BucketStatusSummary[];
+    bySource: SourceStatusSummary[];
+    byStatus: StatusSummary[];
+  };
+}
+
+interface BackupDependencies {
+  client: R2Client;
+  interactive?: boolean;
+  log?: (message: string) => void;
+  now?: () => Date;
+  reportDirectory?: string;
+  runDownloads?: DownloadRunner;
+}
+
+type DownloadFunction = (
+  object: R2ObjectMetadata,
+  signal?: AbortSignal,
+) => Promise<DownloadResult>;
+
+type DownloadRunner = (
+  objects: R2ObjectMetadata[],
+  download: DownloadFunction,
+  selectedBytes: number,
+  interactive: boolean,
+) => Promise<DownloadResult[]>;
+
+class DownloadOutcomeError extends Error {
+  readonly outcome: DownloadResult;
+
+  constructor(outcome: DownloadResult) {
+    super(outcome.reason ?? outcome.status);
+    this.name = 'DownloadOutcomeError';
+    this.outcome = outcome;
+  }
+}
+
+export function parseBackupCliArgs(args: string[]): BackupCliOptions {
+  const normalizedArgs = args[0] === '--' ? args.slice(1) : args;
+  const { values } = parseArgs({
+    allowPositionals: false,
+    args: normalizedArgs,
+    options: {
+      'download-dir': { type: 'string' },
+      'dry-run': { default: false, type: 'boolean' },
+      help: { default: false, short: 'h', type: 'boolean' },
+      'max-download-size': { type: 'string' },
+      source: { type: 'string' },
+    },
+    strict: true,
+  });
+
+  const options: BackupCliOptions = {
+    downloadDir: values['download-dir'],
+    dryRun: values['dry-run'],
+    help: values.help,
+    maxDownloadBytes: values['max-download-size']
+      ? parseByteSize(values['max-download-size'])
+      : undefined,
+    source: values.source,
+  };
+
+  if (!(options.help || options.downloadDir?.trim())) {
+    throw new Error('--download-dir is required');
+  }
+  return options;
+}
+
+export function resolveBackupSources(
+  source: string | undefined,
+  environment: NodeJS.ProcessEnv,
+): R2Location[] {
+  const rawSources =
+    source === undefined
+      ? [
+          requiredEnv(environment, 'R2_BUCKET_NAME'),
+          requiredEnv(environment, 'R2_SPEECH_API_BUCKET_NAME'),
+        ]
+      : source.split(',');
+
+  if (rawSources.some((value) => value.trim().length === 0)) {
+    throw new Error('--source contains an empty R2 location');
+  }
+
+  const unique = new Map<string, R2Location>();
+  for (const rawSource of rawSources) {
+    const value = rawSource.trim();
+    const separator = value.indexOf('/');
+    const location = {
+      bucket: separator === -1 ? value : value.slice(0, separator),
+      prefix: separator === -1 ? '' : value.slice(separator + 1),
+    };
+    assertR2BucketName(location.bucket);
+    unique.set(sourceIdentity(location), location);
+  }
+
+  const locations = [...unique.values()];
+  for (let leftIndex = 0; leftIndex < locations.length; leftIndex += 1) {
+    for (
+      let rightIndex = leftIndex + 1;
+      rightIndex < locations.length;
+      rightIndex += 1
+    ) {
+      const left = locations[leftIndex];
+      const right = locations[rightIndex];
+      if (
+        left.bucket === right.bucket &&
+        (left.prefix.startsWith(right.prefix) ||
+          right.prefix.startsWith(left.prefix))
+      ) {
+        throw new Error(
+          `R2 sources overlap: ${displaySource(left)} and ${displaySource(right)}`,
+        );
+      }
+    }
+  }
+
+  return locations;
+}
+
+export async function runBackup(
+  options: BackupCliOptions,
+  sources: R2Location[],
+  dependencies: BackupDependencies,
+): Promise<{ exitCode: number; report: BackupReport; reportPath: string }> {
+  if (!options.downloadDir) {
+    throw new Error('--download-dir is required');
+  }
+
+  const startedAt = dependencies.now?.() ?? new Date();
+  const startedMilliseconds = startedAt.getTime();
+  const log = dependencies.log ?? console.log;
+  const reportDirectory =
+    dependencies.reportDirectory ?? path.join(SCRIPT_DIRECTORY, 'backups');
+  const reportPath = path.join(
+    reportDirectory,
+    `r2-audio-backup-${fileTimestamp(startedAt)}.json`,
+  );
+
+  const listings = await Promise.allSettled(
+    sources.map((source) => listAllObjects(dependencies.client, source)),
+  );
+  const listingFailures: ListingFailure[] = [];
+  const objectsBySource = new Map<string, R2ObjectMetadata[]>();
+
+  for (const [index, listing] of listings.entries()) {
+    const source = sources[index];
+    if (listing.status === 'rejected') {
+      listingFailures.push({
+        ...source,
+        reason: errorMessage(listing.reason),
+      });
+    } else {
+      objectsBySource.set(sourceIdentity(source), listing.value);
+    }
+  }
+
+  if (listingFailures.length > 0) {
+    const report = createBackupReport({
+      createdAt: startedAt,
+      listingFailures,
+      objectsBySource,
+      options,
+      results: [],
+      sources,
+    });
+    await writeJson(reportPath, report);
+    for (const failure of listingFailures) {
+      log(`Listing failed for ${displaySource(failure)}: ${failure.reason}`);
+    }
+    log(`Report: ${displayReportPath(reportPath)}`);
+    return { exitCode: 1, report, reportPath };
+  }
+
+  const objects = [...objectsBySource.values()]
+    .flat()
+    .sort(compareR2ObjectsOldestFirst);
+  const results = new Map<string, BackupResult>();
+  const missing: R2ObjectMetadata[] = [];
+
+  for (const object of objects) {
+    let destination: string;
+    try {
+      destination = await resolveLocalObjectPath(
+        options.downloadDir,
+        object.bucket,
+        object.key,
+      );
+    } catch (error) {
+      results.set(objectIdentity(object), {
+        ...object,
+        reason: errorMessage(error),
+        status:
+          error instanceof UnsafeLocalPathError
+            ? 'unsafe-path'
+            : 'local-read-failure',
+      });
+      continue;
+    }
+
+    const relativeDestination = path.relative(options.downloadDir, destination);
+    try {
+      const verification = await verifyLocalFile(destination, object);
+      if (verification.status === 'missing') {
+        missing.push(object);
+        continue;
+      }
+      if (verification.status === 'verified-checksum') {
+        results.set(objectIdentity(object), {
+          ...object,
+          destination: relativeDestination,
+          status: 'existing-checksum',
+        });
+        continue;
+      }
+      if (verification.status === 'verified-size') {
+        results.set(objectIdentity(object), {
+          ...object,
+          destination: relativeDestination,
+          reason: verification.reason,
+          status: 'existing-size',
+        });
+        continue;
+      }
+      results.set(objectIdentity(object), {
+        ...object,
+        destination: relativeDestination,
+        reason: verification.reason,
+        status: 'local-mismatch',
+      });
+    } catch (error) {
+      results.set(objectIdentity(object), {
+        ...object,
+        destination: relativeDestination,
+        reason: errorMessage(error),
+        status: 'local-read-failure',
+      });
+    }
+  }
+
+  const selection = options.maxDownloadBytes
+    ? selectByDownloadLimit(missing, options.maxDownloadBytes)
+    : {
+        deferred: [],
+        selected: missing,
+        transferBytes: totalBytes(missing),
+      };
+
+  for (const object of selection.deferred) {
+    results.set(objectIdentity(object), {
+      ...object,
+      destination: relativeObjectPath(object),
+      status: 'deferred-by-size-cap',
+    });
+  }
+
+  printSourceTotals(log, sources, objectsBySource);
+  printPlan(log, objects, results, missing, selection);
+
+  if (options.dryRun) {
+    for (const object of selection.selected) {
+      results.set(objectIdentity(object), {
+        ...object,
+        destination: relativeObjectPath(object),
+        status: 'selected-for-download',
+      });
+    }
+  } else if (selection.selected.length > 0) {
+    const runDownloads = dependencies.runDownloads ?? runDownloadEffects;
+    const downloads = await runDownloads(
+      selection.selected,
+      async (object, signal) => {
+        try {
+          return await downloadWithoutOverwrite(
+            dependencies.client,
+            object,
+            options.downloadDir as string,
+            signal,
+          );
+        } catch (error) {
+          return {
+            destination: '',
+            reason: errorMessage(error),
+            status: 'download-failure',
+          };
+        }
+      },
+      selection.transferBytes,
+      dependencies.interactive ?? process.stdout.isTTY === true,
+    );
+
+    if (downloads.length !== selection.selected.length) {
+      throw new Error('Download runner returned an incomplete result set');
+    }
+    for (const [index, download] of downloads.entries()) {
+      const object = selection.selected[index];
+      results.set(objectIdentity(object), {
+        ...object,
+        destination: relativeObjectPath(object),
+        reason: download.reason,
+        status: download.status,
+      });
+    }
+  }
+
+  const orderedResults = objects.map((object) => {
+    const result = results.get(objectIdentity(object));
+    if (!result) {
+      throw new Error(
+        `No backup result was recorded for ${object.bucket}/${object.key}`,
+      );
+    }
+    return result;
+  });
+  const completedAt = dependencies.now?.() ?? new Date();
+  const report = createBackupReport({
+    createdAt: startedAt,
+    listingFailures,
+    objectsBySource,
+    options,
+    results: orderedResults,
+    sources,
+  });
+  await writeJson(reportPath, report);
+  printFailures(log, orderedResults);
+  printCompletion(
+    log,
+    orderedResults,
+    Math.max(0, completedAt.getTime() - startedMilliseconds),
+    reportPath,
+  );
+
+  return {
+    exitCode: hasFailures(orderedResults) ? 1 : 0,
+    report,
+    reportPath,
+  };
+}
+
+export async function runDownloadEffects(
+  objects: R2ObjectMetadata[],
+  download: DownloadFunction,
+  selectedBytes: number,
+  interactive: boolean,
+): Promise<DownloadResult[]> {
+  const effects = objects.map((object) =>
+    Effect.flatMap(
+      Effect.tryPromise({
+        catch: (cause) =>
+          new DownloadOutcomeError({
+            destination: '',
+            reason: errorMessage(cause),
+            status: 'download-failure',
+          }),
+        try: (signal) => download(object, signal),
+      }),
+      (outcome) =>
+        isSuccessfulDownload(outcome)
+          ? Effect.succeed(outcome)
+          : Effect.fail(new DownloadOutcomeError(outcome)),
+    ),
+  );
+  const options = {
+    concurrency: DOWNLOAD_CONCURRENCY,
+    mode: 'result' as const,
+  };
+  const program = interactive
+    ? progressAll(effects, {
+        ...options,
+        description: `Downloading R2 objects (${formatBytes(selectedBytes)})`,
+      })
+    : Effect.all(effects, options);
+  const outcomes = await Effect.runPromise(program);
+
+  return outcomes.map((outcome) =>
+    Result.isSuccess(outcome) ? outcome.success : outcome.failure.outcome,
+  );
+}
+
+function createBackupReport({
+  createdAt,
+  listingFailures,
+  objectsBySource,
+  options,
+  results,
+  sources,
+}: {
+  createdAt: Date;
+  listingFailures: ListingFailure[];
+  objectsBySource: Map<string, R2ObjectMetadata[]>;
+  options: BackupCliOptions;
+  results: BackupResult[];
+  sources: R2Location[];
+}): BackupReport {
+  const bySource = new Map<string, SourceStatusSummary>();
+  const byBucket = new Map<string, BucketStatusSummary>();
+  const byStatus = new Map<BackupStatus, StatusSummary>();
+  for (const result of results) {
+    const sourceKey = `${sourceIdentity(result)}\0${result.status}`;
+    const sourceTotal = bySource.get(sourceKey) ?? {
+      bucket: result.bucket,
+      bytes: 0,
+      count: 0,
+      prefix: result.prefix,
+      status: result.status,
+    };
+    sourceTotal.bytes += result.size;
+    sourceTotal.count += 1;
+    bySource.set(sourceKey, sourceTotal);
+
+    const bucketKey = `${result.bucket}\0${result.status}`;
+    const bucketTotal = byBucket.get(bucketKey) ?? {
+      bucket: result.bucket,
+      bytes: 0,
+      count: 0,
+      status: result.status,
+    };
+    bucketTotal.bytes += result.size;
+    bucketTotal.count += 1;
+    byBucket.set(bucketKey, bucketTotal);
+
+    const statusTotal = byStatus.get(result.status) ?? {
+      bytes: 0,
+      count: 0,
+      status: result.status,
+    };
+    statusTotal.bytes += result.size;
+    statusTotal.count += 1;
+    byStatus.set(result.status, statusTotal);
+  }
+
+  return {
+    createdAt: createdAt.toISOString(),
+    listingFailures,
+    requested: {
+      dryRun: options.dryRun,
+      maxDownloadBytes: options.maxDownloadBytes,
+      source: options.source,
+    },
+    resolvedSources: sources,
+    results,
+    schemaVersion: REPORT_SCHEMA_VERSION,
+    sourceTotals: sources.map((source) => {
+      const objects = objectsBySource.get(sourceIdentity(source)) ?? [];
+      return {
+        ...source,
+        bytes: totalBytes(objects),
+        count: objects.length,
+      };
+    }),
+    summary: {
+      byBucket: [...byBucket.values()].sort(
+        (left, right) =>
+          left.bucket.localeCompare(right.bucket) ||
+          left.status.localeCompare(right.status),
+      ),
+      bySource: [...bySource.values()].sort(
+        (left, right) =>
+          left.bucket.localeCompare(right.bucket) ||
+          left.prefix.localeCompare(right.prefix) ||
+          left.status.localeCompare(right.status),
+      ),
+      byStatus: [...byStatus.values()].sort((left, right) =>
+        left.status.localeCompare(right.status),
+      ),
+    },
+  };
+}
+
+function printSourceTotals(
+  log: (message: string) => void,
+  sources: R2Location[],
+  objectsBySource: Map<string, R2ObjectMetadata[]>,
+): void {
+  log('Source totals');
+  for (const source of sources) {
+    const objects = objectsBySource.get(sourceIdentity(source)) ?? [];
+    log(
+      `  ${displaySource(source)}: ${objects.length} objects, ${formatBytes(totalBytes(objects))}`,
+    );
+  }
+}
+
+function printPlan(
+  log: (message: string) => void,
+  objects: R2ObjectMetadata[],
+  results: Map<string, BackupResult>,
+  missing: R2ObjectMetadata[],
+  selection: {
+    deferred: R2ObjectMetadata[];
+    selected: R2ObjectMetadata[];
+    transferBytes: number;
+  },
+): void {
+  const existing = objects.filter((object) => {
+    const status = results.get(objectIdentity(object))?.status;
+    return status === 'existing-checksum' || status === 'existing-size';
+  });
+  log('Transfer plan');
+  log(`  existing: ${formatObjectTotals(existing)}`);
+  log(`  missing: ${formatObjectTotals(missing)}`);
+  log(`  deferred: ${formatObjectTotals(selection.deferred)}`);
+  log(`  selected: ${formatObjectTotals(selection.selected)}`);
+}
+
+function printFailures(
+  log: (message: string) => void,
+  results: BackupResult[],
+): void {
+  for (const result of results.filter((entry) =>
+    isFailureStatus(entry.status),
+  )) {
+    log(
+      `Failed ${result.bucket}/${result.key} [${result.status}]: ${result.reason ?? 'No reason returned'}`,
+    );
+  }
+}
+
+function printCompletion(
+  log: (message: string) => void,
+  results: BackupResult[],
+  elapsedMilliseconds: number,
+  reportPath: string,
+): void {
+  const downloaded = results.filter((result) =>
+    result.status.startsWith('downloaded-'),
+  );
+  const checksumVerified = results.filter(
+    (result) =>
+      result.status === 'downloaded-checksum' ||
+      result.status === 'existing-checksum',
+  );
+  const sizeVerified = results.filter(
+    (result) =>
+      result.status === 'downloaded-size' || result.status === 'existing-size',
+  );
+  const failed = results.filter((result) => isFailureStatus(result.status));
+  const downloadedBytes = totalBytes(downloaded);
+  const seconds = elapsedMilliseconds / 1000;
+  const averageBytesPerSecond = seconds > 0 ? downloadedBytes / seconds : 0;
+
+  log('Backup complete');
+  log(`  downloaded: ${formatObjectTotals(downloaded)}`);
+  log(`  checksum verified: ${formatObjectTotals(checksumVerified)}`);
+  log(`  size verified: ${formatObjectTotals(sizeVerified)}`);
+  log(`  failed: ${formatObjectTotals(failed)}`);
+  log(`  elapsed: ${formatDuration(elapsedMilliseconds)}`);
+  log(`  average rate: ${formatBytes(averageBytesPerSecond)}/s`);
+  log(`Report: ${displayReportPath(reportPath)}`);
+}
+
+function hasFailures(results: BackupResult[]): boolean {
+  return results.some((result) => isFailureStatus(result.status));
+}
+
+function isFailureStatus(status: BackupStatus): boolean {
+  return (
+    status === 'changed-in-r2' ||
+    status === 'download-failure' ||
+    status === 'local-mismatch' ||
+    status === 'local-read-failure' ||
+    status === 'missing-from-r2' ||
+    status === 'unsafe-path'
+  );
+}
+
+function isSuccessfulDownload(result: DownloadResult): boolean {
+  return (
+    result.status === 'downloaded-checksum' ||
+    result.status === 'downloaded-size' ||
+    result.status === 'existing-checksum' ||
+    result.status === 'existing-size'
+  );
+}
+
+function relativeObjectPath(object: R2ObjectMetadata): string {
+  return path.join(object.bucket, object.key);
+}
+
+function formatObjectTotals(objects: Array<{ size: number }>): string {
+  return `${objects.length} objects, ${formatBytes(totalBytes(objects))}`;
+}
+
+function totalBytes(objects: Array<{ size: number }>): number {
+  return objects.reduce((sum, object) => sum + object.size, 0);
+}
+
+function formatDuration(milliseconds: number): string {
+  const seconds = milliseconds / 1000;
+  return seconds < 10 ? `${seconds.toFixed(1)}s` : `${Math.round(seconds)}s`;
+}
+
+function sourceIdentity(source: R2Location): string {
+  return `${source.bucket}\0${source.prefix}`;
+}
+
+function objectIdentity(
+  object: Pick<R2ObjectMetadata, 'bucket' | 'key'>,
+): string {
+  return `${object.bucket}\0${object.key}`;
+}
+
+function displaySource(source: R2Location): string {
+  return source.prefix ? `${source.bucket}/${source.prefix}` : source.bucket;
+}
+
+function displayReportPath(reportPath: string): string {
+  const relative = path.relative(REPOSITORY_ROOT, reportPath);
+  return relative.startsWith('..') ? reportPath : relative;
+}
+
+function fileTimestamp(date: Date): string {
+  return date.toISOString().replace(/[:.]/g, '-');
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function requiredEnv(environment: NodeJS.ProcessEnv, name: string): string {
+  const value = environment[name];
+  if (!value) {
+    throw new Error(`Missing env.${name}`);
+  }
+  return value;
+}
+
+async function writeJson(filePath: string, value: unknown): Promise<void> {
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`, {
+    encoding: 'utf8',
+    flag: 'wx',
+  });
+}
+
+function printHelp(): void {
+  console.log(`Back up R2 audio to a local directory without overwriting files.
+
+Usage:
+  pnpm backup-r2-audio -- --download-dir <path> [options]
+
+Options:
+  --download-dir <path>       Required local backup directory
+  --source <locations>        Comma-separated bucket or bucket/prefix sources
+  --max-download-size <size>  Transfer cap, such as 20GB or 500MiB
+  --dry-run                   Scan and compare without downloading
+  -h, --help                  Show this help`);
+}
+
+async function main(): Promise<void> {
+  loadScriptEnv();
+  const options = parseBackupCliArgs(process.argv.slice(2));
+  if (options.help) {
+    printHelp();
+    return;
+  }
+
+  const sources = resolveBackupSources(options.source, process.env);
+  const result = await runBackup(options, sources, {
+    client: createR2Client(),
+  });
+  process.exitCode = result.exitCode;
+}
+
+const entryPoint = process.argv[1]
+  ? pathToFileURL(path.resolve(process.argv[1])).href
+  : undefined;
+if (entryPoint === import.meta.url) {
+  main().catch((error: unknown) => {
+    console.error(errorMessage(error));
+    process.exitCode = 1;
+  });
+}

--- a/scripts/backup-r2-audio.mts
+++ b/scripts/backup-r2-audio.mts
@@ -1,4 +1,5 @@
-import { mkdir, writeFile } from 'node:fs/promises';
+import { constants } from 'node:fs';
+import { access, mkdir, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { parseArgs } from 'node:util';
@@ -219,6 +220,12 @@ export async function runBackup(
 ): Promise<{ exitCode: number; report: BackupReport; reportPath: string }> {
   if (!options.downloadDir) {
     throw new Error('--download-dir is required');
+  }
+
+  if (!options.dryRun) {
+    await mkdir(options.downloadDir, { recursive: true });
+    await access(options.downloadDir, constants.W_OK);
+    await access(options.downloadDir, constants.X_OK);
   }
 
   const startedAt = dependencies.now?.() ?? new Date();

--- a/scripts/backup-r2-audio.mts
+++ b/scripts/backup-r2-audio.mts
@@ -1,5 +1,4 @@
-import { constants } from 'node:fs';
-import { access, mkdir, writeFile } from 'node:fs/promises';
+import { mkdir, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { parseArgs } from 'node:util';
@@ -10,6 +9,7 @@ import { loadScriptEnv } from './lib/env.mts';
 import { createR2Client } from './lib/r2-client.mts';
 import {
   assertR2BucketName,
+  assertUsableDownloadRoot,
   compareR2ObjectsOldestFirst,
   type DownloadResult,
   downloadWithoutOverwrite,
@@ -223,8 +223,7 @@ export async function runBackup(
   }
 
   if (!options.dryRun) {
-    await access(options.downloadDir, constants.W_OK);
-    await access(options.downloadDir, constants.X_OK);
+    await assertUsableDownloadRoot(options.downloadDir);
   }
 
   const startedAt = dependencies.now?.() ?? new Date();

--- a/scripts/backup-r2-audio.mts
+++ b/scripts/backup-r2-audio.mts
@@ -332,13 +332,14 @@ export async function runBackup(
     }
   }
 
-  const selection = options.maxDownloadBytes
-    ? selectByDownloadLimit(missing, options.maxDownloadBytes)
-    : {
-        deferred: [],
-        selected: missing,
-        transferBytes: totalBytes(missing),
-      };
+  const selection =
+    options.maxDownloadBytes === undefined
+      ? {
+          deferred: [],
+          selected: missing,
+          transferBytes: totalBytes(missing),
+        }
+      : selectByDownloadLimit(missing, options.maxDownloadBytes);
 
   for (const object of selection.deferred) {
     results.set(objectIdentity(object), {

--- a/scripts/batch-refund-credits.mts
+++ b/scripts/batch-refund-credits.mts
@@ -1,10 +1,10 @@
 import { readFileSync } from 'node:fs';
 import { stdin as input, stdout as output } from 'node:process';
 import { createInterface } from 'node:readline/promises';
-import { createClient } from '@supabase/supabase-js';
-import { config } from 'dotenv';
+import { loadScriptEnv } from './lib/env.mts';
+import { createScriptAdminClient as createAdminClient } from './lib/supabase.mts';
 
-config({ path: ['.env', '.env.local'] });
+loadScriptEnv();
 
 interface DupeRow {
   duplicateCredits: number;
@@ -21,20 +21,6 @@ interface RefundResult {
   sourceId: string;
   status: 'ok' | 'skipped' | 'error';
   userId: string;
-}
-
-function createAdminClient() {
-  if (!process.env.NEXT_PUBLIC_SUPABASE_URL) {
-    throw new Error('Missing env.NEXT_PUBLIC_SUPABASE_URL');
-  }
-  if (!process.env.SUPABASE_SECRET_KEY) {
-    throw new Error('Missing env.SUPABASE_SECRET_KEY');
-  }
-  return createClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL,
-    process.env.SUPABASE_SECRET_KEY,
-    { auth: { autoRefreshToken: false, persistSession: false } },
-  );
 }
 
 function parseCsv(filePath: string): DupeRow[] {

--- a/scripts/cleanup-orphaned-r2-audio.mts
+++ b/scripts/cleanup-orphaned-r2-audio.mts
@@ -1,6 +1,7 @@
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { Redis } from '@upstash/redis';
 
 import { loadScriptEnv } from './lib/env.mts';
 import { createR2Client } from './lib/r2-client.mts';
@@ -11,6 +12,7 @@ import {
   type CleanupConfig,
   createManifest,
   deleteCandidatesInBatches,
+  evictDeletedAudioCache,
   fetchAllStorageKeys,
   filterAllowedInventoryObjects,
   type InventorySummaryEntry,
@@ -367,6 +369,12 @@ async function runAction(
   if (options.delete) {
     const requestedDeletes = options.download ? backedUp : eligible;
     const storageKeys = createStorageKeySource();
+    const redis = Redis.fromEnv();
+    const audioUrlCache = {
+      async deleteKey(key: string): Promise<void> {
+        await redis.del(key);
+      },
+    };
 
     for (const candidate of requestedDeletes) {
       const identity = objectIdentity(candidate);
@@ -459,6 +467,26 @@ async function runAction(
       }
 
       const [deletion] = await deleteCandidatesInBatches(r2, [candidate], 1);
+      if (deletion.status === 'deleted') {
+        try {
+          await evictDeletedAudioCache(
+            candidate,
+            config.mainBucket,
+            audioUrlCache,
+          );
+        } catch (error) {
+          results.set(identity, {
+            ...candidate,
+            backup: previous?.backup,
+            destination: previous?.destination,
+            reason: `R2 object was deleted, but Redis cache eviction failed: ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+            status: 'deletion-failure',
+          });
+          continue;
+        }
+      }
       results.set(identity, {
         ...candidate,
         backup: previous?.backup,

--- a/scripts/cleanup-orphaned-r2-audio.mts
+++ b/scripts/cleanup-orphaned-r2-audio.mts
@@ -1,14 +1,16 @@
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { Redis } from '@upstash/redis';
 
 import { loadScriptEnv } from './lib/env.mts';
 import { createR2Client } from './lib/r2-client.mts';
 import {
+  type AudioUrlCache,
   analyzeInventory,
   type BucketSummary,
   buildAllowedLocations,
+  type CleanupCliOptions,
   type CleanupConfig,
   createManifest,
   deleteCandidatesInBatches,
@@ -36,8 +38,6 @@ import {
 } from './lib/r2-transfer.mts';
 import { createScriptAdminClient } from './lib/supabase.mts';
 
-loadScriptEnv();
-
 const SCRIPT_DIRECTORY = path.dirname(fileURLToPath(import.meta.url));
 const REPOSITORY_ROOT = path.resolve(SCRIPT_DIRECTORY, '..');
 
@@ -63,11 +63,11 @@ type ActionStatus =
   | 'verified-download'
   | 'verified-existing-file';
 
-interface ScriptStorageKeySource extends StorageKeyPageSource {
+export interface ScriptStorageKeySource extends StorageKeyPageSource {
   hasStorageKey: (key: string) => Promise<boolean>;
 }
 
-interface ActionReport {
+export interface ActionReport {
   createdAt: string;
   manifest: string;
   requested: {
@@ -85,6 +85,21 @@ interface ActionReport {
     prefix: string;
     status: ActionStatus;
   }>;
+}
+
+export interface ActionDependencies {
+  audioUrlCache?: AudioUrlCache;
+  client: R2Client;
+  log?: (message: string) => void;
+  now?: () => Date;
+  storageKeys: ScriptStorageKeySource;
+  writeReport?: (reportPath: string, report: ActionReport) => Promise<void>;
+}
+
+export interface ActionRunResult {
+  exitCode: 0 | 1;
+  report: ActionReport;
+  reportPath: string;
 }
 
 function printHelp(): void {
@@ -160,7 +175,16 @@ function createStorageKeySource(): ScriptStorageKeySource {
   };
 }
 
-async function runInventory(
+function createAudioUrlCache(): AudioUrlCache {
+  const redis = Redis.fromEnv();
+  return {
+    async deleteKey(key): Promise<void> {
+      await redis.del(key);
+    },
+  };
+}
+
+export async function runInventory(
   config: CleanupConfig,
   r2: R2Client,
 ): Promise<void> {
@@ -203,11 +227,13 @@ async function runInventory(
   printInventorySummary(inventory.summary);
 }
 
-async function runAction(
-  options: ReturnType<typeof parseCleanupCliArgs>,
+export async function runAction(
+  options: CleanupCliOptions,
   config: CleanupConfig,
-  r2: R2Client,
-): Promise<void> {
+  dependencies: ActionDependencies,
+): Promise<ActionRunResult> {
+  const r2 = dependencies.client;
+  const now = dependencies.now ?? (() => new Date());
   const manifestPath = await resolveExistingInputPath(
     options.manifest as string,
   );
@@ -230,7 +256,7 @@ async function runAction(
   const results = new Map<string, ActionReportEntry>();
   let databaseKeys: Set<string>;
   try {
-    databaseKeys = await fetchAllStorageKeys(createStorageKeySource());
+    databaseKeys = await fetchAllStorageKeys(dependencies.storageKeys);
   } catch (error) {
     const reason = error instanceof Error ? error.message : String(error);
     const failedResults = manifest.candidates.map((candidate) => ({
@@ -238,9 +264,12 @@ async function runAction(
       reason,
       status: 'database-check-failure' as const,
     }));
-    await writeActionReport(manifestPath, options, failedResults);
-    process.exitCode = 1;
-    return;
+    return writeActionReport(
+      manifestPath,
+      options,
+      failedResults,
+      dependencies,
+    );
   }
 
   const initialChecks = await recheckCandidates(
@@ -248,7 +277,7 @@ async function runAction(
     databaseKeys,
     r2,
     locations,
-    new Date(),
+    now(),
   );
   const eligible: R2ObjectMetadata[] = [];
 
@@ -368,13 +397,11 @@ async function runAction(
 
   if (options.delete) {
     const requestedDeletes = options.download ? backedUp : eligible;
-    const storageKeys = createStorageKeySource();
-    const redis = Redis.fromEnv();
-    const audioUrlCache = {
-      async deleteKey(key: string): Promise<void> {
-        await redis.del(key);
-      },
-    };
+    const storageKeys = dependencies.storageKeys;
+    const audioUrlCache = dependencies.audioUrlCache;
+    if (!audioUrlCache) {
+      throw new Error('Delete actions require an audio URL cache client');
+    }
 
     for (const candidate of requestedDeletes) {
       const identity = objectIdentity(candidate);
@@ -453,7 +480,7 @@ async function runAction(
         new Set(),
         r2,
         locations,
-        new Date(),
+        now(),
       );
       if (check.status !== 'eligible') {
         results.set(identity, {
@@ -506,20 +533,23 @@ async function runAction(
     }
     return result;
   });
-  await writeActionReport(manifestPath, options, orderedResults);
+  return writeActionReport(manifestPath, options, orderedResults, dependencies);
 }
 
 async function writeActionReport(
   manifestPath: string,
-  options: ReturnType<typeof parseCleanupCliArgs>,
+  options: CleanupCliOptions,
   results: ActionReportEntry[],
-): Promise<void> {
-  const report = createActionReport(manifestPath, options, results);
-  const reportPath = actionReportPath(manifestPath, new Date());
-  await writeJson(reportPath, report);
+  dependencies: Pick<ActionDependencies, 'log' | 'now' | 'writeReport'>,
+): Promise<ActionRunResult> {
+  const createdAt = dependencies.now?.() ?? new Date();
+  const report = createActionReport(manifestPath, options, results, createdAt);
+  const reportPath = actionReportPath(manifestPath, createdAt);
+  await (dependencies.writeReport ?? writeJson)(reportPath, report);
 
-  console.log(`Report: ${path.relative(REPOSITORY_ROOT, reportPath)}`);
-  printActionSummary(report);
+  const log = dependencies.log ?? console.log;
+  log(`Report: ${path.relative(REPOSITORY_ROOT, reportPath)}`);
+  printActionSummary(report, log);
 
   const failureStatuses = new Set<ActionStatus>([
     'database-check-failure',
@@ -528,15 +558,17 @@ async function writeActionReport(
     'local-mismatch',
     'r2-check-failure',
   ]);
-  if (results.some((result) => failureStatuses.has(result.status))) {
-    process.exitCode = 1;
-  }
+  const exitCode = results.some((result) => failureStatuses.has(result.status))
+    ? 1
+    : 0;
+  return { exitCode, report, reportPath };
 }
 
 function createActionReport(
   manifestPath: string,
-  options: ReturnType<typeof parseCleanupCliArgs>,
+  options: CleanupCliOptions,
   results: ActionReportEntry[],
+  createdAt: Date,
 ): ActionReport {
   const groups = new Map<string, ActionReport['summary'][number]>();
 
@@ -555,7 +587,7 @@ function createActionReport(
   }
 
   return {
-    createdAt: new Date().toISOString(),
+    createdAt: createdAt.toISOString(),
     manifest: path.relative(REPOSITORY_ROOT, manifestPath),
     requested: {
       delete: options.delete,
@@ -645,9 +677,12 @@ function formatTotals(totals: { bytes: number; count: number }): string {
   return `${totals.count} objects, ${formatBytes(totals.bytes)}`;
 }
 
-function printActionSummary(report: ActionReport): void {
+function printActionSummary(
+  report: ActionReport,
+  log: (message: string) => void,
+): void {
   for (const row of report.summary) {
-    console.log(
+    log(
       `${row.bucket}/${row.prefix} ${row.status}: ${row.count} objects, ${formatBytes(row.bytes)}`,
     );
   }
@@ -673,6 +708,7 @@ function isNodeError(
 }
 
 async function main(): Promise<void> {
+  loadScriptEnv();
   const options = parseCleanupCliArgs(process.argv.slice(2));
   if (options.help) {
     printHelp();
@@ -686,14 +722,24 @@ async function main(): Promise<void> {
     if (options.download && options.force) {
       console.log('--force is ignored because --download is active.');
     }
-    await runAction(options, config, r2);
+    const result = await runAction(options, config, {
+      audioUrlCache: options.delete ? createAudioUrlCache() : undefined,
+      client: r2,
+      storageKeys: createStorageKeySource(),
+    });
+    process.exitCode = result.exitCode;
     return;
   }
 
   await runInventory(config, r2);
 }
 
-main().catch((error: unknown) => {
-  console.error(error instanceof Error ? error.message : String(error));
-  process.exitCode = 1;
-});
+const entryPoint = process.argv[1]
+  ? pathToFileURL(path.resolve(process.argv[1])).href
+  : undefined;
+if (entryPoint === import.meta.url) {
+  main().catch((error: unknown) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}

--- a/scripts/cleanup-orphaned-r2-audio.mts
+++ b/scripts/cleanup-orphaned-r2-audio.mts
@@ -410,53 +410,121 @@ export async function runAction(
       const identity = objectIdentity(candidate);
       const previous = results.get(identity);
 
-      if (options.download) {
-        const destination = previous?.destination;
-        if (!destination) {
-          results.set(identity, {
-            ...candidate,
-            backup: previous?.backup,
-            reason: 'Verified backup path is missing from the action state',
-            status: 'deletion-failure',
-          });
-          continue;
+      try {
+        if (options.download) {
+          const destination = previous?.destination;
+          if (!destination) {
+            results.set(identity, {
+              ...candidate,
+              backup: previous?.backup,
+              reason: 'Verified backup path is missing from the action state',
+              status: 'deletion-failure',
+            });
+            continue;
+          }
+
+          let verification: Awaited<ReturnType<typeof verifyLocalFile>>;
+          try {
+            verification = await verifyLocalFile(destination, candidate);
+          } catch (error) {
+            results.set(identity, {
+              ...candidate,
+              backup: previous?.backup,
+              destination,
+              reason: error instanceof Error ? error.message : String(error),
+              status: 'deletion-failure',
+            });
+            continue;
+          }
+
+          if (verification.status !== 'verified-checksum') {
+            results.set(identity, {
+              ...candidate,
+              backup: previous?.backup,
+              destination,
+              reason:
+                'reason' in verification
+                  ? verification.reason
+                  : 'Local backup is missing',
+              status:
+                verification.status === 'verified-size'
+                  ? 'unverifiable-checksum'
+                  : 'local-mismatch',
+            });
+            continue;
+          }
         }
 
-        let verification: Awaited<ReturnType<typeof verifyLocalFile>>;
+        let referenced: boolean;
         try {
-          verification = await verifyLocalFile(destination, candidate);
+          referenced = await storageKeys.hasStorageKey(candidate.key);
         } catch (error) {
           results.set(identity, {
             ...candidate,
             backup: previous?.backup,
-            destination,
+            destination: previous?.destination,
             reason: error instanceof Error ? error.message : String(error),
             status: 'deletion-failure',
           });
           continue;
         }
 
-        if (verification.status !== 'verified-checksum') {
+        if (referenced) {
           results.set(identity, {
             ...candidate,
             backup: previous?.backup,
-            destination,
-            reason:
-              'reason' in verification
-                ? verification.reason
-                : 'Local backup is missing',
-            status:
-              verification.status === 'verified-size'
-                ? 'unverifiable-checksum'
-                : 'local-mismatch',
+            destination: previous?.destination,
+            status: 'referenced-by-database',
           });
           continue;
         }
-      }
 
-      let referenced: boolean;
-      try {
-        referenced = await storageKeys.hasStorageKey(candidate.key);
+        const [check] = await recheckCandidates(
+          [candidate],
+          new Set(),
+          r2,
+          locations,
+          now(),
+        );
+        if (check.status !== 'eligible') {
+          results.set(identity, {
+            ...candidate,
+            backup: previous?.backup,
+            destination: previous?.destination,
+            reason: check.reason,
+            status: check.status,
+          });
+          continue;
+        }
+
+        const [deletion] = await deleteCandidatesInBatches(r2, [candidate], 1);
+        if (deletion.status === 'deleted') {
+          try {
+            await evictDeletedAudioCache(
+              candidate,
+              config.mainBucket,
+              audioUrlCache,
+            );
+          } catch (error) {
+            results.set(identity, {
+              ...candidate,
+              backup: previous?.backup,
+              destination: previous?.destination,
+              reason: `R2 object was deleted, but Redis cache eviction failed: ${
+                error instanceof Error ? error.message : String(error)
+              }`,
+              status: 'deletion-failure',
+            });
+            continue;
+          }
+        }
+        results.set(identity, {
+          ...candidate,
+          backup: previous?.backup,
+          destination: previous?.destination,
+          reason: deletion.reason,
+          status: deletion.status,
+        });
       } catch (error) {
         results.set(identity, {
           ...candidate,
@@ -465,65 +533,7 @@ export async function runAction(
           reason: error instanceof Error ? error.message : String(error),
           status: 'deletion-failure',
         });
-        continue;
       }
-
-      if (referenced) {
-        results.set(identity, {
-          ...candidate,
-          backup: previous?.backup,
-          destination: previous?.destination,
-          status: 'referenced-by-database',
-        });
-        continue;
-      }
-
-      const [check] = await recheckCandidates(
-        [candidate],
-        new Set(),
-        r2,
-        locations,
-        now(),
-      );
-      if (check.status !== 'eligible') {
-        results.set(identity, {
-          ...candidate,
-          backup: previous?.backup,
-          destination: previous?.destination,
-          reason: check.reason,
-          status: check.status,
-        });
-        continue;
-      }
-
-      const [deletion] = await deleteCandidatesInBatches(r2, [candidate], 1);
-      if (deletion.status === 'deleted') {
-        try {
-          await evictDeletedAudioCache(
-            candidate,
-            config.mainBucket,
-            audioUrlCache,
-          );
-        } catch (error) {
-          results.set(identity, {
-            ...candidate,
-            backup: previous?.backup,
-            destination: previous?.destination,
-            reason: `R2 object was deleted, but Redis cache eviction failed: ${
-              error instanceof Error ? error.message : String(error)
-            }`,
-            status: 'deletion-failure',
-          });
-          continue;
-        }
-      }
-      results.set(identity, {
-        ...candidate,
-        backup: previous?.backup,
-        destination: previous?.destination,
-        reason: deletion.reason,
-        status: deletion.status,
-      });
     }
   }
 

--- a/scripts/cleanup-orphaned-r2-audio.mts
+++ b/scripts/cleanup-orphaned-r2-audio.mts
@@ -144,6 +144,8 @@ function readConfig(): CleanupConfig {
 function createStorageKeySource(): ScriptStorageKeySource {
   const supabase = createScriptAdminClient();
 
+  // audio_files uses soft deletion. Keep every row in these checks so a future
+  // status filter cannot turn user-deleted history into cleanup candidates.
   return {
     async hasStorageKey(key) {
       const { data, error } = await supabase

--- a/scripts/cleanup-orphaned-r2-audio.mts
+++ b/scripts/cleanup-orphaned-r2-audio.mts
@@ -1,41 +1,37 @@
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import {
-  DeleteObjectsCommand,
-  GetObjectCommand,
-  HeadObjectCommand,
-  ListObjectsV2Command,
-  S3Client,
-} from '@aws-sdk/client-s3';
 
 import { loadScriptEnv } from './lib/env.mts';
+import { createR2Client } from './lib/r2-client.mts';
 import {
   analyzeInventory,
-  buildAllowedLocations,
   type BucketSummary,
+  buildAllowedLocations,
   type CleanupConfig,
-  type CleanupR2Client,
   createManifest,
   deleteCandidatesInBatches,
-  downloadWithoutOverwrite,
   fetchAllStorageKeys,
   filterAllowedInventoryObjects,
   type InventorySummaryEntry,
-  listAllObjects,
   MINIMUM_AGE_DAYS,
   objectIdentity,
   parseCleanupCliArgs,
-  type R2DeleteResponse,
-  type R2ObjectMetadata,
   recheckCandidates,
-  resolveLocalObjectPath,
   type StorageKeyPageSource,
-  selectByDownloadLimit,
   summarizeBuckets,
   validateManifest,
-  verifyLocalFile,
 } from './lib/r2-orphan-audio-cleanup.mts';
+import {
+  downloadWithoutOverwrite,
+  formatBytes,
+  listAllObjects,
+  type R2Client,
+  type R2ObjectMetadata,
+  resolveLocalObjectPath,
+  selectByDownloadLimit,
+  verifyLocalFile,
+} from './lib/r2-transfer.mts';
 import { createScriptAdminClient } from './lib/supabase.mts';
 
 loadScriptEnv();
@@ -128,95 +124,6 @@ function readConfig(): CleanupConfig {
   };
 }
 
-function createR2Client(): CleanupR2Client {
-  const client = new S3Client({
-    credentials: {
-      accessKeyId: requiredEnv('R2_ACCESS_KEY_ID'),
-      secretAccessKey: requiredEnv('R2_SECRET_ACCESS_KEY'),
-    },
-    endpoint: requiredEnv('R2_ENDPOINT'),
-    region: 'auto',
-  });
-
-  return {
-    async deleteObjects(bucket, keys): Promise<R2DeleteResponse> {
-      const response = await client.send(
-        new DeleteObjectsCommand({
-          Bucket: bucket,
-          Delete: {
-            Objects: keys.map((Key) => ({ Key })),
-            Quiet: false,
-          },
-        }),
-      );
-
-      return {
-        deleted: (response.Deleted ?? [])
-          .map((object) => object.Key)
-          .filter((key): key is string => Boolean(key)),
-        errors: (response.Errors ?? [])
-          .filter((error) => Boolean(error.Key))
-          .map((error) => ({
-            code: error.Code,
-            key: error.Key as string,
-            message: error.Message,
-          })),
-      };
-    },
-
-    async getObject(bucket, key, expectedEtag) {
-      const response = await client.send(
-        new GetObjectCommand({
-          Bucket: bucket,
-          IfMatch: `"${expectedEtag}"`,
-          Key: key,
-        }),
-      );
-      if (!(response.Body && Symbol.asyncIterator in response.Body)) {
-        throw new Error(`R2 returned no streaming body for ${bucket}/${key}`);
-      }
-      return response.Body as AsyncIterable<Uint8Array>;
-    },
-
-    async headObject(bucket, key) {
-      try {
-        const response = await client.send(
-          new HeadObjectCommand({ Bucket: bucket, Key: key }),
-        );
-        return {
-          etag: response.ETag,
-          lastModified: response.LastModified,
-          size: response.ContentLength,
-        };
-      } catch (error) {
-        if (isNotFound(error)) {
-          return null;
-        }
-        throw error;
-      }
-    },
-
-    async listObjects(bucket, prefix, continuationToken) {
-      const response = await client.send(
-        new ListObjectsV2Command({
-          Bucket: bucket,
-          ContinuationToken: continuationToken,
-          Prefix: prefix,
-        }),
-      );
-      return {
-        nextContinuationToken: response.NextContinuationToken,
-        objects: (response.Contents ?? []).map((object) => ({
-          etag: object.ETag,
-          key: object.Key,
-          lastModified: object.LastModified,
-          size: object.Size,
-        })),
-      };
-    },
-  };
-}
-
 function createStorageKeySource(): ScriptStorageKeySource {
   const supabase = createScriptAdminClient();
 
@@ -253,7 +160,7 @@ function createStorageKeySource(): ScriptStorageKeySource {
 
 async function runInventory(
   config: CleanupConfig,
-  r2: CleanupR2Client,
+  r2: R2Client,
 ): Promise<void> {
   const now = new Date();
   const locations = buildAllowedLocations(config);
@@ -297,7 +204,7 @@ async function runInventory(
 async function runAction(
   options: ReturnType<typeof parseCleanupCliArgs>,
   config: CleanupConfig,
-  r2: CleanupR2Client,
+  r2: R2Client,
 ): Promise<void> {
   const manifestPath = await resolveExistingInputPath(
     options.manifest as string,
@@ -310,7 +217,7 @@ async function runAction(
 
   if (options.download) {
     for (const candidate of manifest.candidates) {
-      resolveLocalObjectPath(
+      await resolveLocalObjectPath(
         options.downloadDir as string,
         candidate.bucket,
         candidate.key,
@@ -360,7 +267,7 @@ async function runAction(
     const missingLocally: R2ObjectMetadata[] = [];
 
     for (const candidate of eligible) {
-      const destination = resolveLocalObjectPath(
+      const destination = await resolveLocalObjectPath(
         options.downloadDir as string,
         candidate.bucket,
         candidate.key,
@@ -378,7 +285,7 @@ async function runAction(
         continue;
       }
 
-      if (verification.status === 'verified') {
+      if (verification.status === 'verified-checksum') {
         backedUp.push(candidate);
         results.set(objectIdentity(candidate), {
           ...candidate,
@@ -394,7 +301,7 @@ async function runAction(
           destination,
           reason: verification.reason,
           status:
-            verification.status === 'unverifiable'
+            verification.status === 'verified-size'
               ? 'unverifiable-checksum'
               : 'local-mismatch',
         });
@@ -418,26 +325,40 @@ async function runAction(
         candidate,
         options.downloadDir as string,
       );
-      if (download.status === 'downloaded' || download.status === 'exists') {
+      if (
+        download.status === 'downloaded-checksum' ||
+        download.status === 'existing-checksum'
+      ) {
         backedUp.push(candidate);
         results.set(objectIdentity(candidate), {
           ...candidate,
-          backup: download.status === 'downloaded' ? 'downloaded' : 'existing',
+          backup:
+            download.status === 'downloaded-checksum'
+              ? 'downloaded'
+              : 'existing',
           destination: download.destination,
           status:
-            download.status === 'downloaded'
+            download.status === 'downloaded-checksum'
               ? 'verified-download'
               : 'verified-existing-file',
         });
       } else {
+        let status: ActionStatus = 'download-failure';
+        if (
+          download.status === 'downloaded-size' ||
+          download.status === 'existing-size'
+        ) {
+          status = 'unverifiable-checksum';
+        } else if (download.status === 'changed-in-r2') {
+          status = 'changed-in-r2';
+        } else if (download.status === 'missing-from-r2') {
+          status = 'missing-from-r2';
+        }
         results.set(objectIdentity(candidate), {
           ...candidate,
           destination: download.destination,
           reason: download.reason,
-          status:
-            download.status === 'unverifiable'
-              ? 'unverifiable-checksum'
-              : 'download-failure',
+          status,
         });
       }
     }
@@ -477,14 +398,17 @@ async function runAction(
           continue;
         }
 
-        if (verification.status !== 'verified') {
+        if (verification.status !== 'verified-checksum') {
           results.set(identity, {
             ...candidate,
             backup: previous?.backup,
             destination,
-            reason: verification.reason,
+            reason:
+              'reason' in verification
+                ? verification.reason
+                : 'Local backup is missing',
             status:
-              verification.status === 'unverifiable'
+              verification.status === 'verified-size'
                 ? 'unverifiable-checksum'
                 : 'local-mismatch',
           });
@@ -701,22 +625,6 @@ function printActionSummary(report: ActionReport): void {
   }
 }
 
-function formatBytes(bytes: number): string {
-  const units = ['B', 'KiB', 'MiB', 'GiB', 'TiB'];
-  let value = bytes;
-  let unit = units[0];
-
-  for (const candidate of units) {
-    unit = candidate;
-    if (value < 1024 || candidate === units.at(-1)) {
-      break;
-    }
-    value /= 1024;
-  }
-
-  return `${value.toFixed(value >= 10 || unit === 'B' ? 0 : 1)} ${unit}`;
-}
-
 function fileTimestamp(date: Date): string {
   return date.toISOString().replace(/[:.]/g, '-');
 }
@@ -729,27 +637,11 @@ function requiredEnv(name: string): string {
   return value;
 }
 
-function isNotFound(error: unknown): boolean {
-  if (!isRecord(error)) {
-    return false;
-  }
-  const metadata = isRecord(error.$metadata) ? error.$metadata : undefined;
-  return (
-    error.name === 'NotFound' ||
-    error.name === 'NoSuchKey' ||
-    metadata?.httpStatusCode === 404
-  );
-}
-
 function isNodeError(
   error: unknown,
   code: string,
 ): error is NodeJS.ErrnoException {
   return error instanceof Error && 'code' in error && error.code === code;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 async function main(): Promise<void> {

--- a/scripts/cleanup-orphaned-r2-audio.mts
+++ b/scripts/cleanup-orphaned-r2-audio.mts
@@ -166,6 +166,7 @@ function createStorageKeySource(): ScriptStorageKeySource {
         .from('audio_files')
         .select('storage_key')
         .order('storage_key', { ascending: true })
+        .order('id', { ascending: true })
         .range(from, to);
 
       if (error) {

--- a/scripts/cleanup-orphaned-r2-audio.mts
+++ b/scripts/cleanup-orphaned-r2-audio.mts
@@ -28,6 +28,7 @@ import {
   validateManifest,
 } from './lib/r2-orphan-audio-cleanup.mts';
 import {
+  assertUsableDownloadRoot,
   downloadWithoutOverwrite,
   formatBytes,
   listAllObjects,
@@ -237,6 +238,9 @@ export async function runAction(
   dependencies: ActionDependencies,
 ): Promise<ActionRunResult> {
   validateCleanupCliOptions(options);
+  if (options.download) {
+    await assertUsableDownloadRoot(options.downloadDir as string);
+  }
 
   const r2 = dependencies.client;
   const now = dependencies.now ?? (() => new Date());

--- a/scripts/cleanup-orphaned-r2-audio.mts
+++ b/scripts/cleanup-orphaned-r2-audio.mts
@@ -1,4 +1,4 @@
-import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { access, mkdir, readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { Redis } from '@upstash/redis';
@@ -620,7 +620,7 @@ function actionReportPath(manifestPath: string, now: Date): string {
 
 async function resolveExistingInputPath(input: string): Promise<string> {
   if (path.isAbsolute(input)) {
-    await readFile(input);
+    await access(input);
     return input;
   }
 
@@ -630,7 +630,7 @@ async function resolveExistingInputPath(input: string): Promise<string> {
   ];
   for (const candidate of new Set(candidates)) {
     try {
-      await readFile(candidate);
+      await access(candidate);
       return candidate;
     } catch (error) {
       if (!isNodeError(error, 'ENOENT')) {

--- a/scripts/cleanup-orphaned-r2-audio.mts
+++ b/scripts/cleanup-orphaned-r2-audio.mts
@@ -24,6 +24,7 @@ import {
   recheckCandidates,
   type StorageKeyPageSource,
   summarizeBuckets,
+  validateCleanupCliOptions,
   validateManifest,
 } from './lib/r2-orphan-audio-cleanup.mts';
 import {
@@ -235,6 +236,8 @@ export async function runAction(
   config: CleanupConfig,
   dependencies: ActionDependencies,
 ): Promise<ActionRunResult> {
+  validateCleanupCliOptions(options);
+
   const r2 = dependencies.client;
   const now = dependencies.now ?? (() => new Date());
   const manifestPath = await resolveExistingInputPath(

--- a/scripts/cleanup-orphaned-r2-audio.mts
+++ b/scripts/cleanup-orphaned-r2-audio.mts
@@ -1,0 +1,779 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  DeleteObjectsCommand,
+  GetObjectCommand,
+  HeadObjectCommand,
+  ListObjectsV2Command,
+  S3Client,
+} from '@aws-sdk/client-s3';
+
+import { loadScriptEnv } from './lib/env.mts';
+import {
+  analyzeInventory,
+  buildAllowedLocations,
+  type BucketSummary,
+  type CleanupConfig,
+  type CleanupR2Client,
+  createManifest,
+  deleteCandidatesInBatches,
+  downloadWithoutOverwrite,
+  fetchAllStorageKeys,
+  filterAllowedInventoryObjects,
+  type InventorySummaryEntry,
+  listAllObjects,
+  MINIMUM_AGE_DAYS,
+  objectIdentity,
+  parseCleanupCliArgs,
+  type R2DeleteResponse,
+  type R2ObjectMetadata,
+  recheckCandidates,
+  resolveLocalObjectPath,
+  type StorageKeyPageSource,
+  selectByDownloadLimit,
+  summarizeBuckets,
+  validateManifest,
+  verifyLocalFile,
+} from './lib/r2-orphan-audio-cleanup.mts';
+import { createScriptAdminClient } from './lib/supabase.mts';
+
+loadScriptEnv();
+
+const SCRIPT_DIRECTORY = path.dirname(fileURLToPath(import.meta.url));
+const REPOSITORY_ROOT = path.resolve(SCRIPT_DIRECTORY, '..');
+
+interface ActionReportEntry extends R2ObjectMetadata {
+  backup?: 'downloaded' | 'existing';
+  destination?: string;
+  reason?: string;
+  status: ActionStatus;
+}
+
+type ActionStatus =
+  | 'changed-in-r2'
+  | 'database-check-failure'
+  | 'deferred-by-size-cap'
+  | 'deleted'
+  | 'deletion-failure'
+  | 'download-failure'
+  | 'local-mismatch'
+  | 'missing-from-r2'
+  | 'r2-check-failure'
+  | 'referenced-by-database'
+  | 'unverifiable-checksum'
+  | 'verified-download'
+  | 'verified-existing-file';
+
+interface ScriptStorageKeySource extends StorageKeyPageSource {
+  hasStorageKey: (key: string) => Promise<boolean>;
+}
+
+interface ActionReport {
+  createdAt: string;
+  manifest: string;
+  requested: {
+    delete: boolean;
+    download: boolean;
+    force: boolean;
+    maxDownloadBytes?: number;
+  };
+  results: ActionReportEntry[];
+  schemaVersion: 1;
+  summary: Array<{
+    bucket: string;
+    bytes: number;
+    count: number;
+    prefix: string;
+    status: ActionStatus;
+  }>;
+}
+
+function printHelp(): void {
+  console.log(`Find and clean unreferenced free-user audio in R2.
+
+Inventory:
+  pnpm cleanup-orphaned-r2-audio
+
+Download from a reviewed manifest:
+  pnpm cleanup-orphaned-r2-audio -- \\
+    --manifest scripts/backups/r2-orphan-candidates-<timestamp>.json \\
+    --download \\
+    --download-dir /Volumes/ExternalHD/sexyvoice-r2-bucket \\
+    --max-download-size 20GB
+
+Delete verified downloads:
+  Add --delete --yes to the download command.
+
+Delete without a backup:
+  pnpm cleanup-orphaned-r2-audio -- \\
+    --manifest scripts/backups/r2-orphan-candidates-<timestamp>.json \\
+    --delete --force --yes
+
+Options:
+  --manifest <path>           Reviewed inventory manifest
+  --download                  Download selected objects
+  --download-dir <path>       Required with --download
+  --max-download-size <size>  Transfer cap, such as 20GB or 500MiB
+  --delete                    Delete eligible objects
+  --force                     Skip backup checks when deleting
+  --yes                       Required for deletion
+  -h, --help                  Show this help`);
+}
+
+function readConfig(): CleanupConfig {
+  return {
+    apiBucket: requiredEnv('R2_SPEECH_API_BUCKET_NAME'),
+    mainBucket: requiredEnv('R2_BUCKET_NAME'),
+  };
+}
+
+function createR2Client(): CleanupR2Client {
+  const client = new S3Client({
+    credentials: {
+      accessKeyId: requiredEnv('R2_ACCESS_KEY_ID'),
+      secretAccessKey: requiredEnv('R2_SECRET_ACCESS_KEY'),
+    },
+    endpoint: requiredEnv('R2_ENDPOINT'),
+    region: 'auto',
+  });
+
+  return {
+    async deleteObjects(bucket, keys): Promise<R2DeleteResponse> {
+      const response = await client.send(
+        new DeleteObjectsCommand({
+          Bucket: bucket,
+          Delete: {
+            Objects: keys.map((Key) => ({ Key })),
+            Quiet: false,
+          },
+        }),
+      );
+
+      return {
+        deleted: (response.Deleted ?? [])
+          .map((object) => object.Key)
+          .filter((key): key is string => Boolean(key)),
+        errors: (response.Errors ?? [])
+          .filter((error) => Boolean(error.Key))
+          .map((error) => ({
+            code: error.Code,
+            key: error.Key as string,
+            message: error.Message,
+          })),
+      };
+    },
+
+    async getObject(bucket, key, expectedEtag) {
+      const response = await client.send(
+        new GetObjectCommand({
+          Bucket: bucket,
+          IfMatch: `"${expectedEtag}"`,
+          Key: key,
+        }),
+      );
+      if (!(response.Body && Symbol.asyncIterator in response.Body)) {
+        throw new Error(`R2 returned no streaming body for ${bucket}/${key}`);
+      }
+      return response.Body as AsyncIterable<Uint8Array>;
+    },
+
+    async headObject(bucket, key) {
+      try {
+        const response = await client.send(
+          new HeadObjectCommand({ Bucket: bucket, Key: key }),
+        );
+        return {
+          etag: response.ETag,
+          lastModified: response.LastModified,
+          size: response.ContentLength,
+        };
+      } catch (error) {
+        if (isNotFound(error)) {
+          return null;
+        }
+        throw error;
+      }
+    },
+
+    async listObjects(bucket, prefix, continuationToken) {
+      const response = await client.send(
+        new ListObjectsV2Command({
+          Bucket: bucket,
+          ContinuationToken: continuationToken,
+          Prefix: prefix,
+        }),
+      );
+      return {
+        nextContinuationToken: response.NextContinuationToken,
+        objects: (response.Contents ?? []).map((object) => ({
+          etag: object.ETag,
+          key: object.Key,
+          lastModified: object.LastModified,
+          size: object.Size,
+        })),
+      };
+    },
+  };
+}
+
+function createStorageKeySource(): ScriptStorageKeySource {
+  const supabase = createScriptAdminClient();
+
+  return {
+    async hasStorageKey(key) {
+      const { data, error } = await supabase
+        .from('audio_files')
+        .select('storage_key')
+        .eq('storage_key', key)
+        .limit(1);
+
+      if (error) {
+        throw new Error(`Failed to check audio file key: ${error.message}`);
+      }
+
+      return (data ?? []).length > 0;
+    },
+
+    async listStorageKeys(from, to) {
+      const { data, error } = await supabase
+        .from('audio_files')
+        .select('storage_key')
+        .order('storage_key', { ascending: true })
+        .range(from, to);
+
+      if (error) {
+        throw new Error(`Failed to fetch audio file keys: ${error.message}`);
+      }
+
+      return (data ?? []).map((row) => row.storage_key);
+    },
+  };
+}
+
+async function runInventory(
+  config: CleanupConfig,
+  r2: CleanupR2Client,
+): Promise<void> {
+  const now = new Date();
+  const locations = buildAllowedLocations(config);
+  const buckets = [...new Set([config.mainBucket, config.apiBucket])];
+  const databaseKeysPromise = fetchAllStorageKeys(createStorageKeySource());
+  const objectListsPromise = Promise.all(
+    buckets.map((bucket) => listAllObjects(r2, { bucket, prefix: '' })),
+  );
+  const [databaseKeys, objectLists] = await Promise.all([
+    databaseKeysPromise,
+    objectListsPromise,
+  ]);
+  const allObjects = objectLists.flat();
+  const bucketTotals = summarizeBuckets(allObjects, buckets);
+  const allowedObjects = filterAllowedInventoryObjects(allObjects, locations);
+  const inventory = analyzeInventory(
+    allowedObjects,
+    databaseKeys,
+    now,
+    locations,
+  );
+  const manifest = createManifest(
+    inventory.candidates,
+    config,
+    now,
+    inventory.summary,
+    bucketTotals,
+  );
+  const outputPath = path.join(
+    SCRIPT_DIRECTORY,
+    'backups',
+    `r2-orphan-candidates-${fileTimestamp(now)}.json`,
+  );
+
+  await writeJson(outputPath, manifest);
+  console.log(`Manifest: ${path.relative(REPOSITORY_ROOT, outputPath)}`);
+  printBucketTotals(bucketTotals);
+  printInventorySummary(inventory.summary);
+}
+
+async function runAction(
+  options: ReturnType<typeof parseCleanupCliArgs>,
+  config: CleanupConfig,
+  r2: CleanupR2Client,
+): Promise<void> {
+  const manifestPath = await resolveExistingInputPath(
+    options.manifest as string,
+  );
+  const manifest = validateManifest(
+    JSON.parse(await readFile(manifestPath, 'utf8')) as unknown,
+    config,
+  );
+  const locations = buildAllowedLocations(config);
+
+  if (options.download) {
+    for (const candidate of manifest.candidates) {
+      resolveLocalObjectPath(
+        options.downloadDir as string,
+        candidate.bucket,
+        candidate.key,
+      );
+    }
+  }
+
+  const results = new Map<string, ActionReportEntry>();
+  let databaseKeys: Set<string>;
+  try {
+    databaseKeys = await fetchAllStorageKeys(createStorageKeySource());
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    const failedResults = manifest.candidates.map((candidate) => ({
+      ...candidate,
+      reason,
+      status: 'database-check-failure' as const,
+    }));
+    await writeActionReport(manifestPath, options, failedResults);
+    process.exitCode = 1;
+    return;
+  }
+
+  const initialChecks = await recheckCandidates(
+    manifest.candidates,
+    databaseKeys,
+    r2,
+    locations,
+    new Date(),
+  );
+  const eligible: R2ObjectMetadata[] = [];
+
+  for (const check of initialChecks) {
+    if (check.status === 'eligible') {
+      eligible.push(check.candidate);
+      continue;
+    }
+    results.set(objectIdentity(check.candidate), {
+      ...check.candidate,
+      reason: check.reason,
+      status: check.status,
+    });
+  }
+
+  const backedUp: R2ObjectMetadata[] = [];
+  if (options.download) {
+    const missingLocally: R2ObjectMetadata[] = [];
+
+    for (const candidate of eligible) {
+      const destination = resolveLocalObjectPath(
+        options.downloadDir as string,
+        candidate.bucket,
+        candidate.key,
+      );
+      let verification: Awaited<ReturnType<typeof verifyLocalFile>>;
+      try {
+        verification = await verifyLocalFile(destination, candidate);
+      } catch (error) {
+        results.set(objectIdentity(candidate), {
+          ...candidate,
+          destination,
+          reason: error instanceof Error ? error.message : String(error),
+          status: 'download-failure',
+        });
+        continue;
+      }
+
+      if (verification.status === 'verified') {
+        backedUp.push(candidate);
+        results.set(objectIdentity(candidate), {
+          ...candidate,
+          backup: 'existing',
+          destination,
+          status: 'verified-existing-file',
+        });
+      } else if (verification.status === 'missing') {
+        missingLocally.push(candidate);
+      } else {
+        results.set(objectIdentity(candidate), {
+          ...candidate,
+          destination,
+          reason: verification.reason,
+          status:
+            verification.status === 'unverifiable'
+              ? 'unverifiable-checksum'
+              : 'local-mismatch',
+        });
+      }
+    }
+
+    const selection = selectByDownloadLimit(
+      missingLocally,
+      options.maxDownloadBytes as number,
+    );
+    for (const candidate of selection.deferred) {
+      results.set(objectIdentity(candidate), {
+        ...candidate,
+        status: 'deferred-by-size-cap',
+      });
+    }
+
+    for (const candidate of selection.selected) {
+      const download = await downloadWithoutOverwrite(
+        r2,
+        candidate,
+        options.downloadDir as string,
+      );
+      if (download.status === 'downloaded' || download.status === 'exists') {
+        backedUp.push(candidate);
+        results.set(objectIdentity(candidate), {
+          ...candidate,
+          backup: download.status === 'downloaded' ? 'downloaded' : 'existing',
+          destination: download.destination,
+          status:
+            download.status === 'downloaded'
+              ? 'verified-download'
+              : 'verified-existing-file',
+        });
+      } else {
+        results.set(objectIdentity(candidate), {
+          ...candidate,
+          destination: download.destination,
+          reason: download.reason,
+          status:
+            download.status === 'unverifiable'
+              ? 'unverifiable-checksum'
+              : 'download-failure',
+        });
+      }
+    }
+  }
+
+  if (options.delete) {
+    const requestedDeletes = options.download ? backedUp : eligible;
+    const storageKeys = createStorageKeySource();
+
+    for (const candidate of requestedDeletes) {
+      const identity = objectIdentity(candidate);
+      const previous = results.get(identity);
+
+      if (options.download) {
+        const destination = previous?.destination;
+        if (!destination) {
+          results.set(identity, {
+            ...candidate,
+            backup: previous?.backup,
+            reason: 'Verified backup path is missing from the action state',
+            status: 'deletion-failure',
+          });
+          continue;
+        }
+
+        let verification: Awaited<ReturnType<typeof verifyLocalFile>>;
+        try {
+          verification = await verifyLocalFile(destination, candidate);
+        } catch (error) {
+          results.set(identity, {
+            ...candidate,
+            backup: previous?.backup,
+            destination,
+            reason: error instanceof Error ? error.message : String(error),
+            status: 'deletion-failure',
+          });
+          continue;
+        }
+
+        if (verification.status !== 'verified') {
+          results.set(identity, {
+            ...candidate,
+            backup: previous?.backup,
+            destination,
+            reason: verification.reason,
+            status:
+              verification.status === 'unverifiable'
+                ? 'unverifiable-checksum'
+                : 'local-mismatch',
+          });
+          continue;
+        }
+      }
+
+      let referenced: boolean;
+      try {
+        referenced = await storageKeys.hasStorageKey(candidate.key);
+      } catch (error) {
+        results.set(identity, {
+          ...candidate,
+          backup: previous?.backup,
+          destination: previous?.destination,
+          reason: error instanceof Error ? error.message : String(error),
+          status: 'deletion-failure',
+        });
+        continue;
+      }
+
+      if (referenced) {
+        results.set(identity, {
+          ...candidate,
+          backup: previous?.backup,
+          destination: previous?.destination,
+          status: 'referenced-by-database',
+        });
+        continue;
+      }
+
+      const [check] = await recheckCandidates(
+        [candidate],
+        new Set(),
+        r2,
+        locations,
+        new Date(),
+      );
+      if (check.status !== 'eligible') {
+        results.set(identity, {
+          ...candidate,
+          backup: previous?.backup,
+          destination: previous?.destination,
+          reason: check.reason,
+          status: check.status,
+        });
+        continue;
+      }
+
+      const [deletion] = await deleteCandidatesInBatches(r2, [candidate], 1);
+      results.set(identity, {
+        ...candidate,
+        backup: previous?.backup,
+        destination: previous?.destination,
+        reason: deletion.reason,
+        status: deletion.status,
+      });
+    }
+  }
+
+  const orderedResults = manifest.candidates.map((candidate) => {
+    const result = results.get(objectIdentity(candidate));
+    if (!result) {
+      throw new Error(
+        `No action result was recorded for ${candidate.bucket}/${candidate.key}`,
+      );
+    }
+    return result;
+  });
+  await writeActionReport(manifestPath, options, orderedResults);
+}
+
+async function writeActionReport(
+  manifestPath: string,
+  options: ReturnType<typeof parseCleanupCliArgs>,
+  results: ActionReportEntry[],
+): Promise<void> {
+  const report = createActionReport(manifestPath, options, results);
+  const reportPath = actionReportPath(manifestPath, new Date());
+  await writeJson(reportPath, report);
+
+  console.log(`Report: ${path.relative(REPOSITORY_ROOT, reportPath)}`);
+  printActionSummary(report);
+
+  const failureStatuses = new Set<ActionStatus>([
+    'database-check-failure',
+    'deletion-failure',
+    'download-failure',
+    'local-mismatch',
+    'r2-check-failure',
+  ]);
+  if (results.some((result) => failureStatuses.has(result.status))) {
+    process.exitCode = 1;
+  }
+}
+
+function createActionReport(
+  manifestPath: string,
+  options: ReturnType<typeof parseCleanupCliArgs>,
+  results: ActionReportEntry[],
+): ActionReport {
+  const groups = new Map<string, ActionReport['summary'][number]>();
+
+  for (const result of results) {
+    const id = `${result.bucket}\0${result.prefix}\0${result.status}`;
+    const current = groups.get(id) ?? {
+      bucket: result.bucket,
+      bytes: 0,
+      count: 0,
+      prefix: result.prefix,
+      status: result.status,
+    };
+    current.bytes += result.size;
+    current.count += 1;
+    groups.set(id, current);
+  }
+
+  return {
+    createdAt: new Date().toISOString(),
+    manifest: path.relative(REPOSITORY_ROOT, manifestPath),
+    requested: {
+      delete: options.delete,
+      download: options.download,
+      force: options.force && !options.download,
+      maxDownloadBytes: options.maxDownloadBytes,
+    },
+    results,
+    schemaVersion: 1,
+    summary: [...groups.values()].sort(
+      (left, right) =>
+        left.bucket.localeCompare(right.bucket) ||
+        left.prefix.localeCompare(right.prefix) ||
+        left.status.localeCompare(right.status),
+    ),
+  };
+}
+
+function actionReportPath(manifestPath: string, now: Date): string {
+  const extension = path.extname(manifestPath);
+  const base = path.basename(manifestPath, extension);
+  return path.join(
+    path.dirname(manifestPath),
+    `${base}-action-${fileTimestamp(now)}.json`,
+  );
+}
+
+async function resolveExistingInputPath(input: string): Promise<string> {
+  if (path.isAbsolute(input)) {
+    await readFile(input);
+    return input;
+  }
+
+  const candidates = [
+    path.resolve(process.cwd(), input),
+    path.resolve(REPOSITORY_ROOT, input),
+  ];
+  for (const candidate of new Set(candidates)) {
+    try {
+      await readFile(candidate);
+      return candidate;
+    } catch (error) {
+      if (!isNodeError(error, 'ENOENT')) {
+        throw error;
+      }
+    }
+  }
+
+  throw new Error(`Manifest not found: ${input}`);
+}
+
+async function writeJson(filePath: string, value: unknown): Promise<void> {
+  const directory = path.dirname(filePath);
+  await mkdir(directory, { recursive: true });
+  await writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`, {
+    encoding: 'utf8',
+    flag: 'wx',
+  });
+}
+
+function printBucketTotals(totals: BucketSummary[]): void {
+  console.log('Bucket totals');
+  for (const total of totals) {
+    console.log(`  ${total.bucket}: ${formatTotals(total)}`);
+  }
+}
+
+function printInventorySummary(summary: InventorySummaryEntry[]): void {
+  for (const row of summary) {
+    console.log(`${row.bucket}/${row.prefix}`);
+    console.log(`  scanned: ${formatTotals(row.scanned)}`);
+    console.log(
+      `  younger than ${MINIMUM_AGE_DAYS} days: ${formatTotals(row.youngerThanCutoff)}`,
+    );
+    console.log(
+      `  old and referenced by database: ${formatTotals(row.referencedByDatabase)}`,
+    );
+    console.log(`  orphan candidates: ${formatTotals(row.candidates)}`);
+  }
+
+  if (summary.every((row) => row.candidates.count === 0)) {
+    console.log('No orphan candidates found.');
+  }
+}
+
+function formatTotals(totals: { bytes: number; count: number }): string {
+  return `${totals.count} objects, ${formatBytes(totals.bytes)}`;
+}
+
+function printActionSummary(report: ActionReport): void {
+  for (const row of report.summary) {
+    console.log(
+      `${row.bucket}/${row.prefix} ${row.status}: ${row.count} objects, ${formatBytes(row.bytes)}`,
+    );
+  }
+}
+
+function formatBytes(bytes: number): string {
+  const units = ['B', 'KiB', 'MiB', 'GiB', 'TiB'];
+  let value = bytes;
+  let unit = units[0];
+
+  for (const candidate of units) {
+    unit = candidate;
+    if (value < 1024 || candidate === units.at(-1)) {
+      break;
+    }
+    value /= 1024;
+  }
+
+  return `${value.toFixed(value >= 10 || unit === 'B' ? 0 : 1)} ${unit}`;
+}
+
+function fileTimestamp(date: Date): string {
+  return date.toISOString().replace(/[:.]/g, '-');
+}
+
+function requiredEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`Missing env.${name}`);
+  }
+  return value;
+}
+
+function isNotFound(error: unknown): boolean {
+  if (!isRecord(error)) {
+    return false;
+  }
+  const metadata = isRecord(error.$metadata) ? error.$metadata : undefined;
+  return (
+    error.name === 'NotFound' ||
+    error.name === 'NoSuchKey' ||
+    metadata?.httpStatusCode === 404
+  );
+}
+
+function isNodeError(
+  error: unknown,
+  code: string,
+): error is NodeJS.ErrnoException {
+  return error instanceof Error && 'code' in error && error.code === code;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+async function main(): Promise<void> {
+  const options = parseCleanupCliArgs(process.argv.slice(2));
+  if (options.help) {
+    printHelp();
+    return;
+  }
+
+  const config = readConfig();
+  const r2 = createR2Client();
+
+  if (options.manifest) {
+    if (options.download && options.force) {
+      console.log('--force is ignored because --download is active.');
+    }
+    await runAction(options, config, r2);
+    return;
+  }
+
+  await runInventory(config, r2);
+}
+
+main().catch((error: unknown) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});

--- a/scripts/compile-dispute-evidence.mts
+++ b/scripts/compile-dispute-evidence.mts
@@ -1,13 +1,10 @@
 import { writeFile } from 'node:fs/promises';
 import { stdin as input, stdout as output } from 'node:process';
 import { createInterface } from 'node:readline/promises';
-import { createClient } from '@supabase/supabase-js';
-import { config } from 'dotenv';
+import { loadScriptEnv } from './lib/env.mts';
+import { createScriptAdminClient as createAdminClient } from './lib/supabase.mts';
 
-// Load environment variables
-config({
-  path: ['.env', '.env.local'],
-});
+loadScriptEnv();
 
 // ---------------------------------------------------------------------------
 // Types
@@ -95,29 +92,6 @@ interface DisputeReport {
 // ---------------------------------------------------------------------------
 // Supabase
 // ---------------------------------------------------------------------------
-
-/**
- * Create Supabase admin client
- */
-function createAdminClient() {
-  if (!process.env.NEXT_PUBLIC_SUPABASE_URL) {
-    throw new Error('Missing env.NEXT_PUBLIC_SUPABASE_URL');
-  }
-  if (!process.env.SUPABASE_SECRET_KEY) {
-    throw new Error('Missing env.SUPABASE_SECRET_KEY');
-  }
-
-  return createClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL,
-    process.env.SUPABASE_SECRET_KEY,
-    {
-      auth: {
-        autoRefreshToken: false,
-        persistSession: false,
-      },
-    },
-  );
-}
 
 // ---------------------------------------------------------------------------
 // Data gathering (read-only, no side effects)

--- a/scripts/lib/env.mts
+++ b/scripts/lib/env.mts
@@ -1,0 +1,8 @@
+import { config } from 'dotenv';
+
+export function loadScriptEnv(): void {
+  config({
+    override: false,
+    path: ['.env', '.env.local'],
+  });
+}

--- a/scripts/lib/r2-client.mts
+++ b/scripts/lib/r2-client.mts
@@ -1,0 +1,159 @@
+import {
+  DeleteObjectsCommand,
+  GetObjectCommand,
+  HeadObjectCommand,
+  ListObjectsV2Command,
+  S3Client,
+} from '@aws-sdk/client-s3';
+
+import {
+  normalizeEtag,
+  type R2Client,
+  type R2DeleteResponse,
+  type R2GetObjectResult,
+} from './r2-transfer.mts';
+
+export function createR2Client(
+  environment: NodeJS.ProcessEnv = process.env,
+): R2Client {
+  const client = new S3Client({
+    credentials: {
+      accessKeyId: requiredEnv(environment, 'R2_ACCESS_KEY_ID'),
+      secretAccessKey: requiredEnv(environment, 'R2_SECRET_ACCESS_KEY'),
+    },
+    endpoint: requiredEnv(environment, 'R2_ENDPOINT'),
+    region: 'auto',
+  });
+
+  return {
+    async deleteObjects(bucket, keys): Promise<R2DeleteResponse> {
+      const response = await client.send(
+        new DeleteObjectsCommand({
+          Bucket: bucket,
+          Delete: {
+            Objects: keys.map((Key) => ({ Key })),
+            Quiet: false,
+          },
+        }),
+      );
+
+      return {
+        deleted: (response.Deleted ?? [])
+          .map((object) => object.Key)
+          .filter((key): key is string => Boolean(key)),
+        errors: (response.Errors ?? [])
+          .filter((error) => Boolean(error.Key))
+          .map((error) => ({
+            code: error.Code,
+            key: error.Key as string,
+            message: error.Message,
+          })),
+      };
+    },
+
+    async getObject(
+      bucket,
+      key,
+      expectedEtag,
+      signal,
+    ): Promise<R2GetObjectResult> {
+      try {
+        const response = await client.send(
+          new GetObjectCommand({
+            Bucket: bucket,
+            IfMatch: `"${normalizeEtag(expectedEtag)}"`,
+            Key: key,
+          }),
+          signal ? { abortSignal: signal } : undefined,
+        );
+        if (!(response.Body && Symbol.asyncIterator in response.Body)) {
+          throw new Error(`R2 returned no streaming body for ${bucket}/${key}`);
+        }
+        return {
+          body: response.Body as AsyncIterable<Uint8Array>,
+          status: 'ok',
+        };
+      } catch (error) {
+        if (isNotFound(error)) {
+          return { status: 'missing' };
+        }
+        if (isPreconditionFailed(error)) {
+          return { status: 'changed' };
+        }
+        throw error;
+      }
+    },
+
+    async headObject(bucket, key) {
+      try {
+        const response = await client.send(
+          new HeadObjectCommand({ Bucket: bucket, Key: key }),
+        );
+        return {
+          etag: response.ETag,
+          lastModified: response.LastModified,
+          size: response.ContentLength,
+        };
+      } catch (error) {
+        if (isNotFound(error)) {
+          return null;
+        }
+        throw error;
+      }
+    },
+
+    async listObjects(bucket, prefix, continuationToken) {
+      const response = await client.send(
+        new ListObjectsV2Command({
+          Bucket: bucket,
+          ContinuationToken: continuationToken,
+          Prefix: prefix,
+        }),
+      );
+      return {
+        nextContinuationToken: response.NextContinuationToken,
+        objects: (response.Contents ?? []).map((object) => ({
+          etag: object.ETag,
+          key: object.Key,
+          lastModified: object.LastModified,
+          size: object.Size,
+        })),
+      };
+    },
+  };
+}
+
+function requiredEnv(environment: NodeJS.ProcessEnv, name: string): string {
+  const value = environment[name];
+  if (!value) {
+    throw new Error(`Missing env.${name}`);
+  }
+  return value;
+}
+
+function isNotFound(error: unknown): boolean {
+  return hasAwsErrorStatus(error, 404, 'NotFound', 'NoSuchKey');
+}
+
+function isPreconditionFailed(error: unknown): boolean {
+  return hasAwsErrorStatus(error, 412, 'PreconditionFailed');
+}
+
+function hasAwsErrorStatus(
+  error: unknown,
+  statusCode: number,
+  ...names: string[]
+): boolean {
+  if (!isRecord(error)) {
+    return false;
+  }
+  const metadata = isRecord(error.$metadata) ? error.$metadata : undefined;
+  return (
+    names.includes(String(error.name)) ||
+    metadata?.httpStatusCode === statusCode
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/scripts/lib/r2-client.mts
+++ b/scripts/lib/r2-client.mts
@@ -25,6 +25,12 @@ export function createR2Client(
     region: 'auto',
   });
 
+  return createR2ClientAdapter(client);
+}
+
+export function createR2ClientAdapter(
+  client: Pick<S3Client, 'send'>,
+): R2Client {
   return {
     async deleteObjects(bucket, keys): Promise<R2DeleteResponse> {
       const response = await client.send(

--- a/scripts/lib/r2-orphan-audio-cleanup.mts
+++ b/scripts/lib/r2-orphan-audio-cleanup.mts
@@ -1,10 +1,19 @@
-import { createHash, randomUUID } from 'node:crypto';
-import { constants, createReadStream, createWriteStream } from 'node:fs';
-import { copyFile, link, mkdir, rm, stat } from 'node:fs/promises';
-import path from 'node:path';
-import { Readable, Transform } from 'node:stream';
-import { pipeline } from 'node:stream/promises';
 import { parseArgs } from 'node:util';
+
+import {
+  compareR2ObjectsOldestFirst as compareOldestFirst,
+  normalizeEtag,
+  parseByteSize,
+  type R2Client,
+  type R2DeleteResponse,
+  type R2HeadObject,
+  type R2Location,
+  type R2ObjectMetadata,
+} from './r2-transfer.mts';
+
+export type CleanupR2Client = R2Client;
+export type AllowedLocation = R2Location;
+export type { R2ObjectMetadata } from './r2-transfer.mts';
 
 export const MANIFEST_SCHEMA_VERSION = 1;
 export const MINIMUM_AGE_DAYS = 45;
@@ -12,26 +21,10 @@ export const DEFAULT_PAGE_SIZE = 1000;
 export const DEFAULT_DELETE_BATCH_SIZE = 100;
 
 const MILLISECONDS_PER_DAY = 24 * 60 * 60 * 1000;
-const SIMPLE_ETAG_PATTERN = /^[a-f\d]{32}$/i;
-const SIZE_PATTERN = /^(\d+(?:\.\d+)?)\s*(KB|MB|GB|TB|KiB|MiB|GiB|TiB)$/i;
 
 export interface CleanupConfig {
   apiBucket: string;
   mainBucket: string;
-}
-
-export interface AllowedLocation {
-  bucket: string;
-  prefix: string;
-}
-
-export interface R2ObjectMetadata {
-  bucket: string;
-  etag: string;
-  key: string;
-  lastModified: string;
-  prefix: string;
-  size: number;
 }
 
 export interface ManifestSummaryEntry {
@@ -94,50 +87,6 @@ export interface StorageKeyPageSource {
   listStorageKeys: (from: number, to: number) => Promise<string[]>;
 }
 
-export interface R2ListedObject {
-  etag?: string;
-  key?: string;
-  lastModified?: Date;
-  size?: number;
-}
-
-export interface R2ListPage {
-  nextContinuationToken?: string;
-  objects: R2ListedObject[];
-}
-
-export interface R2HeadObject {
-  etag?: string;
-  lastModified?: Date;
-  size?: number;
-}
-
-export interface R2DeleteError {
-  code?: string;
-  key: string;
-  message?: string;
-}
-
-export interface R2DeleteResponse {
-  deleted: string[];
-  errors: R2DeleteError[];
-}
-
-export interface CleanupR2Client {
-  deleteObjects: (bucket: string, keys: string[]) => Promise<R2DeleteResponse>;
-  getObject: (
-    bucket: string,
-    key: string,
-    expectedEtag: string,
-  ) => Promise<AsyncIterable<Uint8Array>>;
-  headObject: (bucket: string, key: string) => Promise<R2HeadObject | null>;
-  listObjects: (
-    bucket: string,
-    prefix: string,
-    continuationToken?: string,
-  ) => Promise<R2ListPage>;
-}
-
 export type RecheckStatus =
   | 'changed-in-r2'
   | 'eligible'
@@ -149,29 +98,6 @@ export interface RecheckResult {
   candidate: R2ObjectMetadata;
   reason?: string;
   status: RecheckStatus;
-}
-
-export interface DownloadSelection {
-  deferred: R2ObjectMetadata[];
-  selected: R2ObjectMetadata[];
-  transferBytes: number;
-}
-
-export type LocalVerificationStatus =
-  | 'missing'
-  | 'mismatch'
-  | 'unverifiable'
-  | 'verified';
-
-export interface LocalVerification {
-  reason?: string;
-  status: LocalVerificationStatus;
-}
-
-export interface DownloadResult {
-  destination: string;
-  reason?: string;
-  status: 'downloaded' | 'exists' | 'failed' | 'unverifiable';
 }
 
 export interface DeleteResult {
@@ -197,39 +123,6 @@ export function buildAllowedLocations({
   }
 
   return [...unique.values()];
-}
-
-export function parseByteSize(input: string): number {
-  const match = SIZE_PATTERN.exec(input.trim());
-  if (!match) {
-    throw new Error(
-      'Size must use KB, MB, GB, TB, KiB, MiB, GiB, or TiB, for example 20GB',
-    );
-  }
-
-  const value = Number(match[1]);
-  if (!(value > 0)) {
-    throw new Error('Size must be greater than zero');
-  }
-
-  const unit = match[2].toLowerCase();
-  const powers: Record<string, number> = {
-    gb: 1000 ** 3,
-    gib: 1024 ** 3,
-    kb: 1000,
-    kib: 1024,
-    mb: 1000 ** 2,
-    mib: 1024 ** 2,
-    tb: 1000 ** 4,
-    tib: 1024 ** 4,
-  };
-  const bytes = value * powers[unit];
-
-  if (!Number.isSafeInteger(bytes)) {
-    throw new Error('Size must resolve to a whole, safe number of bytes');
-  }
-
-  return bytes;
 }
 
 export function parseCleanupCliArgs(args: string[]): CleanupCliOptions {
@@ -319,19 +212,6 @@ export function isAtLeastDaysOld(
   return timestamp <= now.getTime() - days * MILLISECONDS_PER_DAY;
 }
 
-export function normalizeEtag(etag: string): string {
-  const trimmed = etag.trim();
-  if (trimmed.startsWith('"') && trimmed.endsWith('"')) {
-    return trimmed.slice(1, -1);
-  }
-  return trimmed;
-}
-
-export function simpleEtagMd5(etag: string): string | null {
-  const normalized = normalizeEtag(etag);
-  return SIMPLE_ETAG_PATTERN.test(normalized) ? normalized.toLowerCase() : null;
-}
-
 export function findAllowedLocation(
   bucket: string,
   key: string,
@@ -398,30 +278,6 @@ export function findOrphanCandidates(
         isAtLeastDaysOld(object.lastModified, now),
     )
     .sort(compareOldestFirst);
-}
-
-export function selectByDownloadLimit(
-  candidates: R2ObjectMetadata[],
-  maxBytes: number,
-): DownloadSelection {
-  if (!Number.isSafeInteger(maxBytes) || maxBytes <= 0) {
-    throw new Error('Download limit must be a positive, safe integer');
-  }
-
-  const selected: R2ObjectMetadata[] = [];
-  const deferred: R2ObjectMetadata[] = [];
-  let transferBytes = 0;
-
-  for (const candidate of [...candidates].sort(compareOldestFirst)) {
-    if (candidate.size <= maxBytes - transferBytes) {
-      selected.push(candidate);
-      transferBytes += candidate.size;
-    } else {
-      deferred.push(candidate);
-    }
-  }
-
-  return { deferred, selected, transferBytes };
 }
 
 export function summarizeObjects(
@@ -634,62 +490,6 @@ export async function fetchAllStorageKeys(
   return keys;
 }
 
-export async function listAllObjects(
-  client: CleanupR2Client,
-  location: AllowedLocation,
-): Promise<R2ObjectMetadata[]> {
-  const objects: R2ObjectMetadata[] = [];
-  const seenTokens = new Set<string>();
-  let continuationToken: string | undefined;
-
-  while (true) {
-    const page = await client.listObjects(
-      location.bucket,
-      location.prefix,
-      continuationToken,
-    );
-
-    for (const object of page.objects) {
-      if (
-        !object.key ||
-        object.size === undefined ||
-        !object.lastModified ||
-        !object.etag
-      ) {
-        throw new Error(
-          `R2 returned incomplete metadata under ${location.bucket}/${location.prefix}`,
-        );
-      }
-      if (!object.key.startsWith(location.prefix)) {
-        throw new Error(
-          `R2 returned an object outside requested prefix ${location.prefix}`,
-        );
-      }
-
-      objects.push({
-        bucket: location.bucket,
-        etag: normalizeEtag(object.etag),
-        key: object.key,
-        lastModified: object.lastModified.toISOString(),
-        prefix: location.prefix,
-        size: object.size,
-      });
-    }
-
-    const nextToken = page.nextContinuationToken;
-    if (!nextToken) {
-      break;
-    }
-    if (seenTokens.has(nextToken)) {
-      throw new Error('R2 pagination returned a repeated continuation token');
-    }
-    seenTokens.add(nextToken);
-    continuationToken = nextToken;
-  }
-
-  return objects;
-}
-
 export async function recheckCandidates(
   candidates: R2ObjectMetadata[],
   databaseKeys: ReadonlySet<string>,
@@ -742,152 +542,6 @@ export async function recheckCandidates(
   }
 
   return results;
-}
-
-export function resolveLocalObjectPath(
-  downloadDir: string,
-  bucket: string,
-  key: string,
-): string {
-  assertBucketName(bucket);
-  if (
-    !key ||
-    path.isAbsolute(key) ||
-    key.split(/[\\/]/).some((segment) => segment === '..')
-  ) {
-    throw new Error(`Unsafe R2 key: ${key}`);
-  }
-
-  const bucketDirectory = path.resolve(downloadDir, bucket);
-  const destination = path.resolve(bucketDirectory, key);
-  const relative = path.relative(bucketDirectory, destination);
-
-  if (!relative || relative === '..' || relative.startsWith(`..${path.sep}`)) {
-    throw new Error(`Unsafe R2 key: ${key}`);
-  }
-  if (path.isAbsolute(relative)) {
-    throw new Error(`Unsafe R2 key: ${key}`);
-  }
-
-  return destination;
-}
-
-export async function verifyLocalFile(
-  filePath: string,
-  candidate: R2ObjectMetadata,
-): Promise<LocalVerification> {
-  let fileStats: Awaited<ReturnType<typeof stat>>;
-  try {
-    fileStats = await stat(filePath);
-  } catch (error) {
-    if (isNodeError(error, 'ENOENT')) {
-      return { status: 'missing' };
-    }
-    throw error;
-  }
-
-  if (!fileStats.isFile()) {
-    return { reason: 'Local path is not a regular file', status: 'mismatch' };
-  }
-  if (fileStats.size !== candidate.size) {
-    return {
-      reason: `Local size ${fileStats.size} does not match R2 size ${candidate.size}`,
-      status: 'mismatch',
-    };
-  }
-
-  const expectedMd5 = simpleEtagMd5(candidate.etag);
-  if (!expectedMd5) {
-    return {
-      reason: 'R2 ETag is not a simple MD5 checksum',
-      status: 'unverifiable',
-    };
-  }
-
-  const actualMd5 = await md5File(filePath);
-  if (actualMd5 !== expectedMd5) {
-    return {
-      reason: `Local MD5 ${actualMd5} does not match R2 ETag ${expectedMd5}`,
-      status: 'mismatch',
-    };
-  }
-
-  return { status: 'verified' };
-}
-
-export async function downloadWithoutOverwrite(
-  client: CleanupR2Client,
-  candidate: R2ObjectMetadata,
-  downloadDir: string,
-): Promise<DownloadResult> {
-  const destination = resolveLocalObjectPath(
-    downloadDir,
-    candidate.bucket,
-    candidate.key,
-  );
-  let temporaryPath: string | undefined;
-
-  try {
-    const existing = await verifyLocalFile(destination, candidate);
-    if (existing.status !== 'missing') {
-      let status: DownloadResult['status'] = 'failed';
-      if (existing.status === 'verified') {
-        status = 'exists';
-      } else if (existing.status === 'unverifiable') {
-        status = 'unverifiable';
-      }
-      return {
-        destination,
-        reason: existing.reason,
-        status,
-      };
-    }
-
-    await mkdir(path.dirname(destination), { recursive: true });
-    temporaryPath = `${destination}.partial-${randomUUID()}`;
-    const body = await client.getObject(
-      candidate.bucket,
-      candidate.key,
-      candidate.etag,
-    );
-    await pipeline(
-      Readable.from(body),
-      createByteLimitTransform(candidate.size),
-      createWriteStream(temporaryPath, { flags: 'wx' }),
-    );
-
-    const verification = await verifyLocalFile(temporaryPath, candidate);
-    if (
-      verification.status === 'missing' ||
-      verification.status === 'mismatch'
-    ) {
-      return {
-        destination,
-        reason: verification.reason,
-        status: 'failed',
-      };
-    }
-
-    await finalizeWithoutOverwrite(temporaryPath, destination);
-    if (verification.status === 'unverifiable') {
-      return {
-        destination,
-        reason: verification.reason,
-        status: 'unverifiable',
-      };
-    }
-    return { destination, status: 'downloaded' };
-  } catch (error) {
-    return {
-      destination,
-      reason: error instanceof Error ? error.message : String(error),
-      status: 'failed',
-    };
-  } finally {
-    if (temporaryPath) {
-      await rm(temporaryPath, { force: true }).catch(() => undefined);
-    }
-  }
 }
 
 export async function deleteCandidatesInBatches(
@@ -1200,18 +854,6 @@ function compareLocationSummary(
   );
 }
 
-function compareOldestFirst(
-  left: R2ObjectMetadata,
-  right: R2ObjectMetadata,
-): number {
-  return (
-    new Date(left.lastModified).getTime() -
-      new Date(right.lastModified).getTime() ||
-    left.bucket.localeCompare(right.bucket) ||
-    left.key.localeCompare(right.key)
-  );
-}
-
 function assertBucketName(bucket: string): void {
   if (
     !bucket ||
@@ -1236,55 +878,4 @@ function assertIsoDate(value: unknown, label: string): asserts value is string {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
-
-function isNodeError(
-  error: unknown,
-  code: string,
-): error is NodeJS.ErrnoException {
-  return error instanceof Error && 'code' in error && error.code === code;
-}
-
-function createByteLimitTransform(maxBytes: number): Transform {
-  let bytes = 0;
-  return new Transform({
-    transform(chunk: Buffer, _encoding, callback) {
-      bytes += chunk.byteLength;
-      if (bytes > maxBytes) {
-        callback(
-          new Error(
-            `R2 response exceeded the expected size of ${maxBytes} bytes`,
-          ),
-        );
-        return;
-      }
-      callback(null, chunk);
-    },
-  });
-}
-
-async function finalizeWithoutOverwrite(
-  temporaryPath: string,
-  destination: string,
-): Promise<void> {
-  try {
-    await link(temporaryPath, destination);
-  } catch (error) {
-    const hardLinksUnsupported =
-      isNodeError(error, 'EPERM') ||
-      isNodeError(error, 'ENOTSUP') ||
-      isNodeError(error, 'EOPNOTSUPP');
-    if (!hardLinksUnsupported) {
-      throw error;
-    }
-    await copyFile(temporaryPath, destination, constants.COPYFILE_EXCL);
-  }
-}
-
-async function md5File(filePath: string): Promise<string> {
-  const hash = createHash('md5');
-  for await (const chunk of createReadStream(filePath)) {
-    hash.update(chunk);
-  }
-  return hash.digest('hex');
 }

--- a/scripts/lib/r2-orphan-audio-cleanup.mts
+++ b/scripts/lib/r2-orphan-audio-cleanup.mts
@@ -1,0 +1,1290 @@
+import { createHash, randomUUID } from 'node:crypto';
+import { constants, createReadStream, createWriteStream } from 'node:fs';
+import { copyFile, link, mkdir, rm, stat } from 'node:fs/promises';
+import path from 'node:path';
+import { Readable, Transform } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
+import { parseArgs } from 'node:util';
+
+export const MANIFEST_SCHEMA_VERSION = 1;
+export const MINIMUM_AGE_DAYS = 45;
+export const DEFAULT_PAGE_SIZE = 1000;
+export const DEFAULT_DELETE_BATCH_SIZE = 100;
+
+const MILLISECONDS_PER_DAY = 24 * 60 * 60 * 1000;
+const SIMPLE_ETAG_PATTERN = /^[a-f\d]{32}$/i;
+const SIZE_PATTERN = /^(\d+(?:\.\d+)?)\s*(KB|MB|GB|TB|KiB|MiB|GiB|TiB)$/i;
+
+export interface CleanupConfig {
+  apiBucket: string;
+  mainBucket: string;
+}
+
+export interface AllowedLocation {
+  bucket: string;
+  prefix: string;
+}
+
+export interface R2ObjectMetadata {
+  bucket: string;
+  etag: string;
+  key: string;
+  lastModified: string;
+  prefix: string;
+  size: number;
+}
+
+export interface ManifestSummaryEntry {
+  bucket: string;
+  bytes: number;
+  count: number;
+  prefix: string;
+}
+
+export interface ObjectTotals {
+  bytes: number;
+  count: number;
+}
+
+export interface BucketSummary extends ObjectTotals {
+  bucket: string;
+}
+
+export interface InventorySummaryEntry {
+  bucket: string;
+  candidates: ObjectTotals;
+  prefix: string;
+  referencedByDatabase: ObjectTotals;
+  scanned: ObjectTotals;
+  youngerThanCutoff: ObjectTotals;
+}
+
+export interface InventoryAnalysis {
+  candidates: R2ObjectMetadata[];
+  summary: InventorySummaryEntry[];
+}
+
+export interface CleanupManifest {
+  bucketNames: {
+    api: string;
+    main: string;
+  };
+  bucketTotals?: BucketSummary[];
+  candidates: R2ObjectMetadata[];
+  createdAt: string;
+  cutoff: string;
+  inventory?: InventorySummaryEntry[];
+  minimumAgeDays: number;
+  schemaVersion: number;
+  summary: ManifestSummaryEntry[];
+}
+
+export interface CleanupCliOptions {
+  delete: boolean;
+  download: boolean;
+  downloadDir?: string;
+  force: boolean;
+  help: boolean;
+  manifest?: string;
+  maxDownloadBytes?: number;
+  yes: boolean;
+}
+
+export interface StorageKeyPageSource {
+  listStorageKeys: (from: number, to: number) => Promise<string[]>;
+}
+
+export interface R2ListedObject {
+  etag?: string;
+  key?: string;
+  lastModified?: Date;
+  size?: number;
+}
+
+export interface R2ListPage {
+  nextContinuationToken?: string;
+  objects: R2ListedObject[];
+}
+
+export interface R2HeadObject {
+  etag?: string;
+  lastModified?: Date;
+  size?: number;
+}
+
+export interface R2DeleteError {
+  code?: string;
+  key: string;
+  message?: string;
+}
+
+export interface R2DeleteResponse {
+  deleted: string[];
+  errors: R2DeleteError[];
+}
+
+export interface CleanupR2Client {
+  deleteObjects: (bucket: string, keys: string[]) => Promise<R2DeleteResponse>;
+  getObject: (
+    bucket: string,
+    key: string,
+    expectedEtag: string,
+  ) => Promise<AsyncIterable<Uint8Array>>;
+  headObject: (bucket: string, key: string) => Promise<R2HeadObject | null>;
+  listObjects: (
+    bucket: string,
+    prefix: string,
+    continuationToken?: string,
+  ) => Promise<R2ListPage>;
+}
+
+export type RecheckStatus =
+  | 'changed-in-r2'
+  | 'eligible'
+  | 'missing-from-r2'
+  | 'r2-check-failure'
+  | 'referenced-by-database';
+
+export interface RecheckResult {
+  candidate: R2ObjectMetadata;
+  reason?: string;
+  status: RecheckStatus;
+}
+
+export interface DownloadSelection {
+  deferred: R2ObjectMetadata[];
+  selected: R2ObjectMetadata[];
+  transferBytes: number;
+}
+
+export type LocalVerificationStatus =
+  | 'missing'
+  | 'mismatch'
+  | 'unverifiable'
+  | 'verified';
+
+export interface LocalVerification {
+  reason?: string;
+  status: LocalVerificationStatus;
+}
+
+export interface DownloadResult {
+  destination: string;
+  reason?: string;
+  status: 'downloaded' | 'exists' | 'failed' | 'unverifiable';
+}
+
+export interface DeleteResult {
+  candidate: R2ObjectMetadata;
+  reason?: string;
+  status: 'deleted' | 'deletion-failure';
+}
+
+export function buildAllowedLocations({
+  apiBucket,
+  mainBucket,
+}: CleanupConfig): AllowedLocation[] {
+  const locations = [
+    { bucket: mainBucket, prefix: 'generated-audio-free/' },
+    { bucket: mainBucket, prefix: 'cloned-audio-free/' },
+    { bucket: apiBucket, prefix: 'generated-audio-free/' },
+  ];
+
+  const unique = new Map<string, AllowedLocation>();
+  for (const location of locations) {
+    assertBucketName(location.bucket);
+    unique.set(`${location.bucket}\0${location.prefix}`, location);
+  }
+
+  return [...unique.values()];
+}
+
+export function parseByteSize(input: string): number {
+  const match = SIZE_PATTERN.exec(input.trim());
+  if (!match) {
+    throw new Error(
+      'Size must use KB, MB, GB, TB, KiB, MiB, GiB, or TiB, for example 20GB',
+    );
+  }
+
+  const value = Number(match[1]);
+  if (!(value > 0)) {
+    throw new Error('Size must be greater than zero');
+  }
+
+  const unit = match[2].toLowerCase();
+  const powers: Record<string, number> = {
+    gb: 1000 ** 3,
+    gib: 1024 ** 3,
+    kb: 1000,
+    kib: 1024,
+    mb: 1000 ** 2,
+    mib: 1024 ** 2,
+    tb: 1000 ** 4,
+    tib: 1024 ** 4,
+  };
+  const bytes = value * powers[unit];
+
+  if (!Number.isSafeInteger(bytes)) {
+    throw new Error('Size must resolve to a whole, safe number of bytes');
+  }
+
+  return bytes;
+}
+
+export function parseCleanupCliArgs(args: string[]): CleanupCliOptions {
+  const normalizedArgs = args[0] === '--' ? args.slice(1) : args;
+  const { values } = parseArgs({
+    allowPositionals: false,
+    args: normalizedArgs,
+    options: {
+      delete: { default: false, type: 'boolean' },
+      download: { default: false, type: 'boolean' },
+      'download-dir': { type: 'string' },
+      force: { default: false, type: 'boolean' },
+      help: { default: false, short: 'h', type: 'boolean' },
+      manifest: { type: 'string' },
+      'max-download-size': { type: 'string' },
+      yes: { default: false, type: 'boolean' },
+    },
+    strict: true,
+  });
+
+  const options: CleanupCliOptions = {
+    delete: values.delete,
+    download: values.download,
+    downloadDir: values['download-dir'],
+    force: values.force,
+    help: values.help,
+    manifest: values.manifest,
+    maxDownloadBytes: values['max-download-size']
+      ? parseByteSize(values['max-download-size'])
+      : undefined,
+    yes: values.yes,
+  };
+
+  validateCleanupCliOptions(options);
+  return options;
+}
+
+export function validateCleanupCliOptions(options: CleanupCliOptions): void {
+  if (options.help) {
+    return;
+  }
+
+  if (!options.download && options.downloadDir) {
+    throw new Error('--download-dir requires --download');
+  }
+  if (!options.download && options.maxDownloadBytes !== undefined) {
+    throw new Error('--max-download-size requires --download');
+  }
+  if (options.download && !options.manifest) {
+    throw new Error('--download requires --manifest');
+  }
+  if (options.download && !options.downloadDir) {
+    throw new Error('--download requires --download-dir');
+  }
+  if (options.download && options.maxDownloadBytes === undefined) {
+    throw new Error('--download requires --max-download-size');
+  }
+  if (options.delete && !options.manifest) {
+    throw new Error('--delete requires --manifest');
+  }
+  if (options.delete && !(options.download || options.force)) {
+    throw new Error('--delete requires --download or --force');
+  }
+  if (options.delete && !options.yes) {
+    throw new Error('--delete requires --yes');
+  }
+  if (options.force && !options.delete && !options.download) {
+    throw new Error('--force requires --delete or --download');
+  }
+  if (options.yes && !options.delete) {
+    throw new Error('--yes requires --delete');
+  }
+  if (options.manifest && !(options.download || options.delete)) {
+    throw new Error('--manifest requires --download or --delete');
+  }
+}
+
+export function isAtLeastDaysOld(
+  lastModified: string | Date,
+  now: Date,
+  days = MINIMUM_AGE_DAYS,
+): boolean {
+  const timestamp = new Date(lastModified).getTime();
+  if (!Number.isFinite(timestamp)) {
+    return false;
+  }
+  return timestamp <= now.getTime() - days * MILLISECONDS_PER_DAY;
+}
+
+export function normalizeEtag(etag: string): string {
+  const trimmed = etag.trim();
+  if (trimmed.startsWith('"') && trimmed.endsWith('"')) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}
+
+export function simpleEtagMd5(etag: string): string | null {
+  const normalized = normalizeEtag(etag);
+  return SIMPLE_ETAG_PATTERN.test(normalized) ? normalized.toLowerCase() : null;
+}
+
+export function findAllowedLocation(
+  bucket: string,
+  key: string,
+  locations: AllowedLocation[],
+): AllowedLocation | undefined {
+  return locations.find(
+    (location) => location.bucket === bucket && key.startsWith(location.prefix),
+  );
+}
+
+export function analyzeInventory(
+  objects: R2ObjectMetadata[],
+  databaseKeys: ReadonlySet<string>,
+  now: Date,
+  locations: AllowedLocation[],
+): InventoryAnalysis {
+  const summaries = new Map<string, InventorySummaryEntry>();
+  for (const location of locations) {
+    summaries.set(locationIdentity(location), {
+      bucket: location.bucket,
+      candidates: emptyTotals(),
+      prefix: location.prefix,
+      referencedByDatabase: emptyTotals(),
+      scanned: emptyTotals(),
+      youngerThanCutoff: emptyTotals(),
+    });
+  }
+
+  const candidates: R2ObjectMetadata[] = [];
+  for (const object of objects) {
+    const summary = summaries.get(locationIdentity(object));
+    if (!summary) {
+      throw new Error(
+        `Object is outside the inventory locations: ${object.bucket}/${object.key}`,
+      );
+    }
+
+    addObject(summary.scanned, object);
+    if (!isAtLeastDaysOld(object.lastModified, now)) {
+      addObject(summary.youngerThanCutoff, object);
+    } else if (databaseKeys.has(object.key)) {
+      addObject(summary.referencedByDatabase, object);
+    } else {
+      addObject(summary.candidates, object);
+      candidates.push(object);
+    }
+  }
+
+  return {
+    candidates: candidates.sort(compareOldestFirst),
+    summary: [...summaries.values()].sort(compareLocationSummary),
+  };
+}
+
+export function findOrphanCandidates(
+  objects: R2ObjectMetadata[],
+  databaseKeys: ReadonlySet<string>,
+  now: Date,
+): R2ObjectMetadata[] {
+  return objects
+    .filter(
+      (object) =>
+        !databaseKeys.has(object.key) &&
+        isAtLeastDaysOld(object.lastModified, now),
+    )
+    .sort(compareOldestFirst);
+}
+
+export function selectByDownloadLimit(
+  candidates: R2ObjectMetadata[],
+  maxBytes: number,
+): DownloadSelection {
+  if (!Number.isSafeInteger(maxBytes) || maxBytes <= 0) {
+    throw new Error('Download limit must be a positive, safe integer');
+  }
+
+  const selected: R2ObjectMetadata[] = [];
+  const deferred: R2ObjectMetadata[] = [];
+  let transferBytes = 0;
+
+  for (const candidate of [...candidates].sort(compareOldestFirst)) {
+    if (candidate.size <= maxBytes - transferBytes) {
+      selected.push(candidate);
+      transferBytes += candidate.size;
+    } else {
+      deferred.push(candidate);
+    }
+  }
+
+  return { deferred, selected, transferBytes };
+}
+
+export function summarizeObjects(
+  objects: R2ObjectMetadata[],
+): ManifestSummaryEntry[] {
+  const groups = new Map<string, ManifestSummaryEntry>();
+
+  for (const object of objects) {
+    const id = `${object.bucket}\0${object.prefix}`;
+    const current = groups.get(id) ?? {
+      bucket: object.bucket,
+      bytes: 0,
+      count: 0,
+      prefix: object.prefix,
+    };
+    current.bytes += object.size;
+    current.count += 1;
+    groups.set(id, current);
+  }
+
+  return [...groups.values()].sort(
+    (left, right) =>
+      left.bucket.localeCompare(right.bucket) ||
+      left.prefix.localeCompare(right.prefix),
+  );
+}
+
+export function summarizeBuckets(
+  objects: R2ObjectMetadata[],
+  buckets: string[],
+): BucketSummary[] {
+  const totals = new Map(
+    [...new Set(buckets)].map((bucket) => [
+      bucket,
+      { bucket, bytes: 0, count: 0 },
+    ]),
+  );
+
+  for (const object of objects) {
+    const total = totals.get(object.bucket);
+    if (!total) {
+      throw new Error(`Object belongs to an unknown bucket: ${object.bucket}`);
+    }
+    total.bytes += object.size;
+    total.count += 1;
+  }
+
+  return [...totals.values()].sort((left, right) =>
+    left.bucket.localeCompare(right.bucket),
+  );
+}
+
+export function filterAllowedInventoryObjects(
+  objects: R2ObjectMetadata[],
+  locations: AllowedLocation[],
+): R2ObjectMetadata[] {
+  return objects.flatMap((object) => {
+    const location = findAllowedLocation(object.bucket, object.key, locations);
+    return location ? [{ ...object, prefix: location.prefix }] : [];
+  });
+}
+
+export function createManifest(
+  candidates: R2ObjectMetadata[],
+  config: CleanupConfig,
+  now: Date,
+  inventory?: InventorySummaryEntry[],
+  bucketTotals?: BucketSummary[],
+): CleanupManifest {
+  return {
+    bucketNames: {
+      api: config.apiBucket,
+      main: config.mainBucket,
+    },
+    ...(bucketTotals ? { bucketTotals } : {}),
+    candidates: [...candidates].sort(compareOldestFirst),
+    createdAt: now.toISOString(),
+    cutoff: new Date(
+      now.getTime() - MINIMUM_AGE_DAYS * MILLISECONDS_PER_DAY,
+    ).toISOString(),
+    ...(inventory ? { inventory } : {}),
+    minimumAgeDays: MINIMUM_AGE_DAYS,
+    schemaVersion: MANIFEST_SCHEMA_VERSION,
+    summary: summarizeObjects(candidates),
+  };
+}
+
+export function validateManifest(
+  input: unknown,
+  config: CleanupConfig,
+): CleanupManifest {
+  if (!isRecord(input)) {
+    throw new Error('Manifest must be a JSON object');
+  }
+  if (input.schemaVersion !== MANIFEST_SCHEMA_VERSION) {
+    throw new Error(
+      `Unsupported manifest schema version: ${input.schemaVersion}`,
+    );
+  }
+  if (input.minimumAgeDays !== MINIMUM_AGE_DAYS) {
+    throw new Error(`Manifest minimum age must be ${MINIMUM_AGE_DAYS} days`);
+  }
+  const createdAt = input.createdAt;
+  const cutoff = input.cutoff;
+  assertIsoDate(createdAt, 'Manifest createdAt');
+  assertIsoDate(cutoff, 'Manifest cutoff');
+  const expectedCutoff = new Date(
+    new Date(createdAt).getTime() - MINIMUM_AGE_DAYS * MILLISECONDS_PER_DAY,
+  ).toISOString();
+  if (cutoff !== expectedCutoff) {
+    throw new Error('Manifest cutoff does not match its creation time');
+  }
+
+  if (!isRecord(input.bucketNames)) {
+    throw new Error('Manifest bucketNames must be an object');
+  }
+  if (
+    input.bucketNames.main !== config.mainBucket ||
+    input.bucketNames.api !== config.apiBucket
+  ) {
+    throw new Error(
+      'Manifest bucket names do not match the current environment',
+    );
+  }
+  if (!Array.isArray(input.candidates)) {
+    throw new Error('Manifest candidates must be an array');
+  }
+  if (!Array.isArray(input.summary)) {
+    throw new Error('Manifest summary must be an array');
+  }
+
+  const locations = buildAllowedLocations(config);
+  const seen = new Set<string>();
+  const candidates = input.candidates.map((candidate, index) => {
+    const parsed = parseManifestCandidate(candidate, index);
+    const location = findAllowedLocation(parsed.bucket, parsed.key, locations);
+    if (!location || location.prefix !== parsed.prefix) {
+      throw new Error(
+        `Manifest candidate ${index} is outside the bucket and prefix allowlist`,
+      );
+    }
+
+    if (new Date(parsed.lastModified).getTime() > new Date(cutoff).getTime()) {
+      throw new Error(
+        `Manifest candidate ${index} is newer than the manifest cutoff`,
+      );
+    }
+
+    const identity = objectIdentity(parsed);
+    if (seen.has(identity)) {
+      throw new Error(
+        `Manifest contains duplicate object ${parsed.bucket}/${parsed.key}`,
+      );
+    }
+    seen.add(identity);
+    return parsed;
+  });
+
+  const expectedSummary = summarizeObjects(candidates);
+  if (JSON.stringify(input.summary) !== JSON.stringify(expectedSummary)) {
+    throw new Error('Manifest summary does not match its candidates');
+  }
+  const inventory =
+    input.inventory === undefined
+      ? undefined
+      : validateInventorySummary(input.inventory, locations, expectedSummary);
+  const bucketTotals =
+    input.bucketTotals === undefined
+      ? undefined
+      : validateBucketTotals(input.bucketTotals, config, inventory);
+
+  return {
+    bucketNames: {
+      api: config.apiBucket,
+      main: config.mainBucket,
+    },
+    ...(bucketTotals ? { bucketTotals } : {}),
+    candidates,
+    createdAt,
+    cutoff,
+    ...(inventory ? { inventory } : {}),
+    minimumAgeDays: MINIMUM_AGE_DAYS,
+    schemaVersion: MANIFEST_SCHEMA_VERSION,
+    summary: expectedSummary,
+  };
+}
+
+export async function fetchAllStorageKeys(
+  source: StorageKeyPageSource,
+  pageSize = DEFAULT_PAGE_SIZE,
+): Promise<Set<string>> {
+  if (!Number.isSafeInteger(pageSize) || pageSize <= 0) {
+    throw new Error('Page size must be a positive, safe integer');
+  }
+
+  const keys = new Set<string>();
+  let offset = 0;
+
+  while (true) {
+    const page = await source.listStorageKeys(offset, offset + pageSize - 1);
+    for (const key of page) {
+      keys.add(key);
+    }
+    if (page.length < pageSize) {
+      break;
+    }
+    offset += page.length;
+  }
+
+  return keys;
+}
+
+export async function listAllObjects(
+  client: CleanupR2Client,
+  location: AllowedLocation,
+): Promise<R2ObjectMetadata[]> {
+  const objects: R2ObjectMetadata[] = [];
+  const seenTokens = new Set<string>();
+  let continuationToken: string | undefined;
+
+  while (true) {
+    const page = await client.listObjects(
+      location.bucket,
+      location.prefix,
+      continuationToken,
+    );
+
+    for (const object of page.objects) {
+      if (
+        !object.key ||
+        object.size === undefined ||
+        !object.lastModified ||
+        !object.etag
+      ) {
+        throw new Error(
+          `R2 returned incomplete metadata under ${location.bucket}/${location.prefix}`,
+        );
+      }
+      if (!object.key.startsWith(location.prefix)) {
+        throw new Error(
+          `R2 returned an object outside requested prefix ${location.prefix}`,
+        );
+      }
+
+      objects.push({
+        bucket: location.bucket,
+        etag: normalizeEtag(object.etag),
+        key: object.key,
+        lastModified: object.lastModified.toISOString(),
+        prefix: location.prefix,
+        size: object.size,
+      });
+    }
+
+    const nextToken = page.nextContinuationToken;
+    if (!nextToken) {
+      break;
+    }
+    if (seenTokens.has(nextToken)) {
+      throw new Error('R2 pagination returned a repeated continuation token');
+    }
+    seenTokens.add(nextToken);
+    continuationToken = nextToken;
+  }
+
+  return objects;
+}
+
+export async function recheckCandidates(
+  candidates: R2ObjectMetadata[],
+  databaseKeys: ReadonlySet<string>,
+  client: CleanupR2Client,
+  locations: AllowedLocation[],
+  now: Date,
+): Promise<RecheckResult[]> {
+  const results: RecheckResult[] = [];
+
+  for (const candidate of candidates) {
+    const location = findAllowedLocation(
+      candidate.bucket,
+      candidate.key,
+      locations,
+    );
+    if (!location || location.prefix !== candidate.prefix) {
+      throw new Error(
+        `Object is outside the bucket and prefix allowlist: ${candidate.bucket}/${candidate.key}`,
+      );
+    }
+
+    if (databaseKeys.has(candidate.key)) {
+      results.push({ candidate, status: 'referenced-by-database' });
+      continue;
+    }
+
+    let current: R2HeadObject | null;
+    try {
+      current = await client.headObject(candidate.bucket, candidate.key);
+    } catch (error) {
+      results.push({
+        candidate,
+        reason: error instanceof Error ? error.message : String(error),
+        status: 'r2-check-failure',
+      });
+      continue;
+    }
+    if (!current) {
+      results.push({ candidate, status: 'missing-from-r2' });
+      continue;
+    }
+
+    const reason = metadataMismatchReason(candidate, current, now);
+    if (reason) {
+      results.push({ candidate, reason, status: 'changed-in-r2' });
+      continue;
+    }
+
+    results.push({ candidate, status: 'eligible' });
+  }
+
+  return results;
+}
+
+export function resolveLocalObjectPath(
+  downloadDir: string,
+  bucket: string,
+  key: string,
+): string {
+  assertBucketName(bucket);
+  if (
+    !key ||
+    path.isAbsolute(key) ||
+    key.split(/[\\/]/).some((segment) => segment === '..')
+  ) {
+    throw new Error(`Unsafe R2 key: ${key}`);
+  }
+
+  const bucketDirectory = path.resolve(downloadDir, bucket);
+  const destination = path.resolve(bucketDirectory, key);
+  const relative = path.relative(bucketDirectory, destination);
+
+  if (!relative || relative === '..' || relative.startsWith(`..${path.sep}`)) {
+    throw new Error(`Unsafe R2 key: ${key}`);
+  }
+  if (path.isAbsolute(relative)) {
+    throw new Error(`Unsafe R2 key: ${key}`);
+  }
+
+  return destination;
+}
+
+export async function verifyLocalFile(
+  filePath: string,
+  candidate: R2ObjectMetadata,
+): Promise<LocalVerification> {
+  let fileStats: Awaited<ReturnType<typeof stat>>;
+  try {
+    fileStats = await stat(filePath);
+  } catch (error) {
+    if (isNodeError(error, 'ENOENT')) {
+      return { status: 'missing' };
+    }
+    throw error;
+  }
+
+  if (!fileStats.isFile()) {
+    return { reason: 'Local path is not a regular file', status: 'mismatch' };
+  }
+  if (fileStats.size !== candidate.size) {
+    return {
+      reason: `Local size ${fileStats.size} does not match R2 size ${candidate.size}`,
+      status: 'mismatch',
+    };
+  }
+
+  const expectedMd5 = simpleEtagMd5(candidate.etag);
+  if (!expectedMd5) {
+    return {
+      reason: 'R2 ETag is not a simple MD5 checksum',
+      status: 'unverifiable',
+    };
+  }
+
+  const actualMd5 = await md5File(filePath);
+  if (actualMd5 !== expectedMd5) {
+    return {
+      reason: `Local MD5 ${actualMd5} does not match R2 ETag ${expectedMd5}`,
+      status: 'mismatch',
+    };
+  }
+
+  return { status: 'verified' };
+}
+
+export async function downloadWithoutOverwrite(
+  client: CleanupR2Client,
+  candidate: R2ObjectMetadata,
+  downloadDir: string,
+): Promise<DownloadResult> {
+  const destination = resolveLocalObjectPath(
+    downloadDir,
+    candidate.bucket,
+    candidate.key,
+  );
+  let temporaryPath: string | undefined;
+
+  try {
+    const existing = await verifyLocalFile(destination, candidate);
+    if (existing.status !== 'missing') {
+      let status: DownloadResult['status'] = 'failed';
+      if (existing.status === 'verified') {
+        status = 'exists';
+      } else if (existing.status === 'unverifiable') {
+        status = 'unverifiable';
+      }
+      return {
+        destination,
+        reason: existing.reason,
+        status,
+      };
+    }
+
+    await mkdir(path.dirname(destination), { recursive: true });
+    temporaryPath = `${destination}.partial-${randomUUID()}`;
+    const body = await client.getObject(
+      candidate.bucket,
+      candidate.key,
+      candidate.etag,
+    );
+    await pipeline(
+      Readable.from(body),
+      createByteLimitTransform(candidate.size),
+      createWriteStream(temporaryPath, { flags: 'wx' }),
+    );
+
+    const verification = await verifyLocalFile(temporaryPath, candidate);
+    if (
+      verification.status === 'missing' ||
+      verification.status === 'mismatch'
+    ) {
+      return {
+        destination,
+        reason: verification.reason,
+        status: 'failed',
+      };
+    }
+
+    await finalizeWithoutOverwrite(temporaryPath, destination);
+    if (verification.status === 'unverifiable') {
+      return {
+        destination,
+        reason: verification.reason,
+        status: 'unverifiable',
+      };
+    }
+    return { destination, status: 'downloaded' };
+  } catch (error) {
+    return {
+      destination,
+      reason: error instanceof Error ? error.message : String(error),
+      status: 'failed',
+    };
+  } finally {
+    if (temporaryPath) {
+      await rm(temporaryPath, { force: true }).catch(() => undefined);
+    }
+  }
+}
+
+export async function deleteCandidatesInBatches(
+  client: CleanupR2Client,
+  candidates: R2ObjectMetadata[],
+  batchSize = DEFAULT_DELETE_BATCH_SIZE,
+): Promise<DeleteResult[]> {
+  if (!Number.isSafeInteger(batchSize) || batchSize <= 0 || batchSize > 1000) {
+    throw new Error('Delete batch size must be between 1 and 1000');
+  }
+
+  const results: DeleteResult[] = [];
+  const byBucket = Map.groupBy(candidates, (candidate) => candidate.bucket);
+
+  for (const [bucket, bucketCandidates] of byBucket) {
+    for (let index = 0; index < bucketCandidates.length; index += batchSize) {
+      const batch = bucketCandidates.slice(index, index + batchSize);
+      let response: R2DeleteResponse;
+
+      try {
+        response = await client.deleteObjects(
+          bucket,
+          batch.map((candidate) => candidate.key),
+        );
+      } catch (error) {
+        const reason = error instanceof Error ? error.message : String(error);
+        results.push(
+          ...batch.map((candidate) => ({
+            candidate,
+            reason,
+            status: 'deletion-failure' as const,
+          })),
+        );
+        continue;
+      }
+
+      const deleted = new Set(response.deleted);
+      const errors = new Map(
+        response.errors.map((error) => [error.key, error]),
+      );
+
+      for (const candidate of batch) {
+        if (deleted.has(candidate.key)) {
+          results.push({ candidate, status: 'deleted' });
+          continue;
+        }
+
+        const error = errors.get(candidate.key);
+        results.push({
+          candidate,
+          reason: error
+            ? [error.code, error.message].filter(Boolean).join(': ')
+            : 'R2 did not confirm deletion',
+          status: 'deletion-failure',
+        });
+      }
+    }
+  }
+
+  return results;
+}
+
+export function objectIdentity(
+  object: Pick<R2ObjectMetadata, 'bucket' | 'key'>,
+) {
+  return `${object.bucket}\0${object.key}`;
+}
+
+function validateBucketTotals(
+  input: unknown,
+  config: CleanupConfig,
+  inventory?: InventorySummaryEntry[],
+): BucketSummary[] {
+  if (!Array.isArray(input)) {
+    throw new Error('Manifest bucketTotals must be an array');
+  }
+
+  const expectedBuckets = [...new Set([config.mainBucket, config.apiBucket])];
+  const seen = new Set<string>();
+  const totals = input.map((entry, index) => {
+    if (!isRecord(entry) || typeof entry.bucket !== 'string') {
+      throw new Error(`Manifest bucket total ${index} is invalid`);
+    }
+    if (!expectedBuckets.includes(entry.bucket) || seen.has(entry.bucket)) {
+      throw new Error(`Manifest bucket total ${index} has an invalid bucket`);
+    }
+    seen.add(entry.bucket);
+    const total = parseObjectTotals(entry, index, 'bucketTotals');
+    return { bucket: entry.bucket, ...total };
+  });
+
+  if (seen.size !== expectedBuckets.length) {
+    throw new Error(
+      'Manifest bucketTotals must include every configured bucket',
+    );
+  }
+
+  if (inventory) {
+    for (const bucket of totals) {
+      const scanned = inventory
+        .filter((entry) => entry.bucket === bucket.bucket)
+        .reduce(
+          (sum, entry) => ({
+            bytes: sum.bytes + entry.scanned.bytes,
+            count: sum.count + entry.scanned.count,
+          }),
+          emptyTotals(),
+        );
+      if (scanned.count > bucket.count || scanned.bytes > bucket.bytes) {
+        throw new Error(
+          `Manifest inventory exceeds bucket total for ${bucket.bucket}`,
+        );
+      }
+    }
+  }
+
+  return totals.sort((left, right) => left.bucket.localeCompare(right.bucket));
+}
+
+function validateInventorySummary(
+  input: unknown,
+  locations: AllowedLocation[],
+  candidateSummary: ManifestSummaryEntry[],
+): InventorySummaryEntry[] {
+  if (!Array.isArray(input)) {
+    throw new Error('Manifest inventory must be an array');
+  }
+
+  const expectedCandidates = new Map(
+    candidateSummary.map((entry) => [locationIdentity(entry), entry]),
+  );
+  const seen = new Set<string>();
+  const inventory = input.map((entry, index) => {
+    if (!isRecord(entry)) {
+      throw new Error(`Manifest inventory entry ${index} must be an object`);
+    }
+    if (typeof entry.bucket !== 'string' || typeof entry.prefix !== 'string') {
+      throw new Error(
+        `Manifest inventory entry ${index} has an invalid location`,
+      );
+    }
+
+    const location = locations.find(
+      (candidate) =>
+        candidate.bucket === entry.bucket && candidate.prefix === entry.prefix,
+    );
+    if (!location) {
+      throw new Error(
+        `Manifest inventory entry ${index} is outside the location allowlist`,
+      );
+    }
+
+    const identity = locationIdentity(location);
+    if (seen.has(identity)) {
+      throw new Error(
+        `Manifest inventory repeats ${entry.bucket}/${entry.prefix}`,
+      );
+    }
+    seen.add(identity);
+
+    const scanned = parseObjectTotals(entry.scanned, index, 'scanned');
+    const youngerThanCutoff = parseObjectTotals(
+      entry.youngerThanCutoff,
+      index,
+      'youngerThanCutoff',
+    );
+    const referencedByDatabase = parseObjectTotals(
+      entry.referencedByDatabase,
+      index,
+      'referencedByDatabase',
+    );
+    const candidates = parseObjectTotals(entry.candidates, index, 'candidates');
+    if (
+      scanned.count !==
+        youngerThanCutoff.count +
+          referencedByDatabase.count +
+          candidates.count ||
+      scanned.bytes !==
+        youngerThanCutoff.bytes + referencedByDatabase.bytes + candidates.bytes
+    ) {
+      throw new Error(`Manifest inventory entry ${index} totals do not add up`);
+    }
+
+    const expected = expectedCandidates.get(identity) ?? emptyTotals();
+    if (
+      candidates.count !== expected.count ||
+      candidates.bytes !== expected.bytes
+    ) {
+      throw new Error(
+        `Manifest inventory entry ${index} does not match its candidates`,
+      );
+    }
+
+    return {
+      bucket: location.bucket,
+      candidates,
+      prefix: location.prefix,
+      referencedByDatabase,
+      scanned,
+      youngerThanCutoff,
+    };
+  });
+
+  if (seen.size !== locations.length) {
+    throw new Error('Manifest inventory must include every allowed location');
+  }
+
+  return inventory.sort(compareLocationSummary);
+}
+
+function parseObjectTotals(
+  input: unknown,
+  index: number,
+  field: string,
+): ObjectTotals {
+  if (!isRecord(input)) {
+    throw new Error(`Manifest inventory entry ${index} has invalid ${field}`);
+  }
+  if (
+    !Number.isSafeInteger(input.count) ||
+    (input.count as number) < 0 ||
+    !Number.isSafeInteger(input.bytes) ||
+    (input.bytes as number) < 0
+  ) {
+    throw new Error(`Manifest inventory entry ${index} has invalid ${field}`);
+  }
+  return { bytes: input.bytes as number, count: input.count as number };
+}
+
+function parseManifestCandidate(
+  input: unknown,
+  index: number,
+): R2ObjectMetadata {
+  if (!isRecord(input)) {
+    throw new Error(`Manifest candidate ${index} must be an object`);
+  }
+
+  const stringFields = [
+    'bucket',
+    'etag',
+    'key',
+    'lastModified',
+    'prefix',
+  ] as const;
+  for (const field of stringFields) {
+    if (typeof input[field] !== 'string' || input[field].length === 0) {
+      throw new Error(`Manifest candidate ${index} has invalid ${field}`);
+    }
+  }
+  if (!Number.isSafeInteger(input.size) || (input.size as number) < 0) {
+    throw new Error(`Manifest candidate ${index} has invalid size`);
+  }
+  assertIsoDate(input.lastModified, `Manifest candidate ${index} lastModified`);
+
+  return {
+    bucket: input.bucket as string,
+    etag: normalizeEtag(input.etag as string),
+    key: input.key as string,
+    lastModified: input.lastModified as string,
+    prefix: input.prefix as string,
+    size: input.size as number,
+  };
+}
+
+function metadataMismatchReason(
+  candidate: R2ObjectMetadata,
+  current: R2HeadObject,
+  now: Date,
+): string | undefined {
+  if (current.size === undefined || !current.lastModified || !current.etag) {
+    return 'R2 HeadObject returned incomplete metadata';
+  }
+  if (!isAtLeastDaysOld(current.lastModified, now)) {
+    return 'Object is younger than the retention cutoff';
+  }
+  if (current.size !== candidate.size) {
+    return `Size changed from ${candidate.size} to ${current.size}`;
+  }
+  if (normalizeEtag(current.etag) !== normalizeEtag(candidate.etag)) {
+    return 'ETag changed';
+  }
+  if (current.lastModified.toISOString() !== candidate.lastModified) {
+    return 'LastModified changed';
+  }
+  return undefined;
+}
+
+function emptyTotals(): ObjectTotals {
+  return { bytes: 0, count: 0 };
+}
+
+function addObject(totals: ObjectTotals, object: R2ObjectMetadata): void {
+  totals.bytes += object.size;
+  totals.count += 1;
+}
+
+function locationIdentity(
+  location: Pick<AllowedLocation, 'bucket' | 'prefix'>,
+): string {
+  return `${location.bucket}\0${location.prefix}`;
+}
+
+function compareLocationSummary(
+  left: Pick<AllowedLocation, 'bucket' | 'prefix'>,
+  right: Pick<AllowedLocation, 'bucket' | 'prefix'>,
+): number {
+  return (
+    left.bucket.localeCompare(right.bucket) ||
+    left.prefix.localeCompare(right.prefix)
+  );
+}
+
+function compareOldestFirst(
+  left: R2ObjectMetadata,
+  right: R2ObjectMetadata,
+): number {
+  return (
+    new Date(left.lastModified).getTime() -
+      new Date(right.lastModified).getTime() ||
+    left.bucket.localeCompare(right.bucket) ||
+    left.key.localeCompare(right.key)
+  );
+}
+
+function assertBucketName(bucket: string): void {
+  if (
+    !bucket ||
+    bucket === '.' ||
+    bucket === '..' ||
+    bucket.includes('/') ||
+    bucket.includes('\\')
+  ) {
+    throw new Error(`Unsafe R2 bucket name: ${bucket}`);
+  }
+}
+
+function assertIsoDate(value: unknown, label: string): asserts value is string {
+  if (
+    typeof value !== 'string' ||
+    !Number.isFinite(new Date(value).getTime()) ||
+    new Date(value).toISOString() !== value
+  ) {
+    throw new Error(`${label} must be an ISO timestamp`);
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isNodeError(
+  error: unknown,
+  code: string,
+): error is NodeJS.ErrnoException {
+  return error instanceof Error && 'code' in error && error.code === code;
+}
+
+function createByteLimitTransform(maxBytes: number): Transform {
+  let bytes = 0;
+  return new Transform({
+    transform(chunk: Buffer, _encoding, callback) {
+      bytes += chunk.byteLength;
+      if (bytes > maxBytes) {
+        callback(
+          new Error(
+            `R2 response exceeded the expected size of ${maxBytes} bytes`,
+          ),
+        );
+        return;
+      }
+      callback(null, chunk);
+    },
+  });
+}
+
+async function finalizeWithoutOverwrite(
+  temporaryPath: string,
+  destination: string,
+): Promise<void> {
+  try {
+    await link(temporaryPath, destination);
+  } catch (error) {
+    const hardLinksUnsupported =
+      isNodeError(error, 'EPERM') ||
+      isNodeError(error, 'ENOTSUP') ||
+      isNodeError(error, 'EOPNOTSUPP');
+    if (!hardLinksUnsupported) {
+      throw error;
+    }
+    await copyFile(temporaryPath, destination, constants.COPYFILE_EXCL);
+  }
+}
+
+async function md5File(filePath: string): Promise<string> {
+  const hash = createHash('md5');
+  for await (const chunk of createReadStream(filePath)) {
+    hash.update(chunk);
+  }
+  return hash.digest('hex');
+}

--- a/scripts/lib/r2-orphan-audio-cleanup.mts
+++ b/scripts/lib/r2-orphan-audio-cleanup.mts
@@ -87,6 +87,10 @@ export interface StorageKeyPageSource {
   listStorageKeys: (from: number, to: number) => Promise<string[]>;
 }
 
+export interface AudioUrlCache {
+  deleteKey: (key: string) => Promise<void>;
+}
+
 export type RecheckStatus =
   | 'changed-in-r2'
   | 'eligible'
@@ -542,6 +546,16 @@ export async function recheckCandidates(
   }
 
   return results;
+}
+
+export async function evictDeletedAudioCache(
+  candidate: R2ObjectMetadata,
+  mainBucket: string,
+  cache: AudioUrlCache,
+): Promise<void> {
+  if (candidate.bucket === mainBucket) {
+    await cache.deleteKey(candidate.key);
+  }
 }
 
 export async function deleteCandidatesInBatches(

--- a/scripts/lib/r2-transfer.mts
+++ b/scripts/lib/r2-transfer.mts
@@ -8,6 +8,13 @@ import { pipeline } from 'node:stream/promises';
 const SIMPLE_ETAG_PATTERN = /^[a-f\d]{32}$/i;
 const SIZE_PATTERN = /^(\d+(?:\.\d+)?)\s*(KB|MB|GB|TB|KiB|MiB|GiB|TiB)$/i;
 
+export class UnsafeLocalPathError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'UnsafeLocalPathError';
+  }
+}
+
 export interface R2Location {
   bucket: string;
   prefix: string;
@@ -93,6 +100,18 @@ export interface DownloadResult {
     | 'existing-checksum'
     | 'existing-size'
     | 'missing-from-r2';
+}
+
+export function assertR2BucketName(bucket: string): void {
+  if (
+    !bucket ||
+    bucket === '.' ||
+    bucket === '..' ||
+    bucket.includes('/') ||
+    bucket.includes('\\')
+  ) {
+    throw new UnsafeLocalPathError(`Unsafe R2 bucket name: ${bucket}`);
+  }
 }
 
 export function parseByteSize(input: string): number {
@@ -197,7 +216,7 @@ export async function listAllObjects(
   client: Pick<R2Client, 'listObjects'>,
   location: R2Location,
 ): Promise<R2ObjectMetadata[]> {
-  assertBucketName(location.bucket);
+  assertR2BucketName(location.bucket);
 
   const objects: R2ObjectMetadata[] = [];
   const seenTokens = new Set<string>();
@@ -261,14 +280,18 @@ export async function resolveLocalObjectPath(
   bucket: string,
   key: string,
 ): Promise<string> {
-  assertBucketName(bucket);
+  assertR2BucketName(bucket);
+  const keySegments = key.split('/');
   if (
     !key ||
     path.isAbsolute(key) ||
     path.win32.isAbsolute(key) ||
-    key.split(/[\\/]/).some((segment) => segment === '..')
+    key.includes('\\') ||
+    keySegments.some(
+      (segment) => segment.length === 0 || segment === '.' || segment === '..',
+    )
   ) {
-    throw new Error(`Unsafe R2 key: ${key}`);
+    throw new UnsafeLocalPathError(`Unsafe R2 key: ${key}`);
   }
 
   const rootDirectory = path.resolve(downloadDir);
@@ -277,10 +300,10 @@ export async function resolveLocalObjectPath(
   const relative = path.relative(bucketDirectory, destination);
 
   if (!relative || relative === '..' || relative.startsWith(`..${path.sep}`)) {
-    throw new Error(`Unsafe R2 key: ${key}`);
+    throw new UnsafeLocalPathError(`Unsafe R2 key: ${key}`);
   }
   if (path.isAbsolute(relative)) {
-    throw new Error(`Unsafe R2 key: ${key}`);
+    throw new UnsafeLocalPathError(`Unsafe R2 key: ${key}`);
   }
 
   await assertNoSymlinkComponents(rootDirectory, destination);
@@ -374,10 +397,18 @@ export async function downloadWithoutOverwrite(
       signal,
     );
     if (response.status === 'changed') {
-      return { destination, status: 'changed-in-r2' };
+      return {
+        destination,
+        reason: 'R2 object changed after it was listed',
+        status: 'changed-in-r2',
+      };
     }
     if (response.status === 'missing') {
-      return { destination, status: 'missing-from-r2' };
+      return {
+        destination,
+        reason: 'R2 object disappeared after it was listed',
+        status: 'missing-from-r2',
+      };
     }
 
     await pipeline(
@@ -437,7 +468,9 @@ async function assertNoSymlinkComponents(
     try {
       const currentStats = await lstat(current);
       if (currentStats.isSymbolicLink()) {
-        throw new Error(`Unsafe symlink in local backup path: ${current}`);
+        throw new UnsafeLocalPathError(
+          `Unsafe symlink in local backup path: ${current}`,
+        );
       }
     } catch (error) {
       if (isNodeError(error, 'ENOENT')) {
@@ -445,18 +478,6 @@ async function assertNoSymlinkComponents(
       }
       throw error;
     }
-  }
-}
-
-function assertBucketName(bucket: string): void {
-  if (
-    !bucket ||
-    bucket === '.' ||
-    bucket === '..' ||
-    bucket.includes('/') ||
-    bucket.includes('\\')
-  ) {
-    throw new Error(`Unsafe R2 bucket name: ${bucket}`);
   }
 }
 

--- a/scripts/lib/r2-transfer.mts
+++ b/scripts/lib/r2-transfer.mts
@@ -1,6 +1,14 @@
 import { createHash, randomUUID } from 'node:crypto';
 import { constants, createReadStream, createWriteStream } from 'node:fs';
-import { copyFile, link, lstat, mkdir, rm, stat } from 'node:fs/promises';
+import {
+  access,
+  copyFile,
+  link,
+  lstat,
+  mkdir,
+  rm,
+  stat,
+} from 'node:fs/promises';
 import path from 'node:path';
 import { Readable, Transform } from 'node:stream';
 import { pipeline } from 'node:stream/promises';
@@ -273,6 +281,13 @@ export async function listAllObjects(
   }
 
   return objects;
+}
+
+export async function assertUsableDownloadRoot(
+  downloadDir: string,
+): Promise<void> {
+  await access(downloadDir, constants.W_OK);
+  await access(downloadDir, constants.X_OK);
 }
 
 export async function resolveLocalObjectPath(

--- a/scripts/lib/r2-transfer.mts
+++ b/scripts/lib/r2-transfer.mts
@@ -1,0 +1,512 @@
+import { createHash, randomUUID } from 'node:crypto';
+import { constants, createReadStream, createWriteStream } from 'node:fs';
+import { copyFile, link, lstat, mkdir, rm, stat } from 'node:fs/promises';
+import path from 'node:path';
+import { Readable, Transform } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
+
+const SIMPLE_ETAG_PATTERN = /^[a-f\d]{32}$/i;
+const SIZE_PATTERN = /^(\d+(?:\.\d+)?)\s*(KB|MB|GB|TB|KiB|MiB|GiB|TiB)$/i;
+
+export interface R2Location {
+  bucket: string;
+  prefix: string;
+}
+
+export interface R2ObjectMetadata extends R2Location {
+  etag: string;
+  key: string;
+  lastModified: string;
+  size: number;
+}
+
+export interface R2ListedObject {
+  etag?: string;
+  key?: string;
+  lastModified?: Date;
+  size?: number;
+}
+
+export interface R2ListPage {
+  nextContinuationToken?: string;
+  objects: R2ListedObject[];
+}
+
+export interface R2HeadObject {
+  etag?: string;
+  lastModified?: Date;
+  size?: number;
+}
+
+export interface R2DeleteError {
+  code?: string;
+  key: string;
+  message?: string;
+}
+
+export interface R2DeleteResponse {
+  deleted: string[];
+  errors: R2DeleteError[];
+}
+
+export type R2GetObjectResult =
+  | { body: AsyncIterable<Uint8Array>; status: 'ok' }
+  | { status: 'changed' }
+  | { status: 'missing' };
+
+export interface R2Client {
+  deleteObjects: (bucket: string, keys: string[]) => Promise<R2DeleteResponse>;
+  getObject: (
+    bucket: string,
+    key: string,
+    expectedEtag: string,
+    signal?: AbortSignal,
+  ) => Promise<R2GetObjectResult>;
+  headObject: (bucket: string, key: string) => Promise<R2HeadObject | null>;
+  listObjects: (
+    bucket: string,
+    prefix: string,
+    continuationToken?: string,
+  ) => Promise<R2ListPage>;
+}
+
+export interface DownloadSelection {
+  deferred: R2ObjectMetadata[];
+  selected: R2ObjectMetadata[];
+  transferBytes: number;
+}
+
+export type LocalVerification =
+  | { status: 'missing' }
+  | { reason: string; status: 'mismatch' }
+  | { status: 'verified-checksum' }
+  | { reason: string; status: 'verified-size' };
+
+export interface DownloadResult {
+  destination: string;
+  reason?: string;
+  status:
+    | 'changed-in-r2'
+    | 'download-failure'
+    | 'downloaded-checksum'
+    | 'downloaded-size'
+    | 'existing-checksum'
+    | 'existing-size'
+    | 'missing-from-r2';
+}
+
+export function parseByteSize(input: string): number {
+  const match = SIZE_PATTERN.exec(input.trim());
+  if (!match) {
+    throw new Error(
+      'Size must use KB, MB, GB, TB, KiB, MiB, GiB, or TiB, for example 20GB',
+    );
+  }
+
+  const value = Number(match[1]);
+  if (!(value > 0)) {
+    throw new Error('Size must be greater than zero');
+  }
+
+  const unit = match[2].toLowerCase();
+  const powers: Record<string, number> = {
+    gb: 1000 ** 3,
+    gib: 1024 ** 3,
+    kb: 1000,
+    kib: 1024,
+    mb: 1000 ** 2,
+    mib: 1024 ** 2,
+    tb: 1000 ** 4,
+    tib: 1024 ** 4,
+  };
+  const bytes = value * powers[unit];
+
+  if (!Number.isSafeInteger(bytes)) {
+    throw new Error('Size must resolve to a whole, safe number of bytes');
+  }
+
+  return bytes;
+}
+
+export function formatBytes(bytes: number): string {
+  const units = ['B', 'KiB', 'MiB', 'GiB', 'TiB'];
+  let value = bytes;
+  let unit = units[0];
+
+  for (const candidate of units) {
+    unit = candidate;
+    if (value < 1024 || candidate === units.at(-1)) {
+      break;
+    }
+    value /= 1024;
+  }
+
+  return `${value.toFixed(value >= 10 || unit === 'B' ? 0 : 1)} ${unit}`;
+}
+
+export function normalizeEtag(etag: string): string {
+  const trimmed = etag.trim();
+  if (trimmed.startsWith('"') && trimmed.endsWith('"')) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}
+
+export function simpleEtagMd5(etag: string): string | null {
+  const normalized = normalizeEtag(etag);
+  return SIMPLE_ETAG_PATTERN.test(normalized) ? normalized.toLowerCase() : null;
+}
+
+export function compareR2ObjectsOldestFirst(
+  left: R2ObjectMetadata,
+  right: R2ObjectMetadata,
+): number {
+  return (
+    new Date(left.lastModified).getTime() -
+      new Date(right.lastModified).getTime() ||
+    left.bucket.localeCompare(right.bucket) ||
+    left.key.localeCompare(right.key)
+  );
+}
+
+export function selectByDownloadLimit(
+  candidates: R2ObjectMetadata[],
+  maxBytes: number,
+): DownloadSelection {
+  if (!Number.isSafeInteger(maxBytes) || maxBytes <= 0) {
+    throw new Error('Download limit must be a positive, safe integer');
+  }
+
+  const selected: R2ObjectMetadata[] = [];
+  const deferred: R2ObjectMetadata[] = [];
+  let transferBytes = 0;
+
+  for (const candidate of [...candidates].sort(compareR2ObjectsOldestFirst)) {
+    if (candidate.size <= maxBytes - transferBytes) {
+      selected.push(candidate);
+      transferBytes += candidate.size;
+    } else {
+      deferred.push(candidate);
+    }
+  }
+
+  return { deferred, selected, transferBytes };
+}
+
+export async function listAllObjects(
+  client: Pick<R2Client, 'listObjects'>,
+  location: R2Location,
+): Promise<R2ObjectMetadata[]> {
+  assertBucketName(location.bucket);
+
+  const objects: R2ObjectMetadata[] = [];
+  const seenTokens = new Set<string>();
+  let continuationToken: string | undefined;
+
+  while (true) {
+    const page = await client.listObjects(
+      location.bucket,
+      location.prefix,
+      continuationToken,
+    );
+
+    for (const object of page.objects) {
+      if (
+        !object.key ||
+        object.size === undefined ||
+        !object.lastModified ||
+        !object.etag
+      ) {
+        throw new Error(
+          `R2 returned incomplete metadata under ${location.bucket}/${location.prefix}`,
+        );
+      }
+      if (!object.key.startsWith(location.prefix)) {
+        throw new Error(
+          `R2 returned an object outside requested prefix ${location.prefix}`,
+        );
+      }
+      if (!Number.isSafeInteger(object.size) || object.size < 0) {
+        throw new Error(
+          `R2 returned an invalid size under ${location.bucket}/${location.prefix}`,
+        );
+      }
+
+      objects.push({
+        bucket: location.bucket,
+        etag: normalizeEtag(object.etag),
+        key: object.key,
+        lastModified: object.lastModified.toISOString(),
+        prefix: location.prefix,
+        size: object.size,
+      });
+    }
+
+    const nextToken = page.nextContinuationToken;
+    if (!nextToken) {
+      break;
+    }
+    if (seenTokens.has(nextToken)) {
+      throw new Error('R2 pagination returned a repeated continuation token');
+    }
+    seenTokens.add(nextToken);
+    continuationToken = nextToken;
+  }
+
+  return objects;
+}
+
+export async function resolveLocalObjectPath(
+  downloadDir: string,
+  bucket: string,
+  key: string,
+): Promise<string> {
+  assertBucketName(bucket);
+  if (
+    !key ||
+    path.isAbsolute(key) ||
+    path.win32.isAbsolute(key) ||
+    key.split(/[\\/]/).some((segment) => segment === '..')
+  ) {
+    throw new Error(`Unsafe R2 key: ${key}`);
+  }
+
+  const rootDirectory = path.resolve(downloadDir);
+  const bucketDirectory = path.resolve(rootDirectory, bucket);
+  const destination = path.resolve(bucketDirectory, key);
+  const relative = path.relative(bucketDirectory, destination);
+
+  if (!relative || relative === '..' || relative.startsWith(`..${path.sep}`)) {
+    throw new Error(`Unsafe R2 key: ${key}`);
+  }
+  if (path.isAbsolute(relative)) {
+    throw new Error(`Unsafe R2 key: ${key}`);
+  }
+
+  await assertNoSymlinkComponents(rootDirectory, destination);
+  return destination;
+}
+
+export async function verifyLocalFile(
+  filePath: string,
+  object: R2ObjectMetadata,
+): Promise<LocalVerification> {
+  let fileStats: Awaited<ReturnType<typeof stat>>;
+  try {
+    fileStats = await stat(filePath);
+  } catch (error) {
+    if (isNodeError(error, 'ENOENT')) {
+      return { status: 'missing' };
+    }
+    throw error;
+  }
+
+  if (!fileStats.isFile()) {
+    return { reason: 'Local path is not a regular file', status: 'mismatch' };
+  }
+  if (fileStats.size !== object.size) {
+    return {
+      reason: `Local size ${fileStats.size} does not match R2 size ${object.size}`,
+      status: 'mismatch',
+    };
+  }
+
+  const expectedMd5 = simpleEtagMd5(object.etag);
+  if (!expectedMd5) {
+    return {
+      reason: 'R2 ETag is opaque; verified by size only',
+      status: 'verified-size',
+    };
+  }
+
+  const actualMd5 = await md5File(filePath);
+  if (actualMd5 !== expectedMd5) {
+    return {
+      reason: `Local MD5 ${actualMd5} does not match R2 ETag ${expectedMd5}`,
+      status: 'mismatch',
+    };
+  }
+
+  return { status: 'verified-checksum' };
+}
+
+export async function downloadWithoutOverwrite(
+  client: Pick<R2Client, 'getObject'>,
+  object: R2ObjectMetadata,
+  downloadDir: string,
+  signal?: AbortSignal,
+): Promise<DownloadResult> {
+  const destination = await resolveLocalObjectPath(
+    downloadDir,
+    object.bucket,
+    object.key,
+  );
+  let temporaryPath: string | undefined;
+
+  try {
+    const existing = await verifyLocalFile(destination, object);
+    if (existing.status !== 'missing') {
+      if (existing.status === 'verified-checksum') {
+        return { destination, status: 'existing-checksum' };
+      }
+      if (existing.status === 'verified-size') {
+        return {
+          destination,
+          reason: existing.reason,
+          status: 'existing-size',
+        };
+      }
+      return {
+        destination,
+        reason: existing.reason,
+        status: 'download-failure',
+      };
+    }
+
+    await mkdir(path.dirname(destination), { recursive: true });
+    await resolveLocalObjectPath(downloadDir, object.bucket, object.key);
+    temporaryPath = `${destination}.partial-${randomUUID()}`;
+
+    const response = await client.getObject(
+      object.bucket,
+      object.key,
+      object.etag,
+      signal,
+    );
+    if (response.status === 'changed') {
+      return { destination, status: 'changed-in-r2' };
+    }
+    if (response.status === 'missing') {
+      return { destination, status: 'missing-from-r2' };
+    }
+
+    await pipeline(
+      Readable.from(response.body),
+      createByteLimitTransform(object.size),
+      createWriteStream(temporaryPath, { flags: 'wx' }),
+      ...(signal ? [{ signal }] : []),
+    );
+
+    const verification = await verifyLocalFile(temporaryPath, object);
+    if (
+      verification.status === 'missing' ||
+      verification.status === 'mismatch'
+    ) {
+      return {
+        destination,
+        reason:
+          'reason' in verification
+            ? verification.reason
+            : 'Downloaded file is missing',
+        status: 'download-failure',
+      };
+    }
+
+    await resolveLocalObjectPath(downloadDir, object.bucket, object.key);
+    await finalizeWithoutOverwrite(temporaryPath, destination);
+    if (verification.status === 'verified-size') {
+      return {
+        destination,
+        reason: verification.reason,
+        status: 'downloaded-size',
+      };
+    }
+    return { destination, status: 'downloaded-checksum' };
+  } catch (error) {
+    return {
+      destination,
+      reason: error instanceof Error ? error.message : String(error),
+      status: 'download-failure',
+    };
+  } finally {
+    if (temporaryPath) {
+      await rm(temporaryPath, { force: true }).catch(() => undefined);
+    }
+  }
+}
+
+async function assertNoSymlinkComponents(
+  rootDirectory: string,
+  destination: string,
+): Promise<void> {
+  const relative = path.relative(rootDirectory, destination);
+  let current = rootDirectory;
+
+  for (const segment of relative.split(path.sep)) {
+    current = path.join(current, segment);
+    try {
+      const currentStats = await lstat(current);
+      if (currentStats.isSymbolicLink()) {
+        throw new Error(`Unsafe symlink in local backup path: ${current}`);
+      }
+    } catch (error) {
+      if (isNodeError(error, 'ENOENT')) {
+        return;
+      }
+      throw error;
+    }
+  }
+}
+
+function assertBucketName(bucket: string): void {
+  if (
+    !bucket ||
+    bucket === '.' ||
+    bucket === '..' ||
+    bucket.includes('/') ||
+    bucket.includes('\\')
+  ) {
+    throw new Error(`Unsafe R2 bucket name: ${bucket}`);
+  }
+}
+
+function isNodeError(
+  error: unknown,
+  code: string,
+): error is NodeJS.ErrnoException {
+  return error instanceof Error && 'code' in error && error.code === code;
+}
+
+function createByteLimitTransform(maxBytes: number): Transform {
+  let bytes = 0;
+  return new Transform({
+    transform(chunk: Buffer, _encoding, callback) {
+      bytes += chunk.byteLength;
+      if (bytes > maxBytes) {
+        callback(
+          new Error(
+            `R2 response exceeded the expected size of ${maxBytes} bytes`,
+          ),
+        );
+        return;
+      }
+      callback(null, chunk);
+    },
+  });
+}
+
+async function finalizeWithoutOverwrite(
+  temporaryPath: string,
+  destination: string,
+): Promise<void> {
+  try {
+    await link(temporaryPath, destination);
+  } catch (error) {
+    const hardLinksUnsupported =
+      isNodeError(error, 'EPERM') ||
+      isNodeError(error, 'ENOTSUP') ||
+      isNodeError(error, 'EOPNOTSUPP');
+    if (!hardLinksUnsupported) {
+      throw error;
+    }
+    await copyFile(temporaryPath, destination, constants.COPYFILE_EXCL);
+  }
+}
+
+async function md5File(filePath: string): Promise<string> {
+  const hash = createHash('md5');
+  for await (const chunk of createReadStream(filePath)) {
+    hash.update(chunk);
+  }
+  return hash.digest('hex');
+}

--- a/scripts/lib/supabase.mts
+++ b/scripts/lib/supabase.mts
@@ -1,0 +1,26 @@
+import { createClient } from '@supabase/supabase-js';
+
+interface ScriptAdminClientOptions {
+  persistSession?: boolean;
+}
+
+export function createScriptAdminClient({
+  persistSession = false,
+}: ScriptAdminClientOptions = {}) {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const secretKey = process.env.SUPABASE_SECRET_KEY;
+
+  if (!supabaseUrl) {
+    throw new Error('Missing env.NEXT_PUBLIC_SUPABASE_URL');
+  }
+  if (!secretKey) {
+    throw new Error('Missing env.SUPABASE_SECRET_KEY');
+  }
+
+  return createClient(supabaseUrl, secretKey, {
+    auth: {
+      autoRefreshToken: false,
+      persistSession,
+    },
+  });
+}

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -6,7 +6,7 @@
     "analyze-free-users": "node --env-file=.env analyze-free-users.mjs",
     "backfill-call-analysis": "node backfill-call-analysis.mjs",
     "backfill-free-call": "tsx backfill-free-call.mts",
-    "backup-r2-audio": "tsx backup-r2-audio.mts",
+    "backup-r2-audio": "NODE_ENV=production tsx backup-r2-audio.mts",
     "batch-refund-credits": "tsx batch-refund-credits.mts",
     "check-disposable-emails": "node check-disposable-emails.mjs",
     "cleanup-orphaned-r2-audio": "tsx cleanup-orphaned-r2-audio.mts",

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -8,6 +8,7 @@
     "backfill-free-call": "tsx backfill-free-call.mts",
     "batch-refund-credits": "tsx batch-refund-credits.mts",
     "check-disposable-emails": "node check-disposable-emails.mjs",
+    "cleanup-orphaned-r2-audio": "tsx cleanup-orphaned-r2-audio.mts",
     "compile-dispute-evidence": "tsx compile-dispute-evidence.mts",
     "find-truncated-gemini31-tts": "node find-truncated-gemini31-tts.mjs",
     "generate-gemini-speech-samples": "node generate-gemini-speech-samples.mjs",
@@ -15,10 +16,13 @@
     "refund-credits": "tsx refund-credits.mts",
     "reset-freeloader-credits": "tsx reset-freeloader-credits.mts",
     "sync-deny-domains": "node sync-deny-domains.mjs",
-    "test-gemini-tts-stream": "node test-gemini-tts-stream.mjs"
+    "test": "tsx --test r2-orphan-audio-cleanup.test.mts",
+    "test-gemini-tts-stream": "node test-gemini-tts-stream.mjs",
+    "type-check": "tsc --noEmit"
   },
   "dependencies": {
     "@ai-sdk/xai": "3.0.96",
+    "@aws-sdk/client-s3": "3.1011.0",
     "@google/genai": "1.19.0",
     "@supabase/supabase-js": "catalog:",
     "ai": "catalog:",
@@ -26,6 +30,8 @@
     "dotenv": "^16.6.1"
   },
   "devDependencies": {
-    "tsx": "catalog:"
+    "@types/node": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:"
   }
 }

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -26,6 +26,7 @@
     "@aws-sdk/client-s3": "3.1011.0",
     "@google/genai": "1.19.0",
     "@supabase/supabase-js": "catalog:",
+    "@upstash/redis": "catalog:",
     "ai": "catalog:",
     "disposable-email-domains-js": "^1.21.0",
     "dotenv": "^16.6.1",

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -6,6 +6,7 @@
     "analyze-free-users": "node --env-file=.env analyze-free-users.mjs",
     "backfill-call-analysis": "node backfill-call-analysis.mjs",
     "backfill-free-call": "tsx backfill-free-call.mts",
+    "backup-r2-audio": "tsx backup-r2-audio.mts",
     "batch-refund-credits": "tsx batch-refund-credits.mts",
     "check-disposable-emails": "node check-disposable-emails.mjs",
     "cleanup-orphaned-r2-audio": "tsx cleanup-orphaned-r2-audio.mts",
@@ -16,7 +17,7 @@
     "refund-credits": "tsx refund-credits.mts",
     "reset-freeloader-credits": "tsx reset-freeloader-credits.mts",
     "sync-deny-domains": "node sync-deny-domains.mjs",
-    "test": "tsx --test r2-orphan-audio-cleanup.test.mts",
+    "test": "tsx --test *r2*.test.mts",
     "test-gemini-tts-stream": "node test-gemini-tts-stream.mjs",
     "type-check": "tsc --noEmit"
   },
@@ -27,7 +28,9 @@
     "@supabase/supabase-js": "catalog:",
     "ai": "catalog:",
     "disposable-email-domains-js": "^1.21.0",
-    "dotenv": "^16.6.1"
+    "dotenv": "^16.6.1",
+    "effect": "catalog:",
+    "effective-progress": "catalog:"
   },
   "devDependencies": {
     "@types/node": "catalog:",

--- a/scripts/r2-audio-backup.test.mts
+++ b/scripts/r2-audio-backup.test.mts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import { createHash } from 'node:crypto';
 import {
+  access,
   mkdir,
   mkdtemp,
   readdir,
@@ -378,6 +379,82 @@ describe('local transfer safety', () => {
 });
 
 describe('backup planning and reporting', () => {
+  it('creates the download directory before listing', async () => {
+    await withTempDirectory(async (directory) => {
+      const downloadDir = path.join(directory, 'nested', 'download');
+      let listed = false;
+      const output = await runBackup(
+        { downloadDir, dryRun: false, help: false },
+        [{ bucket: 'audio', prefix: '' }],
+        {
+          client: mockR2({
+            async listObjects() {
+              await access(downloadDir);
+              listed = true;
+              return { objects: [] };
+            },
+          }),
+          interactive: false,
+          log: () => undefined,
+          reportDirectory: path.join(directory, 'reports'),
+        },
+      );
+
+      assert.equal(listed, true);
+      assert.equal(output.exitCode, 0);
+    });
+  });
+
+  it('rejects an unusable download directory before listing', async () => {
+    await withTempDirectory(async (directory) => {
+      const blockedPath = path.join(directory, 'blocked');
+      await writeFile(blockedPath, 'not a directory');
+      let listed = false;
+
+      await assert.rejects(
+        runBackup(
+          {
+            downloadDir: path.join(blockedPath, 'download'),
+            dryRun: false,
+            help: false,
+          },
+          [{ bucket: 'audio', prefix: '' }],
+          {
+            client: mockR2({
+              listObjects() {
+                listed = true;
+                return Promise.resolve({ objects: [] });
+              },
+            }),
+            interactive: false,
+            log: () => undefined,
+            reportDirectory: path.join(directory, 'reports'),
+          },
+        ),
+        /EEXIST|ENOTDIR/,
+      );
+      assert.equal(listed, false);
+    });
+  });
+
+  it('does not create the download directory during a dry run', async () => {
+    await withTempDirectory(async (directory) => {
+      const downloadDir = path.join(directory, 'download');
+      await runBackup(
+        { downloadDir, dryRun: true, help: false },
+        [{ bucket: 'audio', prefix: '' }],
+        {
+          client: mockR2(),
+          interactive: false,
+          log: () => undefined,
+          reportDirectory: path.join(directory, 'reports'),
+        },
+      );
+
+      await assert.rejects(access(downloadDir), /ENOENT/);
+    });
+  });
+
   it('rejects a zero transfer cap from direct callers', async () => {
     await withTempDirectory(async (directory) => {
       const item = object('missing.wav');

--- a/scripts/r2-audio-backup.test.mts
+++ b/scripts/r2-audio-backup.test.mts
@@ -340,6 +340,43 @@ describe('local transfer safety', () => {
 });
 
 describe('backup planning and reporting', () => {
+  it('rejects a zero transfer cap from direct callers', async () => {
+    await withTempDirectory(async (directory) => {
+      const item = object('missing.wav');
+      await assert.rejects(
+        runBackup(
+          {
+            downloadDir: path.join(directory, 'download'),
+            dryRun: true,
+            help: false,
+            maxDownloadBytes: 0,
+          },
+          [{ bucket: 'audio', prefix: '' }],
+          {
+            client: mockR2({
+              listObjects() {
+                return Promise.resolve({
+                  objects: [
+                    {
+                      etag: item.etag,
+                      key: item.key,
+                      lastModified: new Date(item.lastModified),
+                      size: item.size,
+                    },
+                  ],
+                });
+              },
+            }),
+            interactive: false,
+            log: () => undefined,
+            reportDirectory: path.join(directory, 'reports'),
+          },
+        ),
+        /positive, safe integer/,
+      );
+    });
+  });
+
   it('plans a dry run without downloading or creating missing files', async () => {
     await withTempDirectory(async (directory) => {
       const downloadDir = path.join(directory, 'download');

--- a/scripts/r2-audio-backup.test.mts
+++ b/scripts/r2-audio-backup.test.mts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import { createHash } from 'node:crypto';
 import {
   access,
+  chmod,
   mkdir,
   mkdtemp,
   readdir,
@@ -406,35 +407,38 @@ describe('backup planning and reporting', () => {
     });
   });
 
-  it('rejects an unusable download directory before listing', async () => {
+  it('rejects a read-only download directory before listing', {
+    skip: process.getuid?.() === 0,
+  }, async () => {
     await withTempDirectory(async (directory) => {
-      const blockedPath = path.join(directory, 'blocked');
-      await writeFile(blockedPath, 'not a directory');
+      const downloadDir = path.join(directory, 'read-only');
+      await mkdir(downloadDir);
+      await chmod(downloadDir, 0o555);
       let listed = false;
 
-      await assert.rejects(
-        runBackup(
-          {
-            downloadDir: path.join(blockedPath, 'download'),
-            dryRun: false,
-            help: false,
-          },
-          [{ bucket: 'audio', prefix: '' }],
-          {
-            client: mockR2({
-              listObjects() {
-                listed = true;
-                return Promise.resolve({ objects: [] });
-              },
-            }),
-            interactive: false,
-            log: () => undefined,
-            reportDirectory: path.join(directory, 'reports'),
-          },
-        ),
-        /EEXIST|ENOTDIR/,
-      );
-      assert.equal(listed, false);
+      try {
+        await assert.rejects(
+          runBackup(
+            { downloadDir, dryRun: false, help: false },
+            [{ bucket: 'audio', prefix: '' }],
+            {
+              client: mockR2({
+                listObjects() {
+                  listed = true;
+                  return Promise.resolve({ objects: [] });
+                },
+              }),
+              interactive: false,
+              log: () => undefined,
+              reportDirectory: path.join(directory, 'reports'),
+            },
+          ),
+          /EACCES/,
+        );
+        assert.equal(listed, false);
+      } finally {
+        await chmod(downloadDir, 0o755);
+      }
     });
   });
 

--- a/scripts/r2-audio-backup.test.mts
+++ b/scripts/r2-audio-backup.test.mts
@@ -1,0 +1,629 @@
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import {
+  mkdir,
+  mkdtemp,
+  readdir,
+  readFile,
+  rm,
+  symlink,
+  writeFile,
+} from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { describe, it } from 'node:test';
+import { GetObjectCommand } from '@aws-sdk/client-s3';
+
+import {
+  parseBackupCliArgs,
+  resolveBackupSources,
+  runBackup,
+  runDownloadEffects,
+} from './backup-r2-audio.mts';
+import { createR2Client, createR2ClientAdapter } from './lib/r2-client.mts';
+import {
+  downloadWithoutOverwrite,
+  type R2Client,
+  type R2ObjectMetadata,
+  resolveLocalObjectPath,
+} from './lib/r2-transfer.mts';
+
+function object(
+  key: string,
+  overrides: Partial<R2ObjectMetadata> = {},
+): R2ObjectMetadata {
+  return {
+    bucket: 'audio',
+    etag: createHash('md5').update(key).digest('hex'),
+    key,
+    lastModified: '2026-01-01T00:00:00.000Z',
+    prefix: '',
+    size: Buffer.byteLength(key),
+    ...overrides,
+  };
+}
+
+async function* byteStream(...chunks: Uint8Array[]) {
+  await Promise.resolve();
+  yield* chunks;
+}
+
+function mockR2(overrides: Partial<R2Client> = {}): R2Client {
+  return {
+    deleteObjects(_bucket, keys) {
+      return Promise.resolve({ deleted: keys, errors: [] });
+    },
+    getObject(_bucket, key) {
+      return Promise.resolve({
+        body: byteStream(Buffer.from(key)),
+        status: 'ok' as const,
+      });
+    },
+    headObject() {
+      return Promise.resolve(null);
+    },
+    listObjects() {
+      return Promise.resolve({ objects: [] });
+    },
+    ...overrides,
+  };
+}
+
+async function withTempDirectory(
+  callback: (directory: string) => Promise<void>,
+): Promise<void> {
+  const directory = await mkdtemp(path.join(tmpdir(), 'r2-backup-'));
+  try {
+    await callback(directory);
+  } finally {
+    await rm(directory, { force: true, recursive: true });
+  }
+}
+
+describe('backup CLI and sources', () => {
+  it('parses required options and transfer sizes', () => {
+    assert.deepEqual(
+      parseBackupCliArgs([
+        '--',
+        '--download-dir',
+        '/Volumes/backup',
+        '--source',
+        'audio/generated/',
+        '--max-download-size',
+        '1.5GiB',
+        '--dry-run',
+      ]),
+      {
+        downloadDir: '/Volumes/backup',
+        dryRun: true,
+        help: false,
+        maxDownloadBytes: 1.5 * 1024 ** 3,
+        source: 'audio/generated/',
+      },
+    );
+    assert.throws(() => parseBackupCliArgs([]), /--download-dir is required/);
+    assert.equal(parseBackupCliArgs(['--help']).help, true);
+  });
+
+  it('uses both default buckets and removes exact duplicates', () => {
+    assert.deepEqual(
+      resolveBackupSources(undefined, {
+        R2_BUCKET_NAME: 'main-audio',
+        R2_SPEECH_API_BUCKET_NAME: 'api-audio',
+      }),
+      [
+        { bucket: 'main-audio', prefix: '' },
+        { bucket: 'api-audio', prefix: '' },
+      ],
+    );
+    assert.deepEqual(
+      resolveBackupSources(' audio/generated/ ,audio/generated/, api ', {}),
+      [
+        { bucket: 'audio', prefix: 'generated/' },
+        { bucket: 'api', prefix: '' },
+      ],
+    );
+  });
+
+  it('preserves exact prefixes and rejects overlap or empty sources', () => {
+    assert.deepEqual(resolveBackupSources('audio/audio', {}), [
+      { bucket: 'audio', prefix: 'audio' },
+    ]);
+    assert.throws(
+      () => resolveBackupSources('audio/audio,audio/audio/', {}),
+      /sources overlap/,
+    );
+    assert.throws(
+      () => resolveBackupSources('audio,audio/generated/', {}),
+      /sources overlap/,
+    );
+    assert.throws(
+      () => resolveBackupSources('audio,,api', {}),
+      /empty R2 location/,
+    );
+    assert.throws(() => resolveBackupSources('', {}), /empty R2 location/);
+  });
+
+  it('validates R2 credentials when the client is created', () => {
+    assert.throws(() => createR2Client({}), /R2_ACCESS_KEY_ID/);
+  });
+});
+
+describe('R2 client adapter', () => {
+  it('sends If-Match and maps conditional request failures', async () => {
+    const calls: Array<{
+      command: unknown;
+      options?: { abortSignal?: AbortSignal };
+    }> = [];
+    let handler: (command: unknown) => Promise<unknown> = () =>
+      Promise.resolve({ body: undefined });
+    const sender = {
+      send(command: unknown, options?: { abortSignal?: AbortSignal }) {
+        calls.push({ command, options });
+        return handler(command);
+      },
+    } as unknown as Parameters<typeof createR2ClientAdapter>[0];
+    const client = createR2ClientAdapter(sender);
+    const signal = AbortSignal.timeout(1000);
+    handler = () =>
+      Promise.resolve({ Body: byteStream(Buffer.from('contents')) });
+
+    const downloaded = await client.getObject(
+      'audio',
+      'file.wav',
+      'ABCDEF0123456789ABCDEF0123456789',
+      signal,
+    );
+    assert.equal(downloaded.status, 'ok');
+    assert.ok(calls[0].command instanceof GetObjectCommand);
+    assert.equal(
+      (calls[0].command as GetObjectCommand).input.IfMatch,
+      '"ABCDEF0123456789ABCDEF0123456789"',
+    );
+    assert.equal(calls[0].options?.abortSignal, signal);
+
+    handler = () =>
+      Promise.reject(
+        Object.assign(new Error('precondition failed'), {
+          $metadata: { httpStatusCode: 412 },
+          name: 'PreconditionFailed',
+        }),
+      );
+    assert.deepEqual(await client.getObject('audio', 'file.wav', 'etag'), {
+      status: 'changed',
+    });
+
+    handler = () =>
+      Promise.reject(
+        Object.assign(new Error('not found'), {
+          $metadata: { httpStatusCode: 404 },
+          name: 'NoSuchKey',
+        }),
+      );
+    assert.deepEqual(await client.getObject('audio', 'file.wav', 'etag'), {
+      status: 'missing',
+    });
+  });
+
+  it('rejects a successful response without a streaming body', async () => {
+    const sender = {
+      send() {
+        return Promise.resolve({});
+      },
+    } as unknown as Parameters<typeof createR2ClientAdapter>[0];
+    const client = createR2ClientAdapter(sender);
+
+    await assert.rejects(
+      client.getObject('audio', 'file.wav', 'etag'),
+      /no streaming body/,
+    );
+  });
+});
+
+describe('local transfer safety', () => {
+  it('rejects keys that cannot map losslessly', async () => {
+    await assert.rejects(
+      resolveLocalObjectPath('/tmp/backups', 'audio', 'a//b.wav'),
+      /Unsafe R2 key/,
+    );
+    await assert.rejects(
+      resolveLocalObjectPath('/tmp/backups', 'audio', 'a/./b.wav'),
+      /Unsafe R2 key/,
+    );
+    await assert.rejects(
+      resolveLocalObjectPath('/tmp/backups', 'audio', 'a/b.wav/'),
+      /Unsafe R2 key/,
+    );
+    await assert.rejects(
+      resolveLocalObjectPath('/tmp/backups', 'audio', 'a\\b.wav'),
+      /Unsafe R2 key/,
+    );
+  });
+
+  it('rejects symlinked destination components', async () => {
+    await withTempDirectory(async (directory) => {
+      const outside = await mkdtemp(path.join(tmpdir(), 'r2-outside-'));
+      try {
+        await mkdir(path.join(directory, 'audio'));
+        await symlink(outside, path.join(directory, 'audio', 'linked'));
+        await assert.rejects(
+          resolveLocalObjectPath(directory, 'audio', 'linked/file.wav'),
+          /Unsafe symlink/,
+        );
+      } finally {
+        await rm(outside, { force: true, recursive: true });
+      }
+    });
+  });
+
+  it('passes the listed ETag to the conditional download', async () => {
+    await withTempDirectory(async (directory) => {
+      const contents = Buffer.from('download me');
+      const item = object('generated/file.wav', {
+        etag: createHash('md5').update(contents).digest('hex'),
+        size: contents.length,
+      });
+      let expectedEtag: string | undefined;
+      const result = await downloadWithoutOverwrite(
+        mockR2({
+          getObject(_bucket, _key, etag) {
+            expectedEtag = etag;
+            return Promise.resolve({
+              body: byteStream(contents),
+              status: 'ok' as const,
+            });
+          },
+        }),
+        item,
+        directory,
+      );
+
+      assert.equal(expectedEtag, item.etag);
+      assert.equal(result.status, 'downloaded-checksum');
+      assert.deepEqual(await readFile(result.destination), contents);
+    });
+  });
+
+  it('classifies changed and missing remote objects', async () => {
+    await withTempDirectory(async (directory) => {
+      const changed = await downloadWithoutOverwrite(
+        mockR2({
+          getObject() {
+            return Promise.resolve({ status: 'changed' as const });
+          },
+        }),
+        object('changed.wav'),
+        directory,
+      );
+      const missing = await downloadWithoutOverwrite(
+        mockR2({
+          getObject() {
+            return Promise.resolve({ status: 'missing' as const });
+          },
+        }),
+        object('missing.wav'),
+        directory,
+      );
+
+      assert.equal(changed.status, 'changed-in-r2');
+      assert.match(changed.reason ?? '', /changed after it was listed/);
+      assert.equal(missing.status, 'missing-from-r2');
+      assert.match(missing.reason ?? '', /disappeared after it was listed/);
+    });
+  });
+
+  it('rejects short downloads and removes partial files', async () => {
+    await withTempDirectory(async (directory) => {
+      const item = object('generated/short.wav', {
+        etag: createHash('md5').update('longer').digest('hex'),
+        size: 6,
+      });
+      const result = await downloadWithoutOverwrite(
+        mockR2({
+          getObject() {
+            return Promise.resolve({
+              body: byteStream(Buffer.from('short')),
+              status: 'ok' as const,
+            });
+          },
+        }),
+        item,
+        directory,
+      );
+
+      assert.equal(result.status, 'download-failure');
+      assert.match(result.reason ?? '', /does not match R2 size/);
+      const parent = path.dirname(result.destination);
+      assert.deepEqual(await readdir(parent), []);
+    });
+  });
+});
+
+describe('backup planning and reporting', () => {
+  it('plans a dry run without downloading or creating missing files', async () => {
+    await withTempDirectory(async (directory) => {
+      const downloadDir = path.join(directory, 'download');
+      const reportDirectory = path.join(directory, 'reports');
+      const checksumContents = Buffer.from('same');
+      const sizeContents = Buffer.from('opaque');
+      const checksum = object('existing/checksum.wav', {
+        etag: createHash('md5').update(checksumContents).digest('hex'),
+        size: checksumContents.length,
+      });
+      const sizeOnly = object('existing/size.wav', {
+        etag: 'multipart-2',
+        size: sizeContents.length,
+      });
+      const mismatch = object('existing/mismatch.wav', { size: 10 });
+      const large = object('missing/large.wav', {
+        lastModified: '2025-01-01T00:00:00.000Z',
+        size: 10,
+      });
+      const small = object('missing/small.wav', {
+        lastModified: '2025-02-01T00:00:00.000Z',
+        size: 4,
+      });
+      for (const [item, contents] of [
+        [checksum, checksumContents],
+        [sizeOnly, sizeContents],
+        [mismatch, Buffer.from('wrong')],
+      ] as const) {
+        const destination = await resolveLocalObjectPath(
+          downloadDir,
+          item.bucket,
+          item.key,
+        );
+        await mkdir(path.dirname(destination), { recursive: true });
+        await writeFile(destination, contents);
+      }
+
+      let getCalls = 0;
+      const client = mockR2({
+        getObject() {
+          getCalls += 1;
+          return Promise.resolve({ status: 'missing' as const });
+        },
+        listObjects() {
+          return Promise.resolve({
+            objects: [checksum, sizeOnly, mismatch, large, small].map(
+              (item) => ({
+                etag: item.etag,
+                key: item.key,
+                lastModified: new Date(item.lastModified),
+                size: item.size,
+              }),
+            ),
+          });
+        },
+      });
+      const output = await runBackup(
+        {
+          downloadDir,
+          dryRun: true,
+          help: false,
+          maxDownloadBytes: 5,
+        },
+        [{ bucket: 'audio', prefix: '' }],
+        {
+          client,
+          interactive: false,
+          log: () => undefined,
+          now: () => new Date('2026-08-23T12:00:00.000Z'),
+          reportDirectory,
+        },
+      );
+
+      assert.equal(getCalls, 0);
+      assert.equal(output.exitCode, 1);
+      assert.deepEqual(
+        output.report.results.map((result) => [result.key, result.status]),
+        [
+          ['missing/large.wav', 'deferred-by-size-cap'],
+          ['missing/small.wav', 'selected-for-download'],
+          ['existing/checksum.wav', 'existing-checksum'],
+          ['existing/mismatch.wav', 'local-mismatch'],
+          ['existing/size.wav', 'existing-size'],
+        ],
+      );
+      await assert.rejects(
+        readFile(path.join(downloadDir, 'audio', small.key)),
+        /ENOENT/,
+      );
+      const saved = JSON.parse(await readFile(output.reportPath, 'utf8'));
+      assert.equal(saved.results.length, 5);
+      assert.deepEqual(saved.sourceTotals, [
+        { bucket: 'audio', bytes: 34, count: 5, prefix: '' },
+      ]);
+    });
+  });
+
+  it('makes no downloads when any source listing fails', async () => {
+    await withTempDirectory(async (directory) => {
+      let downloadsStarted = false;
+      const output = await runBackup(
+        {
+          downloadDir: path.join(directory, 'download'),
+          dryRun: false,
+          help: false,
+        },
+        [
+          { bucket: 'good', prefix: '' },
+          { bucket: 'bad', prefix: 'audio/' },
+        ],
+        {
+          client: mockR2({
+            listObjects(bucket) {
+              return bucket === 'bad'
+                ? Promise.reject(new Error('access denied'))
+                : Promise.resolve({ objects: [] });
+            },
+          }),
+          log: () => undefined,
+          reportDirectory: path.join(directory, 'reports'),
+          runDownloads() {
+            downloadsStarted = true;
+            return Promise.resolve([]);
+          },
+        },
+      );
+
+      assert.equal(downloadsStarted, false);
+      assert.equal(output.exitCode, 1);
+      assert.equal(output.report.results.length, 0);
+      assert.deepEqual(output.report.listingFailures, [
+        { bucket: 'bad', prefix: 'audio/', reason: 'access denied' },
+      ]);
+    });
+  });
+
+  it('records every mixed download result and returns a failure', async () => {
+    await withTempDirectory(async (directory) => {
+      const items = [
+        object('one.wav'),
+        object('two.wav'),
+        object('three.wav'),
+        object('four.wav'),
+        object('five.wav'),
+      ];
+      const statuses = [
+        'downloaded-checksum',
+        'downloaded-size',
+        'changed-in-r2',
+        'missing-from-r2',
+        'download-failure',
+      ] as const;
+      const output = await runBackup(
+        {
+          downloadDir: path.join(directory, 'download'),
+          dryRun: false,
+          help: false,
+        },
+        [{ bucket: 'audio', prefix: '' }],
+        {
+          client: mockR2({
+            listObjects() {
+              return Promise.resolve({
+                objects: items.map((item) => ({
+                  etag: item.etag,
+                  key: item.key,
+                  lastModified: new Date(item.lastModified),
+                  size: item.size,
+                })),
+              });
+            },
+          }),
+          log: () => undefined,
+          reportDirectory: path.join(directory, 'reports'),
+          runDownloads(selected) {
+            return Promise.resolve(
+              selected.map((_, index) => ({
+                destination: '',
+                reason: statuses[index].includes('download')
+                  ? undefined
+                  : 'expected test failure',
+                status: statuses[index],
+              })),
+            );
+          },
+        },
+      );
+
+      assert.equal(output.exitCode, 1);
+      assert.deepEqual(
+        output.report.results.map((result) => result.status),
+        statuses,
+      );
+      assert.equal(
+        output.report.summary.bySource.reduce(
+          (sum, entry) => sum + entry.count,
+          0,
+        ),
+        items.length,
+      );
+      assert.equal(
+        output.report.summary.byBucket.reduce(
+          (sum, entry) => sum + entry.count,
+          0,
+        ),
+        items.length,
+      );
+      assert.equal(
+        output.report.summary.byStatus.reduce(
+          (sum, entry) => sum + entry.count,
+          0,
+        ),
+        items.length,
+      );
+    });
+  });
+
+  it('classifies filesystem inspection errors separately from unsafe paths', async () => {
+    await withTempDirectory(async (directory) => {
+      const downloadDir = path.join(directory, 'download');
+      await mkdir(path.join(downloadDir, 'audio'), { recursive: true });
+      await writeFile(path.join(downloadDir, 'audio', 'blocked'), 'file');
+      const blocked = object('blocked/file.wav');
+      const output = await runBackup(
+        { downloadDir, dryRun: true, help: false },
+        [{ bucket: 'audio', prefix: '' }],
+        {
+          client: mockR2({
+            listObjects() {
+              return Promise.resolve({
+                objects: [
+                  {
+                    etag: blocked.etag,
+                    key: blocked.key,
+                    lastModified: new Date(blocked.lastModified),
+                    size: blocked.size,
+                  },
+                ],
+              });
+            },
+          }),
+          log: () => undefined,
+          reportDirectory: path.join(directory, 'reports'),
+        },
+      );
+
+      assert.equal(output.report.results[0].status, 'local-read-failure');
+      assert.equal(output.exitCode, 1);
+    });
+  });
+});
+
+describe('download scheduler', () => {
+  it('runs at most four downloads and retains failures', async () => {
+    const items = Array.from({ length: 7 }, (_, index) =>
+      object(`file-${index}.wav`),
+    );
+    let active = 0;
+    let maxActive = 0;
+    const outcomes = await runDownloadEffects(
+      items,
+      async (_item, signal) => {
+        assert.ok(signal);
+        active += 1;
+        maxActive = Math.max(maxActive, active);
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        active -= 1;
+        return {
+          destination: '',
+          reason: active === 1 ? 'failure' : undefined,
+          status: active === 1 ? 'download-failure' : 'downloaded-checksum',
+        };
+      },
+      100,
+      false,
+    );
+
+    assert.equal(maxActive, 4);
+    assert.equal(outcomes.length, items.length);
+    assert.ok(
+      outcomes.some((outcome) => outcome.status === 'download-failure'),
+    );
+    assert.ok(
+      outcomes.some((outcome) => outcome.status === 'downloaded-checksum'),
+    );
+  });
+});

--- a/scripts/r2-audio-backup.test.mts
+++ b/scripts/r2-audio-backup.test.mts
@@ -379,29 +379,30 @@ describe('local transfer safety', () => {
 });
 
 describe('backup planning and reporting', () => {
-  it('creates the download directory before listing', async () => {
+  it('rejects a missing download directory before listing', async () => {
     await withTempDirectory(async (directory) => {
-      const downloadDir = path.join(directory, 'nested', 'download');
+      const downloadDir = path.join(directory, 'missing');
       let listed = false;
-      const output = await runBackup(
-        { downloadDir, dryRun: false, help: false },
-        [{ bucket: 'audio', prefix: '' }],
-        {
-          client: mockR2({
-            async listObjects() {
-              await access(downloadDir);
-              listed = true;
-              return { objects: [] };
-            },
-          }),
-          interactive: false,
-          log: () => undefined,
-          reportDirectory: path.join(directory, 'reports'),
-        },
-      );
 
-      assert.equal(listed, true);
-      assert.equal(output.exitCode, 0);
+      await assert.rejects(
+        runBackup(
+          { downloadDir, dryRun: false, help: false },
+          [{ bucket: 'audio', prefix: '' }],
+          {
+            client: mockR2({
+              listObjects() {
+                listed = true;
+                return Promise.resolve({ objects: [] });
+              },
+            }),
+            interactive: false,
+            log: () => undefined,
+            reportDirectory: path.join(directory, 'reports'),
+          },
+        ),
+        /ENOENT/,
+      );
+      assert.equal(listed, false);
     });
   });
 
@@ -591,10 +592,12 @@ describe('backup planning and reporting', () => {
 
   it('makes no downloads when any source listing fails', async () => {
     await withTempDirectory(async (directory) => {
+      const downloadDir = path.join(directory, 'download');
+      await mkdir(downloadDir);
       let downloadsStarted = false;
       const output = await runBackup(
         {
-          downloadDir: path.join(directory, 'download'),
+          downloadDir,
           dryRun: false,
           help: false,
         },
@@ -630,6 +633,8 @@ describe('backup planning and reporting', () => {
 
   it('records every mixed download result and returns a failure', async () => {
     await withTempDirectory(async (directory) => {
+      const downloadDir = path.join(directory, 'download');
+      await mkdir(downloadDir);
       const items = [
         object('one.wav'),
         object('two.wav'),
@@ -646,7 +651,7 @@ describe('backup planning and reporting', () => {
       ] as const;
       const output = await runBackup(
         {
-          downloadDir: path.join(directory, 'download'),
+          downloadDir,
           dryRun: false,
           help: false,
         },

--- a/scripts/r2-audio-backup.test.mts
+++ b/scripts/r2-audio-backup.test.mts
@@ -638,16 +638,19 @@ describe('download scheduler', () => {
     let maxActive = 0;
     const outcomes = await runDownloadEffects(
       items,
-      async (_item, signal) => {
+      async (item, signal) => {
         assert.ok(signal);
         active += 1;
         maxActive = Math.max(maxActive, active);
-        await new Promise((resolve) => setTimeout(resolve, 5));
+        const index = items.indexOf(item);
+        await new Promise((resolve) =>
+          setTimeout(resolve, (items.length - index) * 2),
+        );
         active -= 1;
         return {
           destination: '',
-          reason: active === 1 ? 'failure' : undefined,
-          status: active === 1 ? 'download-failure' : 'downloaded-checksum',
+          reason: item.key,
+          status: index === 3 ? 'download-failure' : 'downloaded-checksum',
         };
       },
       100,
@@ -656,6 +659,10 @@ describe('download scheduler', () => {
 
     assert.equal(maxActive, 4);
     assert.equal(outcomes.length, items.length);
+    assert.deepEqual(
+      outcomes.map((outcome) => outcome.reason),
+      items.map((item) => item.key),
+    );
     assert.ok(
       outcomes.some((outcome) => outcome.status === 'download-failure'),
     );

--- a/scripts/r2-audio-backup.test.mts
+++ b/scripts/r2-audio-backup.test.mts
@@ -284,6 +284,44 @@ describe('local transfer safety', () => {
     });
   });
 
+  it('rejects same-size files with the wrong MD5', async () => {
+    await withTempDirectory(async (directory) => {
+      const expected = Buffer.from('right');
+      const existing = Buffer.from('wrong');
+      const item = object('generated/mismatch.wav', {
+        etag: createHash('md5').update(expected).digest('hex'),
+        size: expected.length,
+      });
+      const destination = await resolveLocalObjectPath(
+        directory,
+        item.bucket,
+        item.key,
+      );
+      await mkdir(path.dirname(destination), { recursive: true });
+      await writeFile(destination, existing);
+      let getCalls = 0;
+
+      const result = await downloadWithoutOverwrite(
+        mockR2({
+          getObject() {
+            getCalls += 1;
+            return Promise.resolve({
+              body: byteStream(expected),
+              status: 'ok' as const,
+            });
+          },
+        }),
+        item,
+        directory,
+      );
+
+      assert.equal(result.status, 'download-failure');
+      assert.match(result.reason ?? '', /Local MD5 .* does not match R2 ETag/);
+      assert.equal(getCalls, 0);
+      assert.deepEqual(await readFile(destination), existing);
+    });
+  });
+
   it('classifies changed and missing remote objects', async () => {
     await withTempDirectory(async (directory) => {
       const changed = await downloadWithoutOverwrite(

--- a/scripts/r2-orphan-audio-cleanup.test.mts
+++ b/scripts/r2-orphan-audio-cleanup.test.mts
@@ -9,26 +9,28 @@ import {
   analyzeInventory,
   buildAllowedLocations,
   type CleanupConfig,
-  type CleanupR2Client,
   createManifest,
   deleteCandidatesInBatches,
-  downloadWithoutOverwrite,
   fetchAllStorageKeys,
   filterAllowedInventoryObjects,
   findAllowedLocation,
   findOrphanCandidates,
   isAtLeastDaysOld,
-  listAllObjects,
-  parseByteSize,
   parseCleanupCliArgs,
-  type R2ObjectMetadata,
   recheckCandidates,
-  resolveLocalObjectPath,
-  selectByDownloadLimit,
-  simpleEtagMd5,
   summarizeBuckets,
   validateManifest,
 } from './lib/r2-orphan-audio-cleanup.mts';
+import {
+  downloadWithoutOverwrite,
+  listAllObjects,
+  parseByteSize,
+  type R2Client,
+  type R2ObjectMetadata,
+  resolveLocalObjectPath,
+  selectByDownloadLimit,
+  simpleEtagMd5,
+} from './lib/r2-transfer.mts';
 
 const config: CleanupConfig = {
   apiBucket: 'api-audio',
@@ -56,13 +58,16 @@ async function* byteStream(...chunks: Uint8Array[]) {
   yield* chunks;
 }
 
-function mockR2(overrides: Partial<CleanupR2Client> = {}): CleanupR2Client {
+function mockR2(overrides: Partial<R2Client> = {}): R2Client {
   return {
     deleteObjects(_bucket, keys) {
       return Promise.resolve({ deleted: keys, errors: [] });
     },
     getObject() {
-      return Promise.resolve(byteStream(new Uint8Array()));
+      return Promise.resolve({
+        body: byteStream(new Uint8Array()),
+        status: 'ok' as const,
+      });
     },
     headObject(_bucket, key) {
       return Promise.resolve({
@@ -409,19 +414,17 @@ describe('manifest and CLI validation', () => {
 });
 
 describe('local backup safety', () => {
-  it('rejects path traversal', () => {
-    assert.throws(
-      () =>
-        resolveLocalObjectPath(
-          '/tmp/backups',
-          'main-audio',
-          'generated-audio-free/../../outside.mp3',
-        ),
+  it('rejects path traversal', async () => {
+    await assert.rejects(
+      resolveLocalObjectPath(
+        '/tmp/backups',
+        'main-audio',
+        'generated-audio-free/../../outside.mp3',
+      ),
       /Unsafe R2 key/,
     );
-    assert.throws(
-      () =>
-        resolveLocalObjectPath('/tmp/backups', 'main-audio', '/outside.mp3'),
+    await assert.rejects(
+      resolveLocalObjectPath('/tmp/backups', 'main-audio', '/outside.mp3'),
       /Unsafe R2 key/,
     );
   });
@@ -446,14 +449,17 @@ describe('local backup safety', () => {
       const result = await downloadWithoutOverwrite(
         mockR2({
           getObject() {
-            return Promise.resolve(byteStream(contents));
+            return Promise.resolve({
+              body: byteStream(contents),
+              status: 'ok' as const,
+            });
           },
         }),
         item,
         directory,
       );
 
-      assert.equal(result.status, 'unverifiable');
+      assert.equal(result.status, 'downloaded-size');
       assert.deepEqual(await readFile(result.destination), contents);
     } finally {
       await rm(directory, { force: true, recursive: true });
@@ -470,14 +476,17 @@ describe('local backup safety', () => {
       const result = await downloadWithoutOverwrite(
         mockR2({
           getObject() {
-            return Promise.resolve(byteStream(Buffer.from('too large')));
+            return Promise.resolve({
+              body: byteStream(Buffer.from('too large')),
+              status: 'ok' as const,
+            });
           },
         }),
         item,
         directory,
       );
 
-      assert.equal(result.status, 'failed');
+      assert.equal(result.status, 'download-failure');
       assert.match(result.reason ?? '', /exceeded the expected size/);
       await assert.rejects(readFile(result.destination), /ENOENT/);
     } finally {
@@ -493,7 +502,7 @@ describe('local backup safety', () => {
         etag: createHash('md5').update(contents).digest('hex'),
         size: contents.length,
       });
-      const destination = resolveLocalObjectPath(
+      const destination = await resolveLocalObjectPath(
         directory,
         item.bucket,
         item.key,
@@ -505,14 +514,17 @@ describe('local backup safety', () => {
         mockR2({
           getObject() {
             getCalls += 1;
-            return Promise.resolve(byteStream(Buffer.from('replacement')));
+            return Promise.resolve({
+              body: byteStream(Buffer.from('replacement')),
+              status: 'ok' as const,
+            });
           },
         }),
         item,
         directory,
       );
 
-      assert.equal(result.status, 'exists');
+      assert.equal(result.status, 'existing-checksum');
       assert.equal(getCalls, 0);
       assert.deepEqual(await readFile(destination), contents);
     } finally {

--- a/scripts/r2-orphan-audio-cleanup.test.mts
+++ b/scripts/r2-orphan-audio-cleanup.test.mts
@@ -1,0 +1,671 @@
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { describe, it } from 'node:test';
+
+import {
+  analyzeInventory,
+  buildAllowedLocations,
+  type CleanupConfig,
+  type CleanupR2Client,
+  createManifest,
+  deleteCandidatesInBatches,
+  downloadWithoutOverwrite,
+  fetchAllStorageKeys,
+  filterAllowedInventoryObjects,
+  findAllowedLocation,
+  findOrphanCandidates,
+  isAtLeastDaysOld,
+  listAllObjects,
+  parseByteSize,
+  parseCleanupCliArgs,
+  type R2ObjectMetadata,
+  recheckCandidates,
+  resolveLocalObjectPath,
+  selectByDownloadLimit,
+  simpleEtagMd5,
+  summarizeBuckets,
+  validateManifest,
+} from './lib/r2-orphan-audio-cleanup.mts';
+
+const config: CleanupConfig = {
+  apiBucket: 'api-audio',
+  mainBucket: 'main-audio',
+};
+const now = new Date('2026-08-22T12:00:00.000Z');
+
+function candidate(
+  key: string,
+  overrides: Partial<R2ObjectMetadata> = {},
+): R2ObjectMetadata {
+  return {
+    bucket: 'main-audio',
+    etag: 'd41d8cd98f00b204e9800998ecf8427e',
+    key,
+    lastModified: '2026-06-01T00:00:00.000Z',
+    prefix: 'generated-audio-free/',
+    size: 0,
+    ...overrides,
+  };
+}
+
+async function* byteStream(...chunks: Uint8Array[]) {
+  await Promise.resolve();
+  yield* chunks;
+}
+
+function mockR2(overrides: Partial<CleanupR2Client> = {}): CleanupR2Client {
+  return {
+    deleteObjects(_bucket, keys) {
+      return Promise.resolve({ deleted: keys, errors: [] });
+    },
+    getObject() {
+      return Promise.resolve(byteStream(new Uint8Array()));
+    },
+    headObject(_bucket, key) {
+      return Promise.resolve({
+        etag: 'd41d8cd98f00b204e9800998ecf8427e',
+        lastModified: new Date('2026-06-01T00:00:00.000Z'),
+        size: key.length,
+      });
+    },
+    listObjects() {
+      return Promise.resolve({ objects: [] });
+    },
+    ...overrides,
+  };
+}
+
+describe('size parsing', () => {
+  it('parses decimal and binary units', () => {
+    assert.equal(parseByteSize('1.5GB'), 1_500_000_000);
+    assert.equal(parseByteSize('2 MiB'), 2 * 1024 * 1024);
+    assert.equal(parseByteSize('1TB'), 1_000_000_000_000);
+    assert.equal(parseByteSize('1TiB'), 1024 ** 4);
+  });
+
+  it('rejects zero and invalid limits', () => {
+    assert.throws(() => parseByteSize('0GB'), /greater than zero/);
+    assert.throws(() => parseByteSize('20'), /Size must use/);
+    assert.throws(() => parseByteSize('-1GB'), /Size must use/);
+  });
+});
+
+describe('candidate rules', () => {
+  it('includes the exact 45-day boundary', () => {
+    const boundary = new Date(now.getTime() - 45 * 24 * 60 * 60 * 1000);
+    assert.equal(isAtLeastDaysOld(boundary, now), true);
+    assert.equal(
+      isAtLeastDaysOld(new Date(boundary.getTime() + 1), now),
+      false,
+    );
+  });
+
+  it('protects a database key across both buckets', () => {
+    const key = 'generated-audio-free/shared.mp3';
+    const objects = [
+      candidate(key),
+      candidate(key, { bucket: 'api-audio' }),
+      candidate('generated-audio-free/orphan.mp3', { bucket: 'api-audio' }),
+    ];
+
+    assert.deepEqual(
+      findOrphanCandidates(objects, new Set([key]), now).map(
+        (object) => object.key,
+      ),
+      ['generated-audio-free/orphan.mp3'],
+    );
+  });
+
+  it('builds an auditable funnel for every allowed location', () => {
+    const locations = buildAllowedLocations(config);
+    const referencedKey = 'generated-audio-free/referenced.mp3';
+    const inventory = analyzeInventory(
+      [
+        candidate('generated-audio-free/young.mp3', {
+          lastModified: '2026-08-01T00:00:00.000Z',
+          size: 1,
+        }),
+        candidate(referencedKey, { size: 2 }),
+        candidate('generated-audio-free/orphan.mp3', { size: 3 }),
+        candidate('generated-audio-free/api-orphan.mp3', {
+          bucket: 'api-audio',
+          size: 4,
+        }),
+      ],
+      new Set([referencedKey]),
+      now,
+      locations,
+    );
+
+    assert.deepEqual(
+      inventory.candidates.map((object) => object.key),
+      [
+        'generated-audio-free/api-orphan.mp3',
+        'generated-audio-free/orphan.mp3',
+      ],
+    );
+    assert.deepEqual(inventory.summary, [
+      {
+        bucket: 'api-audio',
+        candidates: { bytes: 4, count: 1 },
+        prefix: 'generated-audio-free/',
+        referencedByDatabase: { bytes: 0, count: 0 },
+        scanned: { bytes: 4, count: 1 },
+        youngerThanCutoff: { bytes: 0, count: 0 },
+      },
+      {
+        bucket: 'main-audio',
+        candidates: { bytes: 0, count: 0 },
+        prefix: 'cloned-audio-free/',
+        referencedByDatabase: { bytes: 0, count: 0 },
+        scanned: { bytes: 0, count: 0 },
+        youngerThanCutoff: { bytes: 0, count: 0 },
+      },
+      {
+        bucket: 'main-audio',
+        candidates: { bytes: 3, count: 1 },
+        prefix: 'generated-audio-free/',
+        referencedByDatabase: { bytes: 2, count: 1 },
+        scanned: { bytes: 6, count: 3 },
+        youngerThanCutoff: { bytes: 1, count: 1 },
+      },
+    ]);
+  });
+
+  it('summarizes full buckets without admitting paid prefixes', () => {
+    const locations = buildAllowedLocations(config);
+    const objects = [
+      candidate('generated-audio-free/free.mp3', { prefix: '', size: 3 }),
+      candidate('generated-audio/paid.mp3', { prefix: '', size: 5 }),
+      candidate('generated-audio/api-paid.mp3', {
+        bucket: 'api-audio',
+        prefix: '',
+        size: 7,
+      }),
+    ];
+
+    assert.deepEqual(summarizeBuckets(objects, ['main-audio', 'api-audio']), [
+      { bucket: 'api-audio', bytes: 7, count: 1 },
+      { bucket: 'main-audio', bytes: 8, count: 2 },
+    ]);
+    assert.deepEqual(
+      filterAllowedInventoryObjects(objects, locations).map((object) => ({
+        key: object.key,
+        prefix: object.prefix,
+      })),
+      [
+        {
+          key: 'generated-audio-free/free.mp3',
+          prefix: 'generated-audio-free/',
+        },
+      ],
+    );
+  });
+
+  it('allows only configured bucket and prefix pairs', () => {
+    const locations = buildAllowedLocations(config);
+    assert.ok(
+      findAllowedLocation(
+        'main-audio',
+        'generated-audio-free/a.mp3',
+        locations,
+      ),
+    );
+    assert.ok(
+      findAllowedLocation('main-audio', 'cloned-audio-free/a.mp3', locations),
+    );
+    assert.equal(
+      findAllowedLocation('main-audio', 'generated-audio/a.mp3', locations),
+      undefined,
+    );
+    assert.equal(
+      findAllowedLocation('api-audio', 'cloned-audio-free/a.mp3', locations),
+      undefined,
+    );
+  });
+});
+
+describe('download selection', () => {
+  it('sorts oldest first and keeps whole files within the cap', () => {
+    const newest = candidate('generated-audio-free/new.mp3', {
+      lastModified: '2026-06-03T00:00:00.000Z',
+      size: 4,
+    });
+    const oldest = candidate('generated-audio-free/old.mp3', {
+      lastModified: '2026-06-01T00:00:00.000Z',
+      size: 6,
+    });
+
+    const selection = selectByDownloadLimit([newest, oldest], 9);
+    assert.deepEqual(
+      selection.selected.map((item) => item.key),
+      [oldest.key],
+    );
+    assert.deepEqual(
+      selection.deferred.map((item) => item.key),
+      [newest.key],
+    );
+    assert.equal(selection.transferBytes, 6);
+  });
+
+  it('fits a later small file after deferring a large one', () => {
+    const tooLarge = candidate('generated-audio-free/large.mp3', {
+      lastModified: '2026-06-01T00:00:00.000Z',
+      size: 11,
+    });
+    const small = candidate('generated-audio-free/small.mp3', {
+      lastModified: '2026-06-02T00:00:00.000Z',
+      size: 4,
+    });
+
+    const selection = selectByDownloadLimit([small, tooLarge], 10);
+    assert.deepEqual(
+      selection.deferred.map((item) => item.key),
+      [tooLarge.key],
+    );
+    assert.deepEqual(
+      selection.selected.map((item) => item.key),
+      [small.key],
+    );
+  });
+});
+
+describe('manifest and CLI validation', () => {
+  it('validates a generated manifest and rejects unknown prefixes', () => {
+    const manifest = createManifest(
+      [candidate('generated-audio-free/a.mp3')],
+      config,
+      now,
+    );
+    assert.deepEqual(validateManifest(manifest, config), manifest);
+
+    const invalidCutoff = structuredClone(manifest);
+    invalidCutoff.cutoff = '2026-01-01T00:00:00.000Z';
+    assert.throws(
+      () => validateManifest(invalidCutoff, config),
+      /cutoff does not match/,
+    );
+
+    const invalid = structuredClone(manifest);
+    invalid.candidates[0].key = 'generated-audio/a.mp3';
+    assert.throws(
+      () => validateManifest(invalid, config),
+      /outside the bucket and prefix allowlist/,
+    );
+  });
+
+  it('validates inventory totals when they are present', () => {
+    const locations = buildAllowedLocations(config);
+    const inventory = analyzeInventory(
+      [candidate('generated-audio-free/a.mp3', { size: 10 })],
+      new Set(),
+      now,
+      locations,
+    );
+    const bucketTotals = [
+      { bucket: 'api-audio', bytes: 0, count: 0 },
+      { bucket: 'main-audio', bytes: 10, count: 1 },
+    ];
+    const manifest = createManifest(
+      inventory.candidates,
+      config,
+      now,
+      inventory.summary,
+      bucketTotals,
+    );
+    assert.deepEqual(validateManifest(manifest, config), manifest);
+
+    const invalid = structuredClone(manifest);
+    if (!invalid.inventory) {
+      assert.fail('Expected inventory statistics');
+    }
+    invalid.inventory[0].scanned.count += 1;
+    assert.throws(
+      () => validateManifest(invalid, config),
+      /totals do not add up/,
+    );
+
+    const invalidBucketTotal = structuredClone(manifest);
+    if (!invalidBucketTotal.bucketTotals) {
+      assert.fail('Expected bucket totals');
+    }
+    invalidBucketTotal.bucketTotals[1].count = 0;
+    assert.throws(
+      () => validateManifest(invalidBucketTotal, config),
+      /inventory exceeds bucket total/,
+    );
+  });
+
+  it('rejects manifests from another bucket configuration', () => {
+    const manifest = createManifest([], config, now);
+    assert.throws(
+      () =>
+        validateManifest(manifest, {
+          apiBucket: 'other-api',
+          mainBucket: config.mainBucket,
+        }),
+      /bucket names do not match/,
+    );
+  });
+
+  it('enforces CLI option dependencies', () => {
+    assert.equal(parseCleanupCliArgs(['--', '--help']).help, true);
+    assert.deepEqual(parseCleanupCliArgs([]), {
+      delete: false,
+      download: false,
+      downloadDir: undefined,
+      force: false,
+      help: false,
+      manifest: undefined,
+      maxDownloadBytes: undefined,
+      yes: false,
+    });
+    assert.throws(
+      () => parseCleanupCliArgs(['--download']),
+      /--download requires --manifest/,
+    );
+    assert.throws(
+      () => parseCleanupCliArgs(['--download-dir', '/tmp/audio']),
+      /--download-dir requires --download/,
+    );
+    assert.throws(
+      () =>
+        parseCleanupCliArgs([
+          '--manifest',
+          'manifest.json',
+          '--delete',
+          '--yes',
+        ]),
+      /--delete requires --download or --force/,
+    );
+    assert.throws(
+      () =>
+        parseCleanupCliArgs([
+          '--manifest',
+          'manifest.json',
+          '--delete',
+          '--force',
+        ]),
+      /--delete requires --yes/,
+    );
+    const downloadWithIgnoredForce = [
+      '--manifest',
+      'manifest.json',
+      '--download',
+      '--download-dir',
+      '/tmp/audio',
+      '--max-download-size',
+      '1GB',
+      '--force',
+    ];
+    assert.doesNotThrow(() => parseCleanupCliArgs(downloadWithIgnoredForce));
+    assert.doesNotThrow(() =>
+      parseCleanupCliArgs([...downloadWithIgnoredForce, '--delete', '--yes']),
+    );
+  });
+});
+
+describe('local backup safety', () => {
+  it('rejects path traversal', () => {
+    assert.throws(
+      () =>
+        resolveLocalObjectPath(
+          '/tmp/backups',
+          'main-audio',
+          'generated-audio-free/../../outside.mp3',
+        ),
+      /Unsafe R2 key/,
+    );
+    assert.throws(
+      () =>
+        resolveLocalObjectPath('/tmp/backups', 'main-audio', '/outside.mp3'),
+      /Unsafe R2 key/,
+    );
+  });
+
+  it('recognizes simple ETags and rejects opaque ETags', () => {
+    assert.equal(
+      simpleEtagMd5('"D41D8CD98F00B204E9800998ECF8427E"'),
+      'd41d8cd98f00b204e9800998ecf8427e',
+    );
+    assert.equal(simpleEtagMd5('abc-2'), null);
+    assert.equal(simpleEtagMd5('opaque'), null);
+  });
+
+  it('keeps opaque-ETag downloads without marking them verified', async () => {
+    const directory = await mkdtemp(path.join(tmpdir(), 'r2-cleanup-'));
+    try {
+      const contents = Buffer.from('multipart backup');
+      const item = candidate('generated-audio-free/opaque.mp3', {
+        etag: 'opaque-2',
+        size: contents.length,
+      });
+      const result = await downloadWithoutOverwrite(
+        mockR2({
+          getObject() {
+            return Promise.resolve(byteStream(contents));
+          },
+        }),
+        item,
+        directory,
+      );
+
+      assert.equal(result.status, 'unverifiable');
+      assert.deepEqual(await readFile(result.destination), contents);
+    } finally {
+      await rm(directory, { force: true, recursive: true });
+    }
+  });
+
+  it('stops a changed object before it exceeds the expected size', async () => {
+    const directory = await mkdtemp(path.join(tmpdir(), 'r2-cleanup-'));
+    try {
+      const item = candidate('generated-audio-free/changed.mp3', {
+        etag: createHash('md5').update('a').digest('hex'),
+        size: 1,
+      });
+      const result = await downloadWithoutOverwrite(
+        mockR2({
+          getObject() {
+            return Promise.resolve(byteStream(Buffer.from('too large')));
+          },
+        }),
+        item,
+        directory,
+      );
+
+      assert.equal(result.status, 'failed');
+      assert.match(result.reason ?? '', /exceeded the expected size/);
+      await assert.rejects(readFile(result.destination), /ENOENT/);
+    } finally {
+      await rm(directory, { force: true, recursive: true });
+    }
+  });
+
+  it('never overwrites an existing local file', async () => {
+    const directory = await mkdtemp(path.join(tmpdir(), 'r2-cleanup-'));
+    try {
+      const contents = Buffer.from('keep this file');
+      const item = candidate('generated-audio-free/existing.mp3', {
+        etag: createHash('md5').update(contents).digest('hex'),
+        size: contents.length,
+      });
+      const destination = resolveLocalObjectPath(
+        directory,
+        item.bucket,
+        item.key,
+      );
+      await mkdir(path.dirname(destination), { recursive: true });
+      await writeFile(destination, contents);
+      let getCalls = 0;
+      const result = await downloadWithoutOverwrite(
+        mockR2({
+          getObject() {
+            getCalls += 1;
+            return Promise.resolve(byteStream(Buffer.from('replacement')));
+          },
+        }),
+        item,
+        directory,
+      );
+
+      assert.equal(result.status, 'exists');
+      assert.equal(getCalls, 0);
+      assert.deepEqual(await readFile(destination), contents);
+    } finally {
+      await rm(directory, { force: true, recursive: true });
+    }
+  });
+});
+
+describe('paginated reads and live checks', () => {
+  it('fetches all Supabase pages', async () => {
+    const calls: [number, number][] = [];
+    const keys = await fetchAllStorageKeys(
+      {
+        listStorageKeys(from, to) {
+          calls.push([from, to]);
+          return Promise.resolve(from === 0 ? ['a', 'b'] : ['c']);
+        },
+      },
+      2,
+    );
+
+    assert.deepEqual([...keys], ['a', 'b', 'c']);
+    assert.deepEqual(calls, [
+      [0, 1],
+      [2, 3],
+    ]);
+  });
+
+  it('fetches all R2 pages', async () => {
+    const tokens: Array<string | undefined> = [];
+    const objects = await listAllObjects(
+      mockR2({
+        listObjects(_bucket, _prefix, token) {
+          tokens.push(token);
+          if (!token) {
+            return Promise.resolve({
+              nextContinuationToken: 'next',
+              objects: [
+                {
+                  etag: 'etag-a',
+                  key: 'generated-audio-free/a.mp3',
+                  lastModified: new Date('2026-06-01T00:00:00.000Z'),
+                  size: 1,
+                },
+              ],
+            });
+          }
+          return Promise.resolve({
+            objects: [
+              {
+                etag: 'etag-b',
+                key: 'generated-audio-free/b.mp3',
+                lastModified: new Date('2026-06-02T00:00:00.000Z'),
+                size: 2,
+              },
+            ],
+          });
+        },
+      }),
+      { bucket: 'main-audio', prefix: 'generated-audio-free/' },
+    );
+
+    assert.deepEqual(tokens, [undefined, 'next']);
+    assert.deepEqual(
+      objects.map((object) => object.key),
+      ['generated-audio-free/a.mp3', 'generated-audio-free/b.mp3'],
+    );
+  });
+
+  it('reports HeadObject failures without aborting other checks', async () => {
+    const failed = candidate('generated-audio-free/failed.mp3');
+    const missing = candidate('generated-audio-free/missing.mp3');
+    const results = await recheckCandidates(
+      [failed, missing],
+      new Set(),
+      mockR2({
+        headObject(_bucket, key) {
+          if (key === failed.key) {
+            return Promise.reject(new Error('R2 unavailable'));
+          }
+          return Promise.resolve(null);
+        },
+      }),
+      buildAllowedLocations(config),
+      now,
+    );
+
+    assert.deepEqual(
+      results.map((result) => result.status),
+      ['r2-check-failure', 'missing-from-r2'],
+    );
+  });
+
+  it('protects referenced keys and reports changed and missing objects', async () => {
+    const referenced = candidate('generated-audio-free/referenced.mp3');
+    const changed = candidate('generated-audio-free/changed.mp3', { size: 10 });
+    const missing = candidate('generated-audio-free/missing.mp3');
+    const results = await recheckCandidates(
+      [referenced, changed, missing],
+      new Set([referenced.key]),
+      mockR2({
+        headObject(_bucket, key) {
+          if (key === missing.key) {
+            return Promise.resolve(null);
+          }
+          return Promise.resolve({
+            etag: changed.etag,
+            lastModified: new Date(changed.lastModified),
+            size: changed.size + 1,
+          });
+        },
+      }),
+      buildAllowedLocations(config),
+      now,
+    );
+
+    assert.deepEqual(
+      results.map((result) => result.status),
+      ['referenced-by-database', 'changed-in-r2', 'missing-from-r2'],
+    );
+  });
+});
+
+describe('deletion results', () => {
+  it('records partial deletion failures without retrying successes', async () => {
+    const first = candidate('generated-audio-free/first.mp3');
+    const second = candidate('generated-audio-free/second.mp3');
+    let calls = 0;
+    const results = await deleteCandidatesInBatches(
+      mockR2({
+        deleteObjects() {
+          calls += 1;
+          return Promise.resolve({
+            deleted: [first.key],
+            errors: [
+              {
+                code: 'AccessDenied',
+                key: second.key,
+                message: 'denied',
+              },
+            ],
+          });
+        },
+      }),
+      [first, second],
+      100,
+    );
+
+    assert.equal(calls, 1);
+    assert.deepEqual(
+      results.map((result) => result.status),
+      ['deleted', 'deletion-failure'],
+    );
+    assert.match(results[1].reason ?? '', /AccessDenied: denied/);
+  });
+});

--- a/scripts/r2-orphan-audio-cleanup.test.mts
+++ b/scripts/r2-orphan-audio-cleanup.test.mts
@@ -5,9 +5,11 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { describe, it } from 'node:test';
 
+import { runAction } from './cleanup-orphaned-r2-audio.mts';
 import {
   analyzeInventory,
   buildAllowedLocations,
+  type CleanupCliOptions,
   type CleanupConfig,
   createManifest,
   deleteCandidatesInBatches,
@@ -38,6 +40,35 @@ const config: CleanupConfig = {
   mainBucket: 'main-audio',
 };
 const now = new Date('2026-08-22T12:00:00.000Z');
+
+function actionOptions(
+  manifest: string,
+  overrides: Partial<CleanupCliOptions> = {},
+): CleanupCliOptions {
+  return {
+    delete: true,
+    download: false,
+    downloadDir: undefined,
+    force: true,
+    help: false,
+    manifest,
+    maxDownloadBytes: undefined,
+    yes: true,
+    ...overrides,
+  };
+}
+
+async function writeManifest(
+  directory: string,
+  candidates: R2ObjectMetadata[],
+): Promise<string> {
+  const manifestPath = path.join(directory, 'manifest.json');
+  await writeFile(
+    manifestPath,
+    `${JSON.stringify(createManifest(candidates, config, now), null, 2)}\n`,
+  );
+  return manifestPath;
+}
 
 function candidate(
   key: string,
@@ -646,6 +677,145 @@ describe('paginated reads and live checks', () => {
       results.map((result) => result.status),
       ['referenced-by-database', 'changed-in-r2', 'missing-from-r2'],
     );
+  });
+});
+
+describe('cleanup action orchestration', () => {
+  it('checks live state before deleting, then evicts and reports', async () => {
+    const directory = await mkdtemp(path.join(tmpdir(), 'r2-cleanup-action-'));
+    try {
+      const item = candidate('generated-audio-free/delete.wav');
+      const manifestPath = await writeManifest(directory, [item]);
+      const events: string[] = [];
+      const writtenReports: unknown[] = [];
+      const output = await runAction(actionOptions(manifestPath), config, {
+        audioUrlCache: {
+          deleteKey() {
+            events.push('cache');
+            return Promise.resolve();
+          },
+        },
+        client: mockR2({
+          deleteObjects(_bucket, keys) {
+            events.push('delete');
+            return Promise.resolve({ deleted: keys, errors: [] });
+          },
+          headObject() {
+            events.push('head');
+            return Promise.resolve({
+              etag: item.etag,
+              lastModified: new Date(item.lastModified),
+              size: item.size,
+            });
+          },
+        }),
+        log: () => undefined,
+        now: () => now,
+        storageKeys: {
+          hasStorageKey() {
+            events.push('has');
+            return Promise.resolve(false);
+          },
+          listStorageKeys() {
+            events.push('list');
+            return Promise.resolve([]);
+          },
+        },
+        writeReport(_reportPath, report) {
+          events.push('report');
+          writtenReports.push(report);
+          return Promise.resolve();
+        },
+      });
+
+      assert.deepEqual(events, [
+        'list',
+        'head',
+        'has',
+        'head',
+        'delete',
+        'cache',
+        'report',
+      ]);
+      assert.equal(output.exitCode, 0);
+      assert.equal(output.report.results[0].status, 'deleted');
+      assert.equal(writtenReports[0], output.report);
+    } finally {
+      await rm(directory, { force: true, recursive: true });
+    }
+  });
+
+  it('deletes only checksum-backed objects in download mode', async () => {
+    const directory = await mkdtemp(path.join(tmpdir(), 'r2-cleanup-action-'));
+    try {
+      const checksum = candidate('generated-audio-free/checksum.wav');
+      const opaque = candidate('generated-audio-free/opaque.wav', {
+        etag: 'opaque-2',
+      });
+      const manifestPath = await writeManifest(directory, [checksum, opaque]);
+      const downloadDir = path.join(directory, 'downloads');
+      for (const item of [checksum, opaque]) {
+        const destination = await resolveLocalObjectPath(
+          downloadDir,
+          item.bucket,
+          item.key,
+        );
+        await mkdir(path.dirname(destination), { recursive: true });
+        await writeFile(destination, new Uint8Array());
+      }
+      const deletedKeys: string[] = [];
+      const output = await runAction(
+        actionOptions(manifestPath, {
+          download: true,
+          downloadDir,
+          force: false,
+          maxDownloadBytes: 1,
+        }),
+        config,
+        {
+          audioUrlCache: {
+            deleteKey() {
+              return Promise.resolve();
+            },
+          },
+          client: mockR2({
+            deleteObjects(_bucket, keys) {
+              deletedKeys.push(...keys);
+              return Promise.resolve({ deleted: keys, errors: [] });
+            },
+            headObject(_bucket, key) {
+              const item = key === checksum.key ? checksum : opaque;
+              return Promise.resolve({
+                etag: item.etag,
+                lastModified: new Date(item.lastModified),
+                size: item.size,
+              });
+            },
+          }),
+          log: () => undefined,
+          now: () => now,
+          storageKeys: {
+            hasStorageKey() {
+              return Promise.resolve(false);
+            },
+            listStorageKeys() {
+              return Promise.resolve([]);
+            },
+          },
+          writeReport() {
+            return Promise.resolve();
+          },
+        },
+      );
+
+      assert.deepEqual(deletedKeys, [checksum.key]);
+      assert.deepEqual(
+        output.report.results.map((result) => result.status),
+        ['deleted', 'unverifiable-checksum'],
+      );
+    } finally {
+      await rm(directory, { force: true, recursive: true });
+    }
   });
 });
 

--- a/scripts/r2-orphan-audio-cleanup.test.mts
+++ b/scripts/r2-orphan-audio-cleanup.test.mts
@@ -681,6 +681,52 @@ describe('paginated reads and live checks', () => {
 });
 
 describe('cleanup action orchestration', () => {
+  it('validates destructive options for direct callers before work', async () => {
+    const directory = await mkdtemp(path.join(tmpdir(), 'r2-cleanup-action-'));
+    try {
+      const manifestPath = await writeManifest(directory, []);
+      let reportWrites = 0;
+      let storageReads = 0;
+      const dependencies = {
+        client: mockR2(),
+        storageKeys: {
+          hasStorageKey() {
+            return Promise.resolve(false);
+          },
+          listStorageKeys() {
+            storageReads += 1;
+            return Promise.resolve([]);
+          },
+        },
+        writeReport() {
+          reportWrites += 1;
+          return Promise.resolve();
+        },
+      };
+
+      await assert.rejects(
+        runAction(
+          actionOptions(manifestPath, { force: false }),
+          config,
+          dependencies,
+        ),
+        /--delete requires --download or --force/,
+      );
+      await assert.rejects(
+        runAction(
+          actionOptions(manifestPath, { yes: false }),
+          config,
+          dependencies,
+        ),
+        /--delete requires --yes/,
+      );
+      assert.equal(storageReads, 0);
+      assert.equal(reportWrites, 0);
+    } finally {
+      await rm(directory, { force: true, recursive: true });
+    }
+  });
+
   it('checks live state before deleting, then evicts and reports', async () => {
     const directory = await mkdtemp(path.join(tmpdir(), 'r2-cleanup-action-'));
     try {

--- a/scripts/r2-orphan-audio-cleanup.test.mts
+++ b/scripts/r2-orphan-audio-cleanup.test.mts
@@ -745,6 +745,61 @@ describe('cleanup action orchestration', () => {
     }
   });
 
+  it('reports earlier deletions when a later candidate throws', async () => {
+    const directory = await mkdtemp(path.join(tmpdir(), 'r2-cleanup-action-'));
+    try {
+      const first = candidate('generated-audio-free/first.wav');
+      const second = candidate('generated-audio-free/second.wav');
+      const manifestPath = await writeManifest(directory, [first, second]);
+      let nowCalls = 0;
+      const output = await runAction(actionOptions(manifestPath), config, {
+        audioUrlCache: {
+          deleteKey() {
+            return Promise.resolve();
+          },
+        },
+        client: mockR2({
+          headObject(_bucket, key) {
+            const item = key === first.key ? first : second;
+            return Promise.resolve({
+              etag: item.etag,
+              lastModified: new Date(item.lastModified),
+              size: item.size,
+            });
+          },
+        }),
+        log: () => undefined,
+        now: () => {
+          nowCalls += 1;
+          if (nowCalls === 3) {
+            throw new Error('clock failed');
+          }
+          return now;
+        },
+        storageKeys: {
+          hasStorageKey() {
+            return Promise.resolve(false);
+          },
+          listStorageKeys() {
+            return Promise.resolve([]);
+          },
+        },
+        writeReport() {
+          return Promise.resolve();
+        },
+      });
+
+      assert.deepEqual(
+        output.report.results.map((result) => result.status),
+        ['deleted', 'deletion-failure'],
+      );
+      assert.match(output.report.results[1].reason ?? '', /clock failed/);
+      assert.equal(output.exitCode, 1);
+    } finally {
+      await rm(directory, { force: true, recursive: true });
+    }
+  });
+
   it('deletes only checksum-backed objects in download mode', async () => {
     const directory = await mkdtemp(path.join(tmpdir(), 'r2-cleanup-action-'));
     try {

--- a/scripts/r2-orphan-audio-cleanup.test.mts
+++ b/scripts/r2-orphan-audio-cleanup.test.mts
@@ -11,6 +11,7 @@ import {
   type CleanupConfig,
   createManifest,
   deleteCandidatesInBatches,
+  evictDeletedAudioCache,
   fetchAllStorageKeys,
   filterAllowedInventoryObjects,
   findAllowedLocation,
@@ -649,6 +650,40 @@ describe('paginated reads and live checks', () => {
 });
 
 describe('deletion results', () => {
+  it('evicts dashboard cache keys only for the main bucket', async () => {
+    const deletedKeys: string[] = [];
+    const cache = {
+      deleteKey(key: string) {
+        deletedKeys.push(key);
+        return Promise.resolve();
+      },
+    };
+    const mainCandidate = candidate('generated-audio-free/main.wav');
+    const apiCandidate = candidate('generated-audio-free/api.wav', {
+      bucket: config.apiBucket,
+    });
+
+    await evictDeletedAudioCache(mainCandidate, config.mainBucket, cache);
+    await evictDeletedAudioCache(apiCandidate, config.mainBucket, cache);
+
+    assert.deepEqual(deletedKeys, [mainCandidate.key]);
+  });
+
+  it('reports cache eviction failures to the caller', async () => {
+    await assert.rejects(
+      evictDeletedAudioCache(
+        candidate('generated-audio-free/main.wav'),
+        config.mainBucket,
+        {
+          deleteKey() {
+            return Promise.reject(new Error('Redis unavailable'));
+          },
+        },
+      ),
+      /Redis unavailable/,
+    );
+  });
+
   it('records partial deletion failures without retrying successes', async () => {
     const first = candidate('generated-audio-free/first.mp3');
     const second = candidate('generated-audio-free/second.mp3');

--- a/scripts/r2-orphan-audio-cleanup.test.mts
+++ b/scripts/r2-orphan-audio-cleanup.test.mts
@@ -727,6 +727,55 @@ describe('cleanup action orchestration', () => {
     }
   });
 
+  it('rejects a missing download root before reading the manifest', async () => {
+    const directory = await mkdtemp(path.join(tmpdir(), 'r2-cleanup-action-'));
+    try {
+      const downloadDir = path.join(directory, 'missing-download');
+      const manifestPath = path.join(directory, 'missing-manifest.json');
+      let deletes = 0;
+      let storageReads = 0;
+
+      await assert.rejects(
+        runAction(
+          actionOptions(manifestPath, {
+            download: true,
+            downloadDir,
+            force: false,
+            maxDownloadBytes: 1,
+          }),
+          config,
+          {
+            client: mockR2({
+              deleteObjects() {
+                deletes += 1;
+                return Promise.resolve({ deleted: [], errors: [] });
+              },
+            }),
+            storageKeys: {
+              hasStorageKey() {
+                storageReads += 1;
+                return Promise.resolve(false);
+              },
+              listStorageKeys() {
+                storageReads += 1;
+                return Promise.resolve([]);
+              },
+            },
+          },
+        ),
+        (error: NodeJS.ErrnoException) => {
+          assert.equal(error.code, 'ENOENT');
+          assert.equal(error.path, downloadDir);
+          return true;
+        },
+      );
+      assert.equal(storageReads, 0);
+      assert.equal(deletes, 0);
+    } finally {
+      await rm(directory, { force: true, recursive: true });
+    }
+  });
+
   it('checks live state before deleting, then evicts and reports', async () => {
     const directory = await mkdtemp(path.join(tmpdir(), 'r2-cleanup-action-'));
     try {

--- a/scripts/refund-credits.mts
+++ b/scripts/refund-credits.mts
@@ -1,12 +1,9 @@
 import { stdin as input, stdout as output } from 'node:process';
 import { createInterface } from 'node:readline/promises';
-import { createClient } from '@supabase/supabase-js';
-import { config } from 'dotenv';
+import { loadScriptEnv } from './lib/env.mts';
+import { createScriptAdminClient as createAdminClient } from './lib/supabase.mts';
 
-// Load environment variables
-config({
-  path: ['.env', '.env.local'],
-});
+loadScriptEnv();
 
 interface CreditTransaction {
   amount: number;
@@ -37,29 +34,6 @@ interface RefundCalculation {
   totalRefunded: number;
   totalSpentUSD: number;
   totalUsedFromEvents: number;
-}
-
-/**
- * Create Supabase admin client
- */
-function createAdminClient() {
-  if (!process.env.NEXT_PUBLIC_SUPABASE_URL) {
-    throw new Error('Missing env.NEXT_PUBLIC_SUPABASE_URL');
-  }
-  if (!process.env.SUPABASE_SECRET_KEY) {
-    throw new Error('Missing env.SUPABASE_SECRET_KEY');
-  }
-
-  return createClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL,
-    process.env.SUPABASE_SECRET_KEY,
-    {
-      auth: {
-        autoRefreshToken: false,
-        persistSession: false,
-      },
-    },
-  );
 }
 
 /**

--- a/scripts/reset-freeloader-credits.mts
+++ b/scripts/reset-freeloader-credits.mts
@@ -2,13 +2,10 @@ import { readFileSync } from 'node:fs';
 import { stdin as input, stdout as output } from 'node:process';
 import { createInterface } from 'node:readline/promises';
 import { parseArgs } from 'node:util';
-import { createClient } from '@supabase/supabase-js';
-import { config } from 'dotenv';
+import { loadScriptEnv } from './lib/env.mts';
+import { createScriptAdminClient } from './lib/supabase.mts';
 
-// Load environment variables
-config({
-  path: ['.env', '.env.local'],
-});
+loadScriptEnv();
 
 // UUID validation regex at top level for performance
 const UUID_REGEX =
@@ -42,28 +39,8 @@ interface ProcessingResult {
   username: string;
 }
 
-/**
- * Create Supabase admin client
- */
-function createAdminClient() {
-  if (!process.env.NEXT_PUBLIC_SUPABASE_URL) {
-    throw new Error('Missing env.NEXT_PUBLIC_SUPABASE_URL');
-  }
-  if (!process.env.SUPABASE_SECRET_KEY) {
-    throw new Error('Missing env.SUPABASE_SECRET_KEY');
-  }
-
-  return createClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL,
-    process.env.SUPABASE_SECRET_KEY,
-    {
-      auth: {
-        autoRefreshToken: false,
-        persistSession: true,
-      },
-    },
-  );
-}
+const createAdminClient = () =>
+  createScriptAdminClient({ persistSession: true });
 
 /**
  * Parse CSV file and extract freeloader records

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "allowImportingTsExtensions": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "lib": ["ESNext"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "noEmit": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "ES2024",
+    "types": ["node"]
+  },
+  "include": ["*.mts", "lib/*.mts"]
+}


### PR DESCRIPTION
This adds guarded tools for two R2 maintenance jobs: inventorying and cleaning old orphaned free-user audio, and backing up complete buckets or exact prefixes to a local drive without overwriting files. The split matters because backup must not inherit the cleanup command's Supabase, age, allowlist, or deletion behavior.

The cleanup command uses reviewed manifests, database-reference checks, a 45-day cutoff, fresh R2 metadata checks, bounded downloads, and explicit deletion confirmation. The backup command lists every requested source before transfer, verifies simple ETags with MD5 and opaque ETags by size, selects missing objects oldest-first under an optional cap, streams four downloads concurrently, and writes a complete JSON report. Interactive transfers use effective-progress with Effect 4 RC; redirected runs avoid Ink rendering.

Validation:
- pnpm --filter @sexyvoice/scripts test: 39 passed
- pnpm --filter @sexyvoice/scripts type-check: passed
- focused Biome checks: passed
- pnpm fixall: passed with five existing Sentry namespace-import warnings
- pnpm type-check: passed
- production dry run: 5,132 objects, 2.1 GiB, zero downloads
- pnpm test: scripts passed and 62/63 web files passed; 35 Stripe webhook tests fail on the existing closed Redis test connection in tests/utils/redis-test-utils.ts

Documentation updates:
- scripts/README.md
- docs/plans/2026-08-22-r2-orphan-audio-cleanup.md
- docs/plans/2026-08-23-r2-audio-backup-design.md

No migrations, billing, credits, generation behavior, storage deletion policy outside the cleanup command, or public API contracts change.