### PR TITLE
fix(tts): classify Gemini safety blocks

### DIFF
--- a/apps/docs/content/docs/api-reference/error-codes.mdx
+++ b/apps/docs/content/docs/api-reference/error-codes.mdx
@@ -1,6 +1,6 @@
 ---
-title: 'Error Codes'
-description: 'Centralized error response format and code semantics for API.'
+title: "Error Codes"
+description: "Centralized error response format and code semantics for API."
 ---
 
 All errors return this shape:
@@ -27,21 +27,21 @@ All errors return this shape:
 
 ## Common Codes
 
-| Code | Type | Meaning |
-| --- | --- | --- |
-| `invalid_request` | `invalid_request_error` | Request body failed validation.
-| `unsupported_parameter` | `invalid_request_error` | Parameter is not supported.
-| `unsupported_response_format` | `invalid_request_error` | Requested format is unsupported for selected model.
-| `input_too_long` | `invalid_request_error` | Input exceeds model limits.
-| `model_not_found` | `invalid_request_error` | Voice and model combination is invalid.
-| `voice_not_found` | `not_found_error` | Voice name does not exist.
-| `invalid_api_key` | `authentication_error` | Bearer key missing/invalid/inactive.
-| `insufficient_credits` | `permission_error` | Account balance is too low.
-| `rate_limit_exceeded` | `rate_limit_error` | Too many requests.
-| `provider_quota_exceeded` | `rate_limit_error` | Provider quota or billing is temporarily exhausted.
-| `content_policy_violation` | `invalid_request_error` | Content blocked by provider safety policy.
-| `provider_unavailable` | `server_error` | Upstream provider is temporarily unavailable; retry later.
-| `server_error` | `server_error` | Internal service/provider failure.
+| Code                          | Type                    | Meaning                                                                                                |
+| ----------------------------- | ----------------------- | ------------------------------------------------------------------------------------------------------ |
+| `invalid_request`             | `invalid_request_error` | Request body failed validation.                                                                        |
+| `unsupported_parameter`       | `invalid_request_error` | Parameter is not supported.                                                                            |
+| `unsupported_response_format` | `invalid_request_error` | Requested format is unsupported for selected model.                                                    |
+| `input_too_long`              | `invalid_request_error` | Input exceeds model limits.                                                                            |
+| `model_not_found`             | `invalid_request_error` | Voice and model combination is invalid.                                                                |
+| `voice_not_found`             | `not_found_error`       | Voice name does not exist.                                                                             |
+| `invalid_api_key`             | `authentication_error`  | Bearer key missing/invalid/inactive.                                                                   |
+| `insufficient_credits`        | `permission_error`      | Account balance is too low.                                                                            |
+| `rate_limit_exceeded`         | `rate_limit_error`      | Too many requests.                                                                                     |
+| `provider_quota_exceeded`     | `rate_limit_error`      | Provider quota or billing is temporarily exhausted.                                                    |
+| `content_policy_violation`    | `invalid_request_error` | Content blocked by provider safety policy.                                                             |
+| `provider_unavailable`        | `server_error`          | Upstream provider is temporarily unavailable; retry later.                                             |
+| `server_error`                | `server_error`          | Internal service or provider failure. Responses use HTTP 500 or 503; retry 503 responses with backoff. |
 
 ## Debugging with request-id
 

--- a/apps/docs/content/docs/guides/api.mdx
+++ b/apps/docs/content/docs/guides/api.mdx
@@ -137,5 +137,5 @@ Response includes:
 
 - Read full [API Reference](/api-reference/api)
 - Browse [Grok Voices & Speech Tags](/guides/grok-speech-tags) for the full tag reference
-- Retry transient `503 provider_unavailable` responses with backoff, and treat `429 provider_quota_exceeded` as temporary provider quota exhaustion
+- Retry any HTTP 503 response with backoff, regardless of `error.code`, and treat `429 provider_quota_exceeded` as temporary provider quota exhaustion
 - Store `request-id` with your logs for support and tracing

--- a/apps/web/app/api/generate-voice/route.ts
+++ b/apps/web/app/api/generate-voice/route.ts
@@ -1,5 +1,5 @@
 import {
-  type FinishReason,
+  FinishReason,
   type GenerateContentConfig,
   type GenerateContentResponse,
   GoogleGenAI,
@@ -40,7 +40,10 @@ import {
   buildGeminiTtsPrompt,
   resolveGeminiTtsModel,
 } from '@/lib/tts/gemini-prompt';
-import { classifyGeminiTtsResponse } from '@/lib/tts/gemini-response';
+import {
+  classifyGeminiTtsResponse,
+  geminiOutcomeToErrorCode,
+} from '@/lib/tts/gemini-response';
 import { generateXaiTts, normalizeXaiTtsSpeed } from '@/lib/tts/xai';
 import {
   calculateCreditsFromTokens,
@@ -783,14 +786,10 @@ export async function POST(request: Request) {
             user: { id: user.id },
           });
         }
-        let noAudioErrorCode: keyof typeof ERROR_CODES = 'OTHER_GEMINI_BLOCK';
-        if (isProhibitedContent) {
-          noAudioErrorCode = 'PROHIBITED_CONTENT';
-        } else if (isNoAudioData) {
-          noAudioErrorCode = 'NO_AUDIO_DATA';
-        }
-        throw new Error(getErrorMessage(noAudioErrorCode, 'voice-generation'), {
-          cause: noAudioErrorCode,
+        const errorCode =
+          geminiOutcomeToErrorCode(responseOutcome) ?? 'OTHER_GEMINI_BLOCK';
+        throw new Error(getErrorMessage(errorCode, 'voice-generation'), {
+          cause: errorCode,
         });
       }
       logger.info('Gemini voice generation succeeded', {
@@ -1249,24 +1248,22 @@ function streamGeminiTtsResponse({
     let streamBlockReason: string | undefined;
     let audioStarted = false;
     let completed = false;
+    let fallbackAttempted = false;
 
     const getStreamBlockError = () => {
+      if (!(streamFinishReason || streamBlockReason)) {
+        return;
+      }
+
       const responseOutcome = classifyGeminiTtsResponse({
         blockReason: streamBlockReason,
         finishReason: streamFinishReason,
         hasAudio: audioChunks.length > 0,
       });
-      let errorCode: keyof typeof ERROR_CODES | undefined;
-      if (responseOutcome === 'content_blocked') {
-        errorCode = 'PROHIBITED_CONTENT';
-      } else if (responseOutcome === 'no_audio') {
-        errorCode = 'NO_AUDIO_DATA';
-      } else if (
-        responseOutcome === 'unexpected' &&
-        (streamFinishReason || streamBlockReason)
-      ) {
-        errorCode = 'OTHER_GEMINI_BLOCK';
-      }
+      const errorCode =
+        streamFinishReason === FinishReason.OTHER
+          ? 'OTHER_GEMINI_BLOCK'
+          : geminiOutcomeToErrorCode(responseOutcome);
 
       return errorCode
         ? new Error(getErrorMessage(errorCode, 'voice-generation'), {
@@ -1332,6 +1329,8 @@ function streamGeminiTtsResponse({
           return;
         }
 
+        // NO_AUDIO_DATA stays retryable because STOP without chunks can be a
+        // transient model failure. Policy and unknown terminal blocks cannot.
         if (
           Error.isError(primaryError) &&
           (primaryError.cause === 'PROHIBITED_CONTENT' ||
@@ -1361,6 +1360,7 @@ function streamGeminiTtsResponse({
             user: { email: user.email, id: user.id },
           },
         );
+        fallbackAttempted = true;
         modelUsed = 'gemini-2.5-flash-preview-tts';
         audioChunks.length = 0;
         streamUsageMetadata = undefined;
@@ -1547,9 +1547,17 @@ function streamGeminiTtsResponse({
         Error.isError(error) && error.cause === 'PROHIBITED_CONTENT';
       const isNoAudioData =
         Error.isError(error) && error.cause === 'NO_AUDIO_DATA';
-      if (!(audioStarted || isProhibitedContent || isNoAudioData)) {
+      const shouldCaptureException =
+        !(audioStarted || isProhibitedContent) &&
+        (!isNoAudioData || fallbackAttempted);
+      if (shouldCaptureException) {
         captureException(error, {
-          extra: { model: modelUsed, stream: true, voice: voiceObj.name },
+          extra: {
+            fallbackAttempted,
+            model: modelUsed,
+            stream: true,
+            voice: voiceObj.name,
+          },
           user: { id: user.id },
         });
       }

--- a/apps/web/app/api/generate-voice/route.ts
+++ b/apps/web/app/api/generate-voice/route.ts
@@ -1,5 +1,5 @@
 import {
-  FinishReason,
+  type FinishReason,
   type GenerateContentConfig,
   type GenerateContentResponse,
   GoogleGenAI,
@@ -40,6 +40,7 @@ import {
   buildGeminiTtsPrompt,
   resolveGeminiTtsModel,
 } from '@/lib/tts/gemini-prompt';
+import { classifyGeminiTtsResponse } from '@/lib/tts/gemini-response';
 import { generateXaiTts, normalizeXaiTtsSpeed } from '@/lib/tts/xai';
 import {
   calculateCreditsFromTokens,
@@ -695,17 +696,15 @@ export async function POST(request: Request) {
       const { data, mimeType } = extractInlineAudio(genAIResponse);
       const finishReason = genAIResponse?.candidates?.[0]?.finishReason;
       const blockReason = genAIResponse?.promptFeedback?.blockReason;
-      const isProhibitedContent =
-        finishReason === FinishReason.PROHIBITED_CONTENT ||
-        blockReason === 'PROHIBITED_CONTENT';
-      // Finished without audio — transient provider glitch rather than a content
-      // block, so surface it as retryable. Gemini 3.1 may report this as OTHER.
-      const isNoAudioData =
-        (finishReason === FinishReason.STOP ||
-          finishReason === FinishReason.OTHER) &&
-        !(data && mimeType);
+      const responseOutcome = classifyGeminiTtsResponse({
+        blockReason,
+        finishReason,
+        hasAudio: Boolean(data && mimeType),
+      });
+      const isProhibitedContent = responseOutcome === 'content_blocked';
+      const isNoAudioData = responseOutcome === 'no_audio';
 
-      if (finishReason !== FinishReason.STOP || !data || !mimeType) {
+      if (responseOutcome !== 'success' || !data || !mimeType) {
         if (isProhibitedContent) {
           logger.warn('Content generation prohibited by Gemini', {
             extra: {
@@ -716,7 +715,6 @@ export async function POST(request: Request) {
               responseId: genAIResponse?.responseId,
               styleVariant,
               textLength: text.length,
-              textPreview: text.slice(0, 500),
               voice: voiceObj.name,
             },
             user: { email: user.email, id: user.id },
@@ -769,8 +767,7 @@ export async function POST(request: Request) {
             );
           }
         }
-        // Only capture unexpected Gemini blocks to Sentry. PROHIBITED_CONTENT
-        // and no-audio STOP responses are handled user/provider states.
+        // Capture only response shapes that the classifier does not recognize.
         if (!(isProhibitedContent || isNoAudioData)) {
           captureException(new Error('Gemini 200 — no audio data'), {
             extra: {
@@ -1254,15 +1251,19 @@ function streamGeminiTtsResponse({
     let completed = false;
 
     const getStreamBlockError = () => {
+      const responseOutcome = classifyGeminiTtsResponse({
+        blockReason: streamBlockReason,
+        finishReason: streamFinishReason,
+        hasAudio: audioChunks.length > 0,
+      });
       let errorCode: keyof typeof ERROR_CODES | undefined;
-      if (
-        streamFinishReason === FinishReason.PROHIBITED_CONTENT ||
-        streamBlockReason === 'PROHIBITED_CONTENT'
-      ) {
+      if (responseOutcome === 'content_blocked') {
         errorCode = 'PROHIBITED_CONTENT';
+      } else if (responseOutcome === 'no_audio') {
+        errorCode = 'NO_AUDIO_DATA';
       } else if (
-        (streamFinishReason && streamFinishReason !== FinishReason.STOP) ||
-        streamBlockReason
+        responseOutcome === 'unexpected' &&
+        (streamFinishReason || streamBlockReason)
       ) {
         errorCode = 'OTHER_GEMINI_BLOCK';
       }
@@ -1544,7 +1545,9 @@ function streamGeminiTtsResponse({
 
       const isProhibitedContent =
         Error.isError(error) && error.cause === 'PROHIBITED_CONTENT';
-      if (!(audioStarted || isProhibitedContent)) {
+      const isNoAudioData =
+        Error.isError(error) && error.cause === 'NO_AUDIO_DATA';
+      if (!(audioStarted || isProhibitedContent || isNoAudioData)) {
         captureException(error, {
           extra: { model: modelUsed, stream: true, voice: voiceObj.name },
           user: { id: user.id },

--- a/apps/web/app/api/v1/speech/route.ts
+++ b/apps/web/app/api/v1/speech/route.ts
@@ -45,7 +45,10 @@ import {
   saveAudioFileAdmin,
 } from '@/lib/supabase/queries';
 import { buildGeminiTtsPrompt } from '@/lib/tts/gemini-prompt';
-import { classifyGeminiTtsResponse } from '@/lib/tts/gemini-response';
+import {
+  classifyGeminiTtsResponse,
+  geminiOutcomeToErrorCode,
+} from '@/lib/tts/gemini-response';
 import { generateXaiTts, normalizeXaiTtsCodec } from '@/lib/tts/xai';
 import {
   calculateCreditsFromTokens,
@@ -53,6 +56,7 @@ import {
   estimateCredits,
   extractMetadata,
   getErrorMessage,
+  getErrorStatusCode,
   getTtsProvider,
 } from '@/lib/utils';
 import {
@@ -644,21 +648,18 @@ export async function POST(request: Request) {
         hasAudio: Boolean(data && mimeType),
       });
       const isProhibitedContent = responseOutcome === 'content_blocked';
-      const isNoAudioData = responseOutcome === 'no_audio';
 
       if (responseOutcome !== 'success' || !data || !mimeType) {
         const code = isProhibitedContent
           ? 'content_policy_violation'
           : 'server_error';
-        let noAudioErrorCode: keyof typeof ERROR_CODES = 'OTHER_GEMINI_BLOCK';
-        if (isProhibitedContent) {
-          noAudioErrorCode = 'PROHIBITED_CONTENT';
-        } else if (isNoAudioData) {
-          noAudioErrorCode = 'NO_AUDIO_DATA';
-        }
-        const message = getErrorMessage(noAudioErrorCode, 'voice-generation');
-        const httpStatus = isProhibitedContent ? 422 : 500;
-        await refundReservedCredits('gemini_no_audio');
+        const errorCode =
+          geminiOutcomeToErrorCode(responseOutcome) ?? 'OTHER_GEMINI_BLOCK';
+        const message = getErrorMessage(errorCode, 'voice-generation');
+        const httpStatus = getErrorStatusCode(errorCode);
+        await refundReservedCredits(
+          isProhibitedContent ? 'gemini_content_blocked' : 'gemini_no_audio',
+        );
         await log({
           apiKeyId: authResult.apiKeyId,
           error: message,

--- a/apps/web/app/api/v1/speech/route.ts
+++ b/apps/web/app/api/v1/speech/route.ts
@@ -1,5 +1,4 @@
 import {
-  FinishReason,
   type GenerateContentConfig,
   type GenerateContentResponse,
   GoogleGenAI,
@@ -46,6 +45,7 @@ import {
   saveAudioFileAdmin,
 } from '@/lib/supabase/queries';
 import { buildGeminiTtsPrompt } from '@/lib/tts/gemini-prompt';
+import { classifyGeminiTtsResponse } from '@/lib/tts/gemini-response';
 import { generateXaiTts, normalizeXaiTtsCodec } from '@/lib/tts/xai';
 import {
   calculateCreditsFromTokens,
@@ -638,15 +638,15 @@ export async function POST(request: Request) {
       const { data, mimeType } = extractInlineAudio(geminiResponse);
       const finishReason = geminiResponse?.candidates?.[0]?.finishReason;
       const blockReason = geminiResponse?.promptFeedback?.blockReason;
-      const isProhibitedContent =
-        finishReason === FinishReason.PROHIBITED_CONTENT ||
-        blockReason === 'PROHIBITED_CONTENT';
-      // Finished normally but no audio came back — transient provider glitch
-      // rather than a content block, so surface it as retryable.
-      const isNoAudioData =
-        finishReason === FinishReason.STOP && !(data && mimeType);
+      const responseOutcome = classifyGeminiTtsResponse({
+        blockReason,
+        finishReason,
+        hasAudio: Boolean(data && mimeType),
+      });
+      const isProhibitedContent = responseOutcome === 'content_blocked';
+      const isNoAudioData = responseOutcome === 'no_audio';
 
-      if (finishReason !== FinishReason.STOP || !data || !mimeType) {
+      if (responseOutcome !== 'success' || !data || !mimeType) {
         const code = isProhibitedContent
           ? 'content_policy_violation'
           : 'server_error';

--- a/apps/web/lib/api/openapi.ts
+++ b/apps/web/lib/api/openapi.ts
@@ -381,6 +381,14 @@ export function createExternalApiOpenApiDocument() {
               },
               description: 'Server error',
             },
+            503: {
+              content: {
+                'application/json': {
+                  schema: ErrorResponseSchema,
+                },
+              },
+              description: 'Upstream service temporarily unavailable',
+            },
           },
           security: [{ BearerAuth: [] }],
           summary: 'Generate speech audio',

--- a/apps/web/lib/tts/gemini-response.ts
+++ b/apps/web/lib/tts/gemini-response.ts
@@ -1,0 +1,39 @@
+import { FinishReason } from '@google/genai';
+
+export type GeminiTtsResponseOutcome =
+  | 'content_blocked'
+  | 'no_audio'
+  | 'success'
+  | 'unexpected';
+
+export function classifyGeminiTtsResponse({
+  blockReason,
+  finishReason,
+  hasAudio,
+}: {
+  blockReason?: string;
+  finishReason?: FinishReason;
+  hasAudio: boolean;
+}): GeminiTtsResponseOutcome {
+  if (
+    finishReason === FinishReason.SAFETY ||
+    finishReason === FinishReason.PROHIBITED_CONTENT ||
+    blockReason === 'SAFETY' ||
+    blockReason === 'PROHIBITED_CONTENT'
+  ) {
+    return 'content_blocked';
+  }
+
+  if (finishReason === FinishReason.STOP && hasAudio) {
+    return 'success';
+  }
+
+  if (
+    !hasAudio &&
+    (finishReason === FinishReason.STOP || finishReason === FinishReason.OTHER)
+  ) {
+    return 'no_audio';
+  }
+
+  return 'unexpected';
+}

--- a/apps/web/lib/tts/gemini-response.ts
+++ b/apps/web/lib/tts/gemini-response.ts
@@ -6,6 +6,27 @@ export type GeminiTtsResponseOutcome =
   | 'success'
   | 'unexpected';
 
+export type GeminiTtsErrorCode =
+  | 'NO_AUDIO_DATA'
+  | 'OTHER_GEMINI_BLOCK'
+  | 'PROHIBITED_CONTENT';
+
+const GEMINI_OUTCOME_ERROR_CODES: Record<
+  GeminiTtsResponseOutcome,
+  GeminiTtsErrorCode | undefined
+> = {
+  content_blocked: 'PROHIBITED_CONTENT',
+  no_audio: 'NO_AUDIO_DATA',
+  success: undefined,
+  unexpected: 'OTHER_GEMINI_BLOCK',
+};
+
+export function geminiOutcomeToErrorCode(
+  outcome: GeminiTtsResponseOutcome,
+): GeminiTtsErrorCode | undefined {
+  return GEMINI_OUTCOME_ERROR_CODES[outcome];
+}
+
 export function classifyGeminiTtsResponse({
   blockReason,
   finishReason,

--- a/apps/web/lib/tts/gemini-response.ts
+++ b/apps/web/lib/tts/gemini-response.ts
@@ -18,8 +18,11 @@ export function classifyGeminiTtsResponse({
   if (
     finishReason === FinishReason.SAFETY ||
     finishReason === FinishReason.PROHIBITED_CONTENT ||
+    finishReason === FinishReason.BLOCKLIST ||
+    finishReason === FinishReason.SPII ||
     blockReason === 'SAFETY' ||
-    blockReason === 'PROHIBITED_CONTENT'
+    blockReason === 'PROHIBITED_CONTENT' ||
+    blockReason === 'BLOCKLIST'
   ) {
     return 'content_blocked';
   }

--- a/apps/web/tests/api-v1-meta.test.ts
+++ b/apps/web/tests/api-v1-meta.test.ts
@@ -110,6 +110,9 @@ describe('/api/v1 metadata endpoints', () => {
     expect(response.status).toBe(200);
     expect(json.openapi).toBe('3.1.0');
     expect(json.paths['/api/v1/speech']).toBeDefined();
+    expect(
+      json.paths['/api/v1/speech'].post.responses[503].description,
+    ).toBe('Upstream service temporarily unavailable');
     expect(json.paths['/api/v1/billing']).toBeDefined();
     expect(
       json.paths['/api/v1/speech'].post.requestBody.content['application/json']

--- a/apps/web/tests/api-v1-speech.test.ts
+++ b/apps/web/tests/api-v1-speech.test.ts
@@ -808,6 +808,44 @@ describe('/api/v1/speech', () => {
     expect(captureException).not.toHaveBeenCalled();
   });
 
+  it('returns a content-policy error and refunds a Gemini SAFETY response', async () => {
+    const generateContent = vi.fn().mockResolvedValue({
+      candidates: [
+        {
+          content: { parts: [] },
+          finishReason: 'SAFETY',
+        },
+      ],
+    });
+    setMockGoogleGenAIFactory(() => ({
+      models: { countTokens: vi.fn(), generateContent },
+    }));
+
+    const request = new Request('http://localhost/api/v1/speech', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        authorization: TEST_AUTH_HEADER,
+      },
+      body: JSON.stringify({
+        model: 'gpro31',
+        input: 'Hello world',
+        voice: 'achernar',
+      }),
+    });
+
+    const response = await POST(request);
+    const json = await response.json();
+
+    expect(response.status).toBe(422);
+    expect(json.error.type).toBe('invalid_request_error');
+    expect(json.error.code).toBe('content_policy_violation');
+    expect(json.error.param).toBe('input');
+    expect(generateContent).toHaveBeenCalledTimes(1);
+    expect(restoreCredits).toHaveBeenCalledTimes(1);
+    expect(captureException).not.toHaveBeenCalled();
+  });
+
   it('falls back to gemini-2.5-flash-preview-tts when gpro31 primary call fails', async () => {
     let callCount = 0;
     const generateContent = vi.fn().mockImplementation(() => {

--- a/apps/web/tests/api-v1-speech.test.ts
+++ b/apps/web/tests/api-v1-speech.test.ts
@@ -846,6 +846,83 @@ describe('/api/v1/speech', () => {
     expect(captureException).not.toHaveBeenCalled();
   });
 
+  it('returns 503 and refunds when Gemini returns no audio', async () => {
+    const generateContent = vi.fn().mockResolvedValue({
+      candidates: [
+        {
+          content: { parts: [] },
+          finishReason: 'STOP',
+        },
+      ],
+    });
+    setMockGoogleGenAIFactory(() => ({
+      models: { countTokens: vi.fn(), generateContent },
+    }));
+
+    const request = new Request('http://localhost/api/v1/speech', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        authorization: TEST_AUTH_HEADER,
+      },
+      body: JSON.stringify({
+        model: 'gpro31',
+        input: 'Hello world',
+        voice: 'achernar',
+      }),
+    });
+
+    const response = await POST(request);
+    const json = await response.json();
+
+    expect(response.status).toBe(503);
+    expect(json.error.type).toBe('server_error');
+    expect(json.error.code).toBe('server_error');
+    expect(json.error.param).toBeNull();
+    expect(generateContent).toHaveBeenCalledTimes(1);
+    expect(restoreCredits).toHaveBeenCalledTimes(1);
+    expect(captureException).not.toHaveBeenCalled();
+  });
+
+  it('labels failed policy refunds as content blocked', async () => {
+    const refundError = new Error('Refund failed');
+    vi.mocked(restoreCredits).mockRejectedValueOnce(refundError);
+    const generateContent = vi.fn().mockResolvedValue({
+      candidates: [
+        {
+          content: { parts: [] },
+          finishReason: 'SAFETY',
+        },
+      ],
+    });
+    setMockGoogleGenAIFactory(() => ({
+      models: { countTokens: vi.fn(), generateContent },
+    }));
+
+    const request = new Request('http://localhost/api/v1/speech', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        authorization: TEST_AUTH_HEADER,
+      },
+      body: JSON.stringify({
+        model: 'gpro31',
+        input: 'Hello world',
+        voice: 'achernar',
+      }),
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(422);
+    expect(captureException).toHaveBeenCalledWith(
+      refundError,
+      expect.objectContaining({
+        extra: expect.objectContaining({ context: 'gemini_content_blocked' }),
+      }),
+    );
+  });
+
   it('falls back to gemini-2.5-flash-preview-tts when gpro31 primary call fails', async () => {
     let callCount = 0;
     const generateContent = vi.fn().mockImplementation(() => {

--- a/apps/web/tests/gemini-tts-response.test.ts
+++ b/apps/web/tests/gemini-tts-response.test.ts
@@ -1,0 +1,51 @@
+import { FinishReason } from '@google/genai';
+import { describe, expect, it } from 'vitest';
+
+import { classifyGeminiTtsResponse } from '@/lib/tts/gemini-response';
+
+describe('classifyGeminiTtsResponse', () => {
+  it('classifies a normal audio response as successful', () => {
+    expect(
+      classifyGeminiTtsResponse({
+        finishReason: FinishReason.STOP,
+        hasAudio: true,
+      }),
+    ).toBe('success');
+  });
+
+  it.each([
+    { finishReason: FinishReason.SAFETY },
+    { finishReason: FinishReason.PROHIBITED_CONTENT },
+    { blockReason: 'SAFETY' },
+    { blockReason: 'PROHIBITED_CONTENT' },
+  ])('classifies $finishReason$blockReason as content blocked', (response) => {
+    expect(
+      classifyGeminiTtsResponse({
+        ...response,
+        hasAudio: false,
+      }),
+    ).toBe('content_blocked');
+  });
+
+  it.each([FinishReason.STOP, FinishReason.OTHER])(
+    'classifies %s without audio as no audio',
+    (finishReason) => {
+      expect(classifyGeminiTtsResponse({ finishReason, hasAudio: false })).toBe(
+        'no_audio',
+      );
+    },
+  );
+
+  it.each([
+    {},
+    { finishReason: FinishReason.MAX_TOKENS },
+    { blockReason: 'OTHER' },
+  ])('classifies an unhandled response as unexpected', (response) => {
+    expect(
+      classifyGeminiTtsResponse({
+        ...response,
+        hasAudio: false,
+      }),
+    ).toBe('unexpected');
+  });
+});

--- a/apps/web/tests/gemini-tts-response.test.ts
+++ b/apps/web/tests/gemini-tts-response.test.ts
@@ -1,7 +1,21 @@
 import { FinishReason } from '@google/genai';
 import { describe, expect, it } from 'vitest';
 
-import { classifyGeminiTtsResponse } from '@/lib/tts/gemini-response';
+import {
+  classifyGeminiTtsResponse,
+  geminiOutcomeToErrorCode,
+} from '@/lib/tts/gemini-response';
+
+describe('geminiOutcomeToErrorCode', () => {
+  it.each([
+    { errorCode: 'PROHIBITED_CONTENT', outcome: 'content_blocked' },
+    { errorCode: 'NO_AUDIO_DATA', outcome: 'no_audio' },
+    { errorCode: 'OTHER_GEMINI_BLOCK', outcome: 'unexpected' },
+    { errorCode: undefined, outcome: 'success' },
+  ] as const)('maps $outcome to $errorCode', ({ errorCode, outcome }) => {
+    expect(geminiOutcomeToErrorCode(outcome)).toBe(errorCode);
+  });
+});
 
 describe('classifyGeminiTtsResponse', () => {
   it('classifies a normal audio response as successful', () => {

--- a/apps/web/tests/gemini-tts-response.test.ts
+++ b/apps/web/tests/gemini-tts-response.test.ts
@@ -16,8 +16,11 @@ describe('classifyGeminiTtsResponse', () => {
   it.each([
     { finishReason: FinishReason.SAFETY },
     { finishReason: FinishReason.PROHIBITED_CONTENT },
+    { finishReason: FinishReason.BLOCKLIST },
+    { finishReason: FinishReason.SPII },
     { blockReason: 'SAFETY' },
     { blockReason: 'PROHIBITED_CONTENT' },
+    { blockReason: 'BLOCKLIST' },
   ])('classifies $finishReason$blockReason as content blocked', (response) => {
     expect(
       classifyGeminiTtsResponse({

--- a/apps/web/tests/generate-voice.test.ts
+++ b/apps/web/tests/generate-voice.test.ts
@@ -1956,6 +1956,66 @@ describe('Generate Voice API Route', () => {
       );
     });
 
+    it.each([
+      {
+        name: 'candidate finish reason',
+        response: {
+          candidates: [
+            {
+              content: { parts: [] },
+              finishReason: FinishReason.SAFETY,
+            },
+          ],
+        },
+      },
+      {
+        name: 'prompt block reason',
+        response: {
+          candidates: [],
+          promptFeedback: { blockReason: 'SAFETY' },
+        },
+      },
+    ])(
+      'should return 422 and refund credits for a Gemini SAFETY $name',
+      async ({ response: geminiResponse }) => {
+        const { restoreCredits } = await import('@/lib/supabase/queries');
+        setMockGoogleGenAIFactory(() => ({
+          models: {
+            generateContent: vi.fn().mockResolvedValue(geminiResponse),
+          },
+        }));
+
+        const request = new Request('http://localhost/api/generate-voice', {
+          method: 'POST',
+          headers: {
+            'content-type': 'application/json',
+          },
+          body: JSON.stringify({
+            text: 'Hello world',
+            voiceId: 'voice-achernar-31-id',
+          }),
+        });
+
+        const response = await POST(request);
+        const json = await response.json();
+
+        expect(response.status).toBe(422);
+        expect(json.error).toBe(
+          getErrorMessage('PROHIBITED_CONTENT', 'voice-generation'),
+        );
+        expect(restoreCredits).toHaveBeenCalledTimes(1);
+        expect(Sentry.captureException).not.toHaveBeenCalled();
+        expect(Sentry.logger.warn).toHaveBeenCalledWith(
+          'Content generation prohibited by Gemini',
+          expect.objectContaining({
+            extra: expect.objectContaining({
+              model: 'gemini-3.1-flash-tts-preview',
+            }),
+          }),
+        );
+      },
+    );
+
     it('should throw error when Gemini response has PROHIBITED_CONTENT finish reason', async () => {
       // Mock Gemini to return response with PROHIBITED_CONTENT finish reason
       setMockGoogleGenAIFactory(() => ({
@@ -2592,7 +2652,7 @@ describe('Generate Voice API Route', () => {
         },
       },
       {
-        errorCode: 'OTHER_GEMINI_BLOCK' as const,
+        errorCode: 'PROHIBITED_CONTENT' as const,
         name: 'safety prompt block',
         terminalChunk: {
           candidates: [],
@@ -2642,6 +2702,7 @@ describe('Generate Voice API Route', () => {
         userId: 'test-user-id',
         amount: expect.any(Number),
       });
+      expect(Sentry.captureException).not.toHaveBeenCalled();
     });
 
     it('emits error event after audio started and refunds reserved credits when stream throws mid-flight', async () => {

--- a/apps/web/tests/generate-voice.test.ts
+++ b/apps/web/tests/generate-voice.test.ts
@@ -2604,9 +2604,10 @@ describe('Generate Voice API Route', () => {
           usage: { stream: true, userHasPaid: true },
         }),
       );
+      expect(Sentry.captureException).not.toHaveBeenCalled();
     });
 
-    it('emits error event and skips billing when stream yields no audio chunks', async () => {
+    it('reports persistent no-audio after fallback and skips billing', async () => {
       const { hasUserPaid, reduceCredits } = await import(
         '@/lib/supabase/queries'
       );
@@ -2639,6 +2640,68 @@ describe('Generate Voice API Route', () => {
       expect(body).not.toContain('event: done');
       expect(callCount).toBe(2);
       expect(reduceCredits).toHaveBeenCalled();
+      expect(Sentry.captureException).toHaveBeenCalledTimes(1);
+      expect(Sentry.captureException).toHaveBeenCalledWith(
+        expect.objectContaining({
+          cause: 'NO_AUDIO_DATA',
+          message: getErrorMessage('NO_AUDIO_DATA', 'voice-generation'),
+        }),
+        expect.objectContaining({
+          extra: expect.objectContaining({
+            fallbackAttempted: true,
+            model: 'gemini-2.5-flash-preview-tts',
+            stream: true,
+          }),
+        }),
+      );
+    });
+
+    it('does not retry an OTHER finish from the primary stream', async () => {
+      const { hasUserPaid, restoreCredits } = await import(
+        '@/lib/supabase/queries'
+      );
+      vi.mocked(hasUserPaid).mockResolvedValueOnce(true);
+
+      let callCount = 0;
+      const generateContentStream = vi.fn().mockImplementation(function* () {
+        callCount++;
+        yield {
+          candidates: [
+            { content: { parts: [] }, finishReason: FinishReason.OTHER },
+          ],
+        };
+      });
+      setMockGoogleGenAIFactory(() => ({ models: { generateContentStream } }));
+
+      const request = new Request('http://localhost/api/generate-voice', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          text: 'Hello world',
+          voiceId: 'voice-achernar-31-id',
+          stream: true,
+        }),
+      });
+
+      const response = await POST(request);
+      const body = await readSseBody(response);
+
+      expect(body).toContain('event: error');
+      expect(body).toContain(
+        getErrorMessage('OTHER_GEMINI_BLOCK', 'voice-generation'),
+      );
+      expect(body).not.toContain('event: done');
+      expect(callCount).toBe(1);
+      expect(restoreCredits).toHaveBeenCalledWith({
+        amount: expect.any(Number),
+        userId: 'test-user-id',
+      });
+      expect(Sentry.captureException).toHaveBeenCalledWith(
+        expect.objectContaining({ cause: 'OTHER_GEMINI_BLOCK' }),
+        expect.objectContaining({
+          extra: expect.objectContaining({ fallbackAttempted: false }),
+        }),
+      );
     });
 
     it.each([


### PR DESCRIPTION
Share one response classifier across dashboard generation, streaming, and API v1. Map Gemini SAFETY and PROHIBITED_CONTENT responses to the existing 422 policy error, restore reserved credits, and skip retries and Sentry exception capture.

Keep unknown response shapes on the server-error path. Remove prompt previews from handled policy warnings and add coverage for candidate and prompt blocks, streaming, refunds, and API responses.

---

Should fix Sentry: SEXYVOICE-AI-9Z - a response-classification bug, not a Gemini availability failure.