### PR TITLE
Track Gemini TTS tokens and attempt costs

### DIFF
--- a/.agents/notes/proposed/billing/2026-09-08-gemini-usage-events.md
+++ b/.agents/notes/proposed/billing/2026-09-08-gemini-usage-events.md
@@ -3,7 +3,7 @@
 Status: Code prepared; migration application and database tests pending.
 
 Gemini usage must survive missing audio rows, blocked responses, fallback, and
-storage failures. Store one provider attempt in `usage_events` before persistence.
+storage failures. Schedule one provider attempt in `usage_events` per SDK generation.
 Keep customer credit events separate and correlate with `request_id`.
 
 Provider attempts own token counts and estimated supplier costs. Customer events
@@ -21,9 +21,20 @@ semantics. Existing zero-credit support needs no change.
 
 See `docs/devops.md` for the mechanism and deployment order.
 
-Verification: 158 relevant Vitest tests passed; 16 existing tests remain skipped.
+Verification: 163 relevant Vitest tests passed; 16 existing tests remain skipped.
 The new streaming suite exercises the disabled route with a test-only flag.
 Workspace type-check and fixall passed with existing warnings. Checks used the
 installed pnpm 11.7 and Node 26.7 because the pinned pnpm version could not be
 fetched; repository runtime settings remain unchanged. Database tests await
 user application of the migration, as required by AGENTS.md.
+
+Review decisions: Non-streaming writes use Next.js `after()` to avoid delaying
+fallbacks. Streaming writes remain awaited in the background task. Unknown model
+pricing and unavailable SDK HTTP status stay NULL. Cancellation is independent
+of provider outcome. Zero-token telemetry does not waive customer credits.
+
+Customer reports, Telegram statistics, and dispute evidence exclude provider-only
+activity. Internal model cost groups remain intact. Extra indexing and enum
+changes are deferred without workload evidence; raw usage metadata preserves
+provider breakdowns for reconciliation. Fallback pgTAP coverage is prepared but
+awaits the migrated local database.

--- a/.agents/notes/proposed/billing/2026-09-08-gemini-usage-events.md
+++ b/.agents/notes/proposed/billing/2026-09-08-gemini-usage-events.md
@@ -1,0 +1,29 @@
+# Gemini provider usage
+
+Status: Code prepared; migration application and database tests pending.
+
+Gemini usage must survive missing audio rows, blocked responses, fallback, and
+storage failures. Store one provider attempt in `usage_events` before persistence.
+Keep customer credit events separate and correlate with `request_id`.
+
+Provider attempts own token counts and estimated supplier costs. Customer events
+own credits. Copying costs to both would inflate sums. Storing tokens only in
+`audio_files.usage` loses them when files are deleted or never created. Dedicated
+numeric columns support aggregation; metadata retains the provider breakdown.
+
+HTTP 400 and 500 failures are excluded at the user's request. Unknown token counts
+and costs remain NULL. A recorded estimate does not establish that Google charged
+for a failed or blocked generation.
+
+The migration filters provider attempts out of customer operation counts while
+including their costs in API spend. It preserves historical rows and append-only
+semantics. Existing zero-credit support needs no change.
+
+See `docs/devops.md` for the mechanism and deployment order.
+
+Verification: 158 relevant Vitest tests passed; 16 existing tests remain skipped.
+The new streaming suite exercises the disabled route with a test-only flag.
+Workspace type-check and fixall passed with existing warnings. Checks used the
+installed pnpm 11.7 and Node 26.7 because the pinned pnpm version could not be
+fetched; repository runtime settings remain unchanged. Database tests await
+user application of the migration, as required by AGENTS.md.

--- a/apps/web/app/api/billing/usage/route.ts
+++ b/apps/web/app/api/billing/usage/route.ts
@@ -141,7 +141,9 @@ export async function GET(request: NextRequest) {
     return APIErrorResponse('Failed to fetch billing usage', 500);
   }
 
-  const rows = (data ?? []) as ApiUsageDailyRow[];
+  const rows = ((data ?? []) as ApiUsageDailyRow[]).filter(
+    (row) => row.requests > 0,
+  );
   const widthDays = bucketWidth === '7d' ? 7 : 1;
   const bucketMap = new Map<
     string,

--- a/apps/web/app/api/daily-stats/queries.ts
+++ b/apps/web/app/api/daily-stats/queries.ts
@@ -78,6 +78,7 @@ export function getUsageEventsInRange(
       .select(
         'id, user_id, source_type, credits_used, occurred_at, profiles(username)',
       )
+      .eq('event_kind', 'customer_usage')
       .gte('occurred_at', start.toISOString())
       .lt('occurred_at', end.toISOString());
     if (excludeUserIds.length > 0) {

--- a/apps/web/app/api/generate-voice/route.ts
+++ b/apps/web/app/api/generate-voice/route.ts
@@ -1509,7 +1509,7 @@ function streamGeminiTtsResponse({
       const streamUsage = {
         ...extractMetadata(true, {
           usageMetadata: streamUsageMetadata,
-        } as GenerateContentResponse),
+        }),
         stream: true,
         userHasPaid,
       };

--- a/apps/web/app/api/generate-voice/route.ts
+++ b/apps/web/app/api/generate-voice/route.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import {
   FinishReason,
   type GenerateContentConfig,
@@ -54,6 +55,11 @@ import {
   classifyGeminiTtsResponse,
   geminiOutcomeToErrorCode,
 } from '@/lib/tts/gemini-response';
+import {
+  mergeGeminiUsage,
+  trackGeminiGeneration,
+  trackGeminiStream,
+} from '@/lib/tts/gemini-usage';
 import { generateXaiTts, normalizeXaiTtsSpeed } from '@/lib/tts/xai';
 import {
   calculateCreditsFromTokens,
@@ -266,6 +272,7 @@ export const maxDuration = 600; // seconds - fluid compute is enabled
 const redis = Redis.fromEnv();
 
 export async function POST(request: Request) {
+  const requestId = randomUUID();
   let text = '';
   let voiceId = '';
   let voiceName = '';
@@ -608,6 +615,7 @@ export async function POST(request: Request) {
           estimate,
           filename,
           provider,
+          requestId,
           requestSignal: request.signal,
           reservedCredits: estimate,
           styleVariant,
@@ -618,6 +626,25 @@ export async function POST(request: Request) {
         });
       }
 
+      const generationUserId = user.id;
+      const generate = (model: string) =>
+        trackGeminiGeneration(
+          {
+            inputChars: text.length,
+            model,
+            requestId,
+            signal: request.signal,
+            sourceType: 'tts',
+            userId: generationUserId,
+          },
+          () =>
+            ai.models.generateContent({
+              config: geminiTTSConfig,
+              contents: [{ parts: [{ text }], role: 'user' }],
+              model,
+            }),
+        );
+
       if (userHasPaid) {
         try {
           modelUsed = resolveGeminiTtsModel({
@@ -625,11 +652,7 @@ export async function POST(request: Request) {
             userHasPaid,
           });
 
-          genAIResponse = await ai.models.generateContent({
-            config: geminiTTSConfig,
-            contents: [{ parts: [{ text }], role: 'user' }],
-            model: modelUsed,
-          });
+          genAIResponse = await generate(modelUsed);
         } catch (error) {
           console.warn(error);
           if (error instanceof Error && error.name === 'AbortError') {
@@ -673,11 +696,7 @@ export async function POST(request: Request) {
           );
           modelUsed = 'gemini-2.5-flash-preview-tts'; // inputTokenLimit = 8192, outputTokenLimit = 16384
           try {
-            genAIResponse = await ai.models.generateContent({
-              config: geminiTTSConfig,
-              contents: [{ parts: [{ text }], role: 'user' }],
-              model: modelUsed,
-            });
+            genAIResponse = await generate(modelUsed);
 
             logger.info('Gemini flash fallback succeeded after pro failure', {
               extra: {
@@ -724,11 +743,7 @@ export async function POST(request: Request) {
           model: voiceObj.model,
           userHasPaid,
         });
-        genAIResponse = await ai.models.generateContent({
-          config: geminiTTSConfig,
-          contents: [{ parts: [{ text }], role: 'user' }],
-          model: modelUsed,
-        });
+        genAIResponse = await generate(modelUsed);
       }
       const { data, mimeType } = extractInlineAudio(genAIResponse);
       const finishReason = genAIResponse?.candidates?.[0]?.finishReason;
@@ -967,7 +982,7 @@ export async function POST(request: Request) {
       replicateResponse,
     );
 
-    if (isGeminiVoice && usage) {
+    if (isGeminiVoice && usage?.totalTokenCount !== undefined) {
       // Bill against the model that actually ran (`modelUsed`), not the stored
       // voice model: a 3.1 request that fell back to 2.5 Flash must not incur
       // the 3.1 free-user surcharge.
@@ -991,15 +1006,6 @@ export async function POST(request: Request) {
         inputChars: text.length,
         model: modelUsed,
         provider: 'xai',
-        sourceType: 'tts',
-      });
-    } else if (isGeminiVoice && usage && 'promptTokenCount' in usage) {
-      dollarAmount = calculateGenerateApiDollarAmount({
-        candidatesTokenCount: usage.candidatesTokenCount,
-        inputChars: text.length,
-        model: modelUsed,
-        promptTokenCount: usage.promptTokenCount,
-        provider: 'google',
         sourceType: 'tts',
       });
     }
@@ -1051,6 +1057,7 @@ export async function POST(request: Request) {
       await insertUsageEvent({
         creditsUsed: creditsDebited,
         quantity: text.length,
+        requestId,
         sourceId: audioFileDBResult.data?.id,
         sourceType: 'tts',
         unit: 'chars',
@@ -1260,6 +1267,7 @@ function streamGeminiTtsResponse({
   styleVariant,
   provider,
   requestSignal,
+  requestId,
   reservedCredits,
 }: {
   ai: GoogleGenAI;
@@ -1274,6 +1282,7 @@ function streamGeminiTtsResponse({
   styleVariant: string;
   provider: ProviderId;
   requestSignal: AbortSignal;
+  requestId: string;
   reservedCredits: number;
 }): Response {
   const encoder = new TextEncoder();
@@ -1327,11 +1336,22 @@ function streamGeminiTtsResponse({
     };
 
     const tryStream = async (model: string) => {
-      const stream = await ai.models.generateContentStream({
-        config,
-        contents: [{ parts: [{ text }] }],
-        model,
-      });
+      const stream = trackGeminiStream(
+        {
+          inputChars: text.length,
+          model,
+          requestId,
+          signal: requestSignal,
+          sourceType: 'tts',
+          userId: user.id,
+        },
+        () =>
+          ai.models.generateContentStream({
+            config,
+            contents: [{ parts: [{ text }] }],
+            model,
+          }),
+      );
 
       for await (const chunk of stream) {
         if (requestSignal.aborted) return;
@@ -1347,7 +1367,10 @@ function streamGeminiTtsResponse({
           });
         }
         if (chunk.usageMetadata) {
-          streamUsageMetadata = chunk.usageMetadata;
+          streamUsageMetadata = mergeGeminiUsage(
+            streamUsageMetadata,
+            chunk.usageMetadata,
+          );
         }
         const finishReason = chunk.candidates?.[0]?.finishReason;
         if (finishReason) {
@@ -1460,7 +1483,7 @@ function streamGeminiTtsResponse({
 
       // Billing — calculate credits from stream tokens when available.
       let creditsUsed = estimate;
-      if (streamUsageMetadata?.totalTokenCount) {
+      if (streamUsageMetadata?.totalTokenCount !== undefined) {
         // Bill against the model that actually ran (`modelUsed`), which the
         // stream sets to 2.5 Flash on fallback — so a downgraded 3.1 request
         // is not charged the 3.1 free-user surcharge.
@@ -1480,22 +1503,13 @@ function streamGeminiTtsResponse({
       // `finally` block. Mirrors the non-stream path (reservedCredits = 0).
       reservedCredits = 0;
 
-      const streamUsage: Record<string, string | number | boolean> =
-        streamUsageMetadata
-          ? {
-              candidatesTokenCount: String(
-                streamUsageMetadata.candidatesTokenCount ?? '',
-              ),
-              promptTokenCount: String(
-                streamUsageMetadata.promptTokenCount ?? '',
-              ),
-              stream: true,
-              totalTokenCount: String(
-                streamUsageMetadata.totalTokenCount ?? '',
-              ),
-              userHasPaid,
-            }
-          : { stream: true, userHasPaid };
+      const streamUsage = {
+        ...extractMetadata(true, {
+          usageMetadata: streamUsageMetadata,
+        } as GenerateContentResponse),
+        stream: true,
+        userHasPaid,
+      };
 
       const audioFileDBResult = await saveAudioFile({
         credits_used: creditsDebited,
@@ -1535,6 +1549,7 @@ function streamGeminiTtsResponse({
           voiceName: voiceObj.name,
         },
         quantity: text.length,
+        requestId,
         sourceId: audioFileDBResult.data?.id,
         sourceType: 'tts',
         unit: 'chars',

--- a/apps/web/app/api/generate-voice/route.ts
+++ b/apps/web/app/api/generate-voice/route.ts
@@ -982,14 +982,14 @@ export async function POST(request: Request) {
       replicateResponse,
     );
 
-    if (isGeminiVoice && usage?.totalTokenCount !== undefined) {
+    if (isGeminiVoice && Number(usage?.totalTokenCount) > 0) {
       // Bill against the model that actually ran (`modelUsed`), not the stored
       // voice model: a 3.1 request that fell back to 2.5 Flash must not incur
       // the 3.1 free-user surcharge.
-      creditsUsed = calculateCreditsFromTokens(
-        Number.parseInt(usage.totalTokenCount, 10),
-        { model: modelUsed, userHasPaid },
-      );
+      creditsUsed = calculateCreditsFromTokens(Number(usage?.totalTokenCount), {
+        model: modelUsed,
+        userHasPaid,
+      });
     }
 
     const creditsDebited = await reconcileReservedCredits({
@@ -1483,7 +1483,10 @@ function streamGeminiTtsResponse({
 
       // Billing — calculate credits from stream tokens when available.
       let creditsUsed = estimate;
-      if (streamUsageMetadata?.totalTokenCount !== undefined) {
+      if (
+        streamUsageMetadata?.totalTokenCount &&
+        streamUsageMetadata.totalTokenCount > 0
+      ) {
         // Bill against the model that actually ran (`modelUsed`), which the
         // stream sets to 2.5 Flash on fallback — so a downgraded 3.1 request
         // is not charged the 3.1 free-user surcharge.

--- a/apps/web/app/api/v1/speech/route.ts
+++ b/apps/web/app/api/v1/speech/route.ts
@@ -54,6 +54,7 @@ import {
   classifyGeminiTtsResponse,
   geminiOutcomeToErrorCode,
 } from '@/lib/tts/gemini-response';
+import { trackGeminiGeneration } from '@/lib/tts/gemini-usage';
 import { generateXaiTts, normalizeXaiTtsCodec } from '@/lib/tts/xai';
 import {
   calculateCreditsFromTokens,
@@ -612,24 +613,35 @@ export async function POST(request: Request) {
         },
       };
 
+      const generate = (model: string) =>
+        trackGeminiGeneration(
+          {
+            apiKeyId: authResult.apiKeyId,
+            inputChars: finalText.length,
+            model,
+            requestId,
+            signal: request.signal,
+            sourceType: 'api_tts',
+            userId,
+          },
+          () =>
+            ai.models.generateContent({
+              config,
+              contents: [{ parts: [{ text: finalText }], role: 'user' }],
+              model,
+            }),
+        );
+
       try {
         modelUsed =
           model === 'gpro31'
             ? 'gemini-3.1-flash-tts-preview'
             : 'gemini-2.5-pro-preview-tts';
-        geminiResponse = await ai.models.generateContent({
-          config,
-          contents: [{ parts: [{ text: finalText }], role: 'user' }],
-          model: modelUsed,
-        });
+        geminiResponse = await generate(modelUsed);
       } catch (proError) {
         modelUsed = 'gemini-2.5-flash-preview-tts';
         try {
-          geminiResponse = await ai.models.generateContent({
-            config,
-            contents: [{ parts: [{ text: finalText }], role: 'user' }],
-            model: modelUsed,
-          });
+          geminiResponse = await generate(modelUsed);
         } catch (flashError) {
           const providerFailure = getGeminiProviderFailure(
             proError,
@@ -845,7 +857,7 @@ export async function POST(request: Request) {
       geminiResponse,
       replicateResponse,
     );
-    if (isGeminiVoice && usageMetadata?.totalTokenCount) {
+    if (isGeminiVoice && usageMetadata?.totalTokenCount !== undefined) {
       creditsUsed = calculateCreditsFromTokens(
         Number.parseInt(usageMetadata.totalTokenCount, 10),
       );
@@ -899,7 +911,7 @@ export async function POST(request: Request) {
     await insertUsageEvent({
       apiKeyId: authResult.apiKeyId,
       creditsUsed: creditsDebited,
-      dollarAmount,
+      dollarAmount: isGeminiVoice ? null : dollarAmount,
       durationSeconds,
       inputChars: finalText.length,
       metadata: {

--- a/apps/web/app/api/v1/speech/route.ts
+++ b/apps/web/app/api/v1/speech/route.ts
@@ -857,9 +857,9 @@ export async function POST(request: Request) {
       geminiResponse,
       replicateResponse,
     );
-    if (isGeminiVoice && usageMetadata?.totalTokenCount !== undefined) {
+    if (isGeminiVoice && Number(usageMetadata?.totalTokenCount) > 0) {
       creditsUsed = calculateCreditsFromTokens(
-        Number.parseInt(usageMetadata.totalTokenCount, 10),
+        Number(usageMetadata?.totalTokenCount),
       );
     }
     const creditsDebited = await reconcileReservedCredits({

--- a/apps/web/lib/api/pricing.ts
+++ b/apps/web/lib/api/pricing.ts
@@ -75,6 +75,12 @@ function getPriceConfig({
   );
 }
 
+export function hasModelPricing(
+  input: Pick<PricingInput, 'sourceType' | 'provider' | 'model'>,
+): boolean {
+  return getPriceConfig(input) !== ZERO_PRICE;
+}
+
 function normalizeUnitCount(value: number | string | null | undefined): number {
   const parsedValue =
     typeof value === 'number' ? value : Number.parseFloat(value ?? '0');

--- a/apps/web/lib/supabase/queries.ts
+++ b/apps/web/lib/supabase/queries.ts
@@ -122,14 +122,19 @@ export interface InsertUsageEventParams {
   creditsUsed: number;
   dollarAmount?: number | null;
   durationSeconds?: number | null;
+  eventKind?: 'customer_usage' | 'provider_attempt';
   inputChars?: number | null;
+  inputTokens?: number | null;
   metadata?: Json;
   model?: string | null;
+  occurredAt?: string;
   outputChars?: number | null;
+  outputTokens?: number | null;
   quantity: number;
   requestId?: string | null;
   sourceId?: string | null;
   sourceType: UsageSourceType;
+  totalTokens?: number | null;
   unit: UsageUnitType;
   userId: string;
 }
@@ -347,6 +352,11 @@ export const insertUsageEvent = async (
       .insert({
         api_key_id: params.apiKeyId ?? null,
         credits_used: params.creditsUsed,
+        event_kind: params.eventKind ?? 'customer_usage',
+        input_tokens: params.inputTokens ?? null,
+        output_tokens: params.outputTokens ?? null,
+        total_tokens: params.totalTokens ?? null,
+        ...(params.occurredAt ? { occurred_at: params.occurredAt } : {}),
         dollar_amount: params.dollarAmount ?? null,
         duration_seconds: params.durationSeconds ?? null,
         input_chars: params.inputChars ?? null,

--- a/apps/web/lib/supabase/types.d.ts
+++ b/apps/web/lib/supabase/types.d.ts
@@ -668,6 +668,10 @@ declare type Database = {
           source_type: Database['public']['Enums']['usage_source_type'];
           unit: Database['public']['Enums']['usage_unit_type'];
           user_id: string;
+          event_kind: string;
+          input_tokens: number | null;
+          output_tokens: number | null;
+          total_tokens: number | null;
         };
         Insert: {
           api_key_id?: string | null;
@@ -687,6 +691,10 @@ declare type Database = {
           source_type: Database['public']['Enums']['usage_source_type'];
           unit: Database['public']['Enums']['usage_unit_type'];
           user_id: string;
+          event_kind?: string;
+          input_tokens?: number | null;
+          output_tokens?: number | null;
+          total_tokens?: number | null;
         };
         Update: {
           api_key_id?: string | null;
@@ -706,6 +714,10 @@ declare type Database = {
           source_type?: Database['public']['Enums']['usage_source_type'];
           unit?: Database['public']['Enums']['usage_unit_type'];
           user_id?: string;
+          event_kind?: string;
+          input_tokens?: number | null;
+          output_tokens?: number | null;
+          total_tokens?: number | null;
         };
         Relationships: [
           {

--- a/apps/web/lib/supabase/usage-queries.ts
+++ b/apps/web/lib/supabase/usage-queries.ts
@@ -48,6 +48,7 @@ export async function getUsageEventsPaginated(
     .from('usage_events')
     .select('*', { count: 'exact' })
     .eq('user_id', userId)
+    .eq('event_kind', 'customer_usage')
     .order('occurred_at', { ascending: false })
     .range(offset, offset + pageSize - 1);
 

--- a/apps/web/lib/tts/gemini-usage.ts
+++ b/apps/web/lib/tts/gemini-usage.ts
@@ -1,0 +1,176 @@
+import type { FinishReason, GenerateContentResponse } from '@google/genai';
+import { captureException } from '@sentry/nextjs';
+
+import { calculateGenerateApiDollarAmount } from '@/lib/api/pricing';
+import { insertUsageEvent } from '@/lib/supabase/queries';
+import { parseGoogleApiError } from '@/utils/google-errors';
+import { classifyGeminiTtsResponse } from './gemini-response';
+
+type UsageMetadata = GenerateContentResponse['usageMetadata'];
+
+export function mergeGeminiUsage(
+  previous: UsageMetadata,
+  next: UsageMetadata,
+): UsageMetadata {
+  if (!next) return previous;
+  return {
+    ...previous,
+    ...Object.fromEntries(
+      Object.entries(next).filter(
+        ([, value]) => value !== null && typeof value !== 'undefined',
+      ),
+    ),
+  };
+}
+
+function tokenCount(value: number | undefined): number | null {
+  return typeof value === 'number' && Number.isSafeInteger(value) && value >= 0
+    ? value
+    : null;
+}
+
+interface AttemptContext {
+  apiKeyId?: string;
+  inputChars: number;
+  model: string;
+  requestId: string;
+  signal?: AbortSignal;
+  sourceType: 'tts' | 'api_tts';
+  userId: string;
+}
+
+function createAttempt(context: AttemptContext, streaming: boolean) {
+  const occurredAt = new Date().toISOString();
+  let usage: UsageMetadata;
+  let finishReason: FinishReason | undefined;
+  let blockReason: string | undefined;
+  let responseId: string | undefined;
+  let httpStatus: number | null = null;
+  let hasAudio = false;
+  let receivedResponse = false;
+
+  return {
+    observe(response: GenerateContentResponse) {
+      receivedResponse = true;
+      httpStatus = response.sdkHttpResponse?.responseInternal?.status ?? 200;
+      usage = mergeGeminiUsage(usage, response.usageMetadata);
+      finishReason = response.candidates?.[0]?.finishReason ?? finishReason;
+      blockReason = response.promptFeedback?.blockReason ?? blockReason;
+      responseId = response.responseId ?? responseId;
+      hasAudio ||= Boolean(
+        response.candidates?.some((candidate) =>
+          candidate.content?.parts?.some(
+            (part) => part.inlineData?.data && part.inlineData?.mimeType,
+          ),
+        ),
+      );
+    },
+    async record(error?: unknown, completed = true) {
+      // Observability must not trigger a fallback, refund, or generation failure.
+      try {
+        const errorStatus =
+          parseGoogleApiError(error)?.code ??
+          (typeof error === 'object' &&
+          error !== null &&
+          'status' in error &&
+          typeof error.status === 'number'
+            ? error.status
+            : null);
+        if (errorStatus === 400 || errorStatus === 500) return;
+        const inputTokens = tokenCount(usage?.promptTokenCount);
+        const outputTokens = tokenCount(usage?.candidatesTokenCount);
+        const totalTokens = tokenCount(usage?.totalTokenCount);
+        const dollarAmount =
+          inputTokens !== null && outputTokens !== null
+            ? calculateGenerateApiDollarAmount({
+                candidatesTokenCount: outputTokens,
+                model: context.model,
+                promptTokenCount: inputTokens,
+                provider: 'google',
+                sourceType: context.sourceType,
+              })
+            : null;
+        let outcome: string = classifyGeminiTtsResponse({
+          blockReason,
+          finishReason,
+          hasAudio,
+        });
+        if (!completed) outcome = 'incomplete';
+        if (error) outcome = 'error';
+        if (context.signal?.aborted) outcome = 'aborted';
+        await insertUsageEvent({
+          apiKeyId: context.apiKeyId,
+          creditsUsed: 0,
+          dollarAmount,
+          eventKind: 'provider_attempt',
+          inputChars: context.inputChars,
+          inputTokens,
+          metadata: {
+            blockReason: blockReason ?? null,
+            completed,
+            costStatus: dollarAmount === null ? 'unknown' : 'estimated',
+            finishReason: finishReason ?? null,
+            httpStatus: errorStatus ?? httpStatus,
+            outcome,
+            provider: 'google',
+            receivedResponse,
+            responseId: responseId ?? null,
+            stream: streaming,
+            usageMetadata: usage ? JSON.parse(JSON.stringify(usage)) : null,
+          },
+          model: context.model,
+          occurredAt,
+          outputTokens,
+          quantity: 1,
+          requestId: context.requestId,
+          sourceType: context.sourceType,
+          totalTokens,
+          unit: 'operation',
+          userId: context.userId,
+        });
+      } catch (loggingError) {
+        captureException(loggingError, { tags: { context: 'gemini_usage' } });
+      }
+    },
+  };
+}
+
+export async function trackGeminiGeneration(
+  context: AttemptContext,
+  generate: () => Promise<GenerateContentResponse>,
+): Promise<GenerateContentResponse> {
+  const attempt = createAttempt(context, false);
+  let failure: unknown;
+  try {
+    const response = await generate();
+    attempt.observe(response);
+    return response;
+  } catch (error) {
+    failure = error;
+    throw error;
+  } finally {
+    await attempt.record(failure, failure === undefined);
+  }
+}
+
+export async function* trackGeminiStream(
+  context: AttemptContext,
+  generate: () => Promise<AsyncIterable<GenerateContentResponse>>,
+): AsyncGenerator<GenerateContentResponse> {
+  const attempt = createAttempt(context, true);
+  let failure: unknown;
+  let completed = false;
+  try {
+    const stream = await generate();
+    for await (const response of stream) {
+      attempt.observe(response);
+      yield response;
+    }
+    completed = true;
+  } catch (error) {
+    failure = error;
+    throw error;
+  } finally {
+    await attempt.record(failure, completed);
+  }
+}

--- a/apps/web/lib/tts/gemini-usage.ts
+++ b/apps/web/lib/tts/gemini-usage.ts
@@ -1,5 +1,6 @@
 import type { FinishReason, GenerateContentResponse } from '@google/genai';
 import { captureException } from '@sentry/nextjs';
+import { after } from 'next/server';
 
 import { calculateGenerateApiDollarAmount } from '@/lib/api/pricing';
 import { insertUsageEvent } from '@/lib/supabase/queries';
@@ -149,7 +150,7 @@ export async function trackGeminiGeneration(
     failure = error;
     throw error;
   } finally {
-    await attempt.record(failure, failure === undefined);
+    after(() => attempt.record(failure, failure === undefined));
   }
 }
 

--- a/apps/web/lib/tts/gemini-usage.ts
+++ b/apps/web/lib/tts/gemini-usage.ts
@@ -105,7 +105,6 @@ function createAttempt(context: AttemptContext, streaming: boolean) {
         });
         if (!completed) outcome = 'incomplete';
         if (error) outcome = 'error';
-        if (context.signal?.aborted) outcome = 'aborted';
         await insertUsageEvent({
           apiKeyId: context.apiKeyId,
           creditsUsed: 0,
@@ -114,6 +113,7 @@ function createAttempt(context: AttemptContext, streaming: boolean) {
           inputChars: context.inputChars,
           inputTokens,
           metadata: {
+            aborted: context.signal?.aborted ?? false,
             blockReason: blockReason ?? null,
             completed,
             costStatus: dollarAmount === null ? 'unknown' : 'estimated',

--- a/apps/web/lib/tts/gemini-usage.ts
+++ b/apps/web/lib/tts/gemini-usage.ts
@@ -2,7 +2,10 @@ import type { FinishReason, GenerateContentResponse } from '@google/genai';
 import { captureException } from '@sentry/nextjs';
 import { after } from 'next/server';
 
-import { calculateGenerateApiDollarAmount } from '@/lib/api/pricing';
+import {
+  calculateGenerateApiDollarAmount,
+  hasModelPricing,
+} from '@/lib/api/pricing';
 import { insertUsageEvent } from '@/lib/supabase/queries';
 import { parseGoogleApiError } from '@/utils/google-errors';
 import { classifyGeminiTtsResponse } from './gemini-response';
@@ -82,7 +85,13 @@ function createAttempt(context: AttemptContext, streaming: boolean) {
         const outputTokens = tokenCount(usage?.candidatesTokenCount);
         const totalTokens = tokenCount(usage?.totalTokenCount);
         const dollarAmount =
-          inputTokens !== null && outputTokens !== null
+          inputTokens !== null &&
+          outputTokens !== null &&
+          hasModelPricing({
+            model: context.model,
+            provider: 'google',
+            sourceType: context.sourceType,
+          })
             ? calculateGenerateApiDollarAmount({
                 candidatesTokenCount: outputTokens,
                 model: context.model,

--- a/apps/web/lib/tts/gemini-usage.ts
+++ b/apps/web/lib/tts/gemini-usage.ts
@@ -49,14 +49,12 @@ function createAttempt(context: AttemptContext, streaming: boolean) {
   let finishReason: FinishReason | undefined;
   let blockReason: string | undefined;
   let responseId: string | undefined;
-  let httpStatus: number | null = null;
   let hasAudio = false;
   let receivedResponse = false;
 
   return {
     observe(response: GenerateContentResponse) {
       receivedResponse = true;
-      httpStatus = response.sdkHttpResponse?.responseInternal?.status ?? 200;
       usage = mergeGeminiUsage(usage, response.usageMetadata);
       finishReason = response.candidates?.[0]?.finishReason ?? finishReason;
       blockReason = response.promptFeedback?.blockReason ?? blockReason;
@@ -120,7 +118,7 @@ function createAttempt(context: AttemptContext, streaming: boolean) {
             completed,
             costStatus: dollarAmount === null ? 'unknown' : 'estimated',
             finishReason: finishReason ?? null,
-            httpStatus: errorStatus ?? httpStatus,
+            httpStatus: errorStatus,
             outcome,
             provider: 'google',
             receivedResponse,

--- a/apps/web/lib/utils.ts
+++ b/apps/web/lib/utils.ts
@@ -268,10 +268,10 @@ export function encodedRedirect(
   return redirect(`${path}?${type}=${encodeURIComponent(message)}`);
 }
 
-interface GeminiMetadata extends Record<string, string> {
-  readonly candidatesTokenCount: string;
-  readonly promptTokenCount: string;
-  readonly totalTokenCount: string;
+interface GeminiMetadata {
+  readonly candidatesTokenCount?: string;
+  readonly promptTokenCount?: string;
+  readonly totalTokenCount?: string;
 }
 
 interface ReplicateMetadata extends Record<string, string> {
@@ -286,20 +286,20 @@ export function extractMetadata(
 ): GeminiMetadata | ReplicateMetadata | undefined {
   if (isGeminiVoice) {
     const metadata = genAIResponse?.usageMetadata;
-    if (
-      !(
-        metadata?.promptTokenCount &&
-        metadata.candidatesTokenCount &&
-        metadata.totalTokenCount
-      )
-    ) {
-      return;
-    }
-    return {
-      candidatesTokenCount: metadata.candidatesTokenCount.toString(),
-      promptTokenCount: metadata.promptTokenCount.toString(),
-      totalTokenCount: metadata.totalTokenCount.toString(),
-    } as const;
+    if (!metadata) return;
+    const counts = {
+      candidatesTokenCount: metadata.candidatesTokenCount,
+      promptTokenCount: metadata.promptTokenCount,
+      totalTokenCount: metadata.totalTokenCount,
+    };
+    const entries = Object.entries(counts).filter(
+      ([, value]) =>
+        typeof value === 'number' && Number.isSafeInteger(value) && value >= 0,
+    );
+    if (entries.length === 0) return;
+    return Object.fromEntries(
+      entries.map(([key, value]) => [key, String(value)]),
+    );
   }
   const metrics = replicateResponse?.metrics;
   if (!(metrics?.predict_time && metrics?.total_time)) {

--- a/apps/web/lib/utils.ts
+++ b/apps/web/lib/utils.ts
@@ -281,7 +281,7 @@ interface ReplicateMetadata extends Record<string, string> {
 
 export function extractMetadata(
   isGeminiVoice: boolean,
-  genAIResponse: GenerateContentResponse | null,
+  genAIResponse: Pick<GenerateContentResponse, 'usageMetadata'> | null,
   replicateResponse?: Prediction,
 ): GeminiMetadata | ReplicateMetadata | undefined {
   if (isGeminiVoice) {

--- a/apps/web/supabase/functions/telegram-bot/index.ts
+++ b/apps/web/supabase/functions/telegram-bot/index.ts
@@ -384,6 +384,7 @@ async function generateTodayStats(): Promise<string> {
           .select(
             'id, user_id, source_type, credits_used, occurred_at, profiles(username)',
           )
+          .eq('event_kind', 'customer_usage')
           .gte('occurred_at', sevenDaysAgo.toISOString())
           .lt('occurred_at', now.toISOString())
           .order('occurred_at', { ascending: true })

--- a/apps/web/supabase/migrations/20260908120000_add_gemini_provider_usage.sql
+++ b/apps/web/supabase/migrations/20260908120000_add_gemini_provider_usage.sql
@@ -1,0 +1,70 @@
+-- Provider attempts carry estimated supplier cost; customer events carry credits.
+alter table public.usage_events
+  add column event_kind text not null default 'customer_usage'
+    check (event_kind in ('customer_usage', 'provider_attempt')),
+  add column input_tokens bigint check (input_tokens >= 0),
+  add column output_tokens bigint check (output_tokens >= 0),
+  add column total_tokens bigint check (total_tokens >= 0),
+  add constraint usage_events_provider_credits_check
+    check (event_kind <> 'provider_attempt' or credits_used = 0);
+
+comment on column public.usage_events.input_tokens is 'Provider-reported prompt tokens. NULL means unavailable.';
+comment on column public.usage_events.output_tokens is 'Provider-reported candidate tokens. NULL means unavailable.';
+comment on column public.usage_events.total_tokens is 'Provider-reported total tokens. Not derived from input and output.';
+comment on column public.usage_events.event_kind is 'Customer credit consumption or provider attempt. Gemini cost and tokens belong to provider attempts.';
+
+CREATE OR REPLACE FUNCTION public.get_usage_summary(
+  p_user_id UUID,
+  p_start_date TIMESTAMPTZ DEFAULT NULL,
+  p_end_date TIMESTAMPTZ DEFAULT NULL
+)
+RETURNS TABLE (
+  source_type public.usage_source_type,
+  total_credits BIGINT,
+  operation_count BIGINT
+)
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+BEGIN
+  RETURN QUERY
+  SELECT
+    ue.source_type,
+    COALESCE(SUM(ue.credits_used)::BIGINT, 0) AS total_credits,
+    COUNT(*)::BIGINT AS operation_count
+  FROM public.usage_events ue
+  WHERE ue.user_id = p_user_id
+    AND ue.event_kind = 'customer_usage'
+    AND (p_start_date IS NULL OR ue.occurred_at >= p_start_date)
+    AND (p_end_date IS NULL OR ue.occurred_at < p_end_date)
+  GROUP BY ue.source_type;
+END;
+$$;
+
+create or replace view public.api_usage_daily
+with (security_invoker = on) as
+select
+  ue.user_id,
+  date_trunc('day', ue.occurred_at) as usage_date,
+  ue.source_type,
+  ue.api_key_id,
+  ue.model,
+  count(*) filter (where ue.event_kind = 'customer_usage')::bigint as requests,
+  coalesce(sum(coalesce(ue.input_chars, 0)) filter (where ue.event_kind = 'customer_usage'), 0)::bigint as total_input_chars,
+  coalesce(sum(coalesce(ue.output_chars, 0)) filter (where ue.event_kind = 'customer_usage'), 0)::bigint as total_output_chars,
+  coalesce(sum(coalesce(ue.duration_seconds, 0)) filter (where ue.event_kind = 'customer_usage'), 0)::numeric(12, 2) as total_duration_seconds,
+  sum(coalesce(ue.dollar_amount, 0))::numeric(18, 6) as total_dollar_amount,
+  sum(coalesce(ue.credits_used, 0))::bigint as total_credits_used
+from public.usage_events ue
+where ue.source_type::text in (
+  'api_tts',
+  'api_voice_cloning'
+)
+group by
+  ue.user_id,
+  date_trunc('day', ue.occurred_at),
+  ue.source_type,
+  ue.api_key_id,
+  ue.model
+order by usage_date desc;

--- a/apps/web/supabase/tests/gemini_usage.test.sql
+++ b/apps/web/supabase/tests/gemini_usage.test.sql
@@ -1,5 +1,5 @@
 begin;
-select plan(9);
+select plan(10);
 
 -- Fixtures are rolled back, including the deferred Auth-user reference.
 alter table public.profiles alter constraint profiles_id_fkey deferrable initially deferred;
@@ -13,17 +13,21 @@ values
   ('44444444-4444-4444-8444-444444444444', 'api_tts', 'operation', 1, 0,
    'gemini-3.1-flash-tts-preview', 'provider_attempt', 0, 100, 100, 0.002, 100),
   ('44444444-4444-4444-8444-444444444444', 'api_tts', 'chars', 10, 20,
-   'gemini-3.1-flash-tts-preview', 'customer_usage', null, null, null, null, 10);
+   'gemini-3.1-flash-tts-preview', 'customer_usage', null, null, null, null, 10),
+  ('44444444-4444-4444-8444-444444444444', 'api_tts', 'operation', 1, 0,
+   'gemini-2.5-pro-preview-tts', 'provider_attempt', 0, 50, 50, 0.001, 100);
 
 select is((select sum(input_tokens)::bigint from public.usage_events where user_id = '44444444-4444-4444-8444-444444444444'), 0::bigint, 'zero tokens are preserved');
 select is((select total_credits from public.get_usage_summary('44444444-4444-4444-8444-444444444444')), 20::bigint, 'provider telemetry consumes no customer credits');
 select is((select operation_count from public.get_usage_summary('44444444-4444-4444-8444-444444444444')), 1::bigint, 'summary counts customer operations once');
-select is((select requests from public.api_usage_daily where user_id = '44444444-4444-4444-8444-444444444444'), 1::bigint, 'API view counts customer requests once');
-select is((select total_dollar_amount from public.api_usage_daily where user_id = '44444444-4444-4444-8444-444444444444'), 0.002::numeric, 'API view includes provider cost once');
-select is((select total_input_chars from public.api_usage_daily where user_id = '44444444-4444-4444-8444-444444444444'), 10::bigint, 'provider input characters do not double customer totals');
+select is((select requests from public.api_usage_daily where user_id = '44444444-4444-4444-8444-444444444444' and model = 'gemini-3.1-flash-tts-preview'), 1::bigint, 'API view counts customer requests once');
+select is((select sum(total_dollar_amount) from public.api_usage_daily where user_id = '44444444-4444-4444-8444-444444444444'), 0.003::numeric, 'API view includes costs across both models once');
+select is((select sum(total_input_chars)::bigint from public.api_usage_daily where user_id = '44444444-4444-4444-8444-444444444444'), 10::bigint, 'provider input characters do not double customer totals');
 select is((select input_tokens from public.usage_events where user_id = '44444444-4444-4444-8444-444444444444' and event_kind = 'customer_usage'), null::bigint, 'missing token counts remain NULL');
 select throws_ok($$insert into public.usage_events (user_id, source_type, unit, quantity, credits_used, event_kind) values ('44444444-4444-4444-8444-444444444444', 'tts', 'operation', 1, 1, 'provider_attempt')$$, '23514', null, 'provider attempts cannot consume credits');
 select throws_ok($$insert into public.usage_events (user_id, source_type, unit, quantity, credits_used, input_tokens) values ('44444444-4444-4444-8444-444444444444', 'tts', 'operation', 1, 0, -1)$$, '23514', null, 'negative token counts are rejected');
+
+select is((select requests from public.api_usage_daily where user_id = '44444444-4444-4444-8444-444444444444' and model = 'gemini-2.5-pro-preview-tts'), 0::bigint, 'provider-only model remains available for internal cost reporting');
 
 select * from finish();
 rollback;

--- a/apps/web/supabase/tests/gemini_usage.test.sql
+++ b/apps/web/supabase/tests/gemini_usage.test.sql
@@ -1,0 +1,29 @@
+begin;
+select plan(9);
+
+-- Fixtures are rolled back, including the deferred Auth-user reference.
+alter table public.profiles alter constraint profiles_id_fkey deferrable initially deferred;
+insert into public.profiles (id, username)
+values ('44444444-4444-4444-8444-444444444444', 'pgtap-gemini@example.com');
+
+insert into public.usage_events
+  (user_id, source_type, unit, quantity, credits_used, model, event_kind,
+   input_tokens, output_tokens, total_tokens, dollar_amount, input_chars)
+values
+  ('44444444-4444-4444-8444-444444444444', 'api_tts', 'operation', 1, 0,
+   'gemini-3.1-flash-tts-preview', 'provider_attempt', 0, 100, 100, 0.002, 100),
+  ('44444444-4444-4444-8444-444444444444', 'api_tts', 'chars', 10, 20,
+   'gemini-3.1-flash-tts-preview', 'customer_usage', null, null, null, null, 10);
+
+select is((select sum(input_tokens)::bigint from public.usage_events where user_id = '44444444-4444-4444-8444-444444444444'), 0::bigint, 'zero tokens are preserved');
+select is((select total_credits from public.get_usage_summary('44444444-4444-4444-8444-444444444444')), 20::bigint, 'provider telemetry consumes no customer credits');
+select is((select operation_count from public.get_usage_summary('44444444-4444-4444-8444-444444444444')), 1::bigint, 'summary counts customer operations once');
+select is((select requests from public.api_usage_daily where user_id = '44444444-4444-4444-8444-444444444444'), 1::bigint, 'API view counts customer requests once');
+select is((select total_dollar_amount from public.api_usage_daily where user_id = '44444444-4444-4444-8444-444444444444'), 0.002::numeric, 'API view includes provider cost once');
+select is((select total_input_chars from public.api_usage_daily where user_id = '44444444-4444-4444-8444-444444444444'), 10::bigint, 'provider input characters do not double customer totals');
+select is((select input_tokens from public.usage_events where user_id = '44444444-4444-4444-8444-444444444444' and event_kind = 'customer_usage'), null::bigint, 'missing token counts remain NULL');
+select throws_ok($$insert into public.usage_events (user_id, source_type, unit, quantity, credits_used, event_kind) values ('44444444-4444-4444-8444-444444444444', 'tts', 'operation', 1, 1, 'provider_attempt')$$, '23514', null, 'provider attempts cannot consume credits');
+select throws_ok($$insert into public.usage_events (user_id, source_type, unit, quantity, credits_used, input_tokens) values ('44444444-4444-4444-8444-444444444444', 'tts', 'operation', 1, 0, -1)$$, '23514', null, 'negative token counts are rejected');
+
+select * from finish();
+rollback;

--- a/apps/web/tests/api-v1-speech.test.ts
+++ b/apps/web/tests/api-v1-speech.test.ts
@@ -535,10 +535,18 @@ describe('/api/v1/speech', () => {
       'gemini-3.1-flash-tts-preview',
     );
     expect(json.usage.model).toBe('gemini-3.1-flash-tts-preview');
+    expect(insertUsageEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        creditsUsed: 0,
+        dollarAmount: 0.000_726,
+        eventKind: 'provider_attempt',
+        model: 'gemini-3.1-flash-tts-preview',
+      }),
+    );
     expect(vi.mocked(insertUsageEvent)).toHaveBeenCalledWith(
       expect.objectContaining({
         creditsUsed: actualCredits,
-        dollarAmount: 0.000_726,
+        dollarAmount: null,
         durationSeconds: 12,
         model: 'gemini-3.1-flash-tts-preview',
       }),
@@ -986,7 +994,7 @@ describe('/api/v1/speech', () => {
     expect(vi.mocked(insertUsageEvent)).toHaveBeenCalledWith(
       expect.objectContaining({
         dollarAmount: 0.000_103,
-        durationSeconds: 12,
+        eventKind: 'provider_attempt',
         model: 'gemini-2.5-flash-preview-tts',
       }),
     );

--- a/apps/web/tests/api-v1-speech.test.ts
+++ b/apps/web/tests/api-v1-speech.test.ts
@@ -998,6 +998,16 @@ describe('/api/v1/speech', () => {
         model: 'gemini-2.5-flash-preview-tts',
       }),
     );
+    const customerEvent = vi
+      .mocked(insertUsageEvent)
+      .mock.calls.map(([event]) => event)
+      .find((event) => event.eventKind !== 'provider_attempt');
+    expect(customerEvent).toMatchObject({
+      dollarAmount: null,
+      durationSeconds: 12,
+      model: 'gemini-2.5-flash-preview-tts',
+    });
+    expect(customerEvent?.creditsUsed).toBeGreaterThan(0);
   });
 
   it('returns provider unavailable from transient Gemini errors without capture', async () => {

--- a/apps/web/tests/billing-usage.test.ts
+++ b/apps/web/tests/billing-usage.test.ts
@@ -36,6 +36,16 @@ describe('/api/billing/usage', () => {
           data: [
             {
               api_key_id: 'key-1',
+              model: 'failed-primary-model',
+              requests: 0,
+              source_type: 'api_tts',
+              total_credits_used: 0,
+              total_dollar_amount: 0.12,
+              usage_date: '2026-02-26T00:00:00.000Z',
+              user_id: 'test-user-id',
+            },
+            {
+              api_key_id: 'key-1',
               model: 'gpro',
               requests: 2,
               source_type: 'api_tts',

--- a/apps/web/tests/gemini-stream-usage.test.ts
+++ b/apps/web/tests/gemini-stream-usage.test.ts
@@ -120,3 +120,28 @@ it('retains provider usage when audio upload fails', async () => {
     }),
   );
 });
+
+it('charges the estimate while preserving zero provider tokens', async () => {
+  setMockGoogleGenAIFactory(() => ({
+    models: {
+      async *generateContentStream() {
+        yield {
+          ...createDefaultStreamChunk(),
+          usageMetadata: {
+            candidatesTokenCount: 0,
+            promptTokenCount: 0,
+            totalTokenCount: 0,
+          },
+        } as GenerateContentResponse;
+      },
+    },
+  }));
+  expect(await generate()).toContain('event: done');
+  const events = vi.mocked(insertUsageEvent).mock.calls.map(([event]) => event);
+  expect(events[0]).toMatchObject({
+    inputTokens: 0,
+    outputTokens: 0,
+    totalTokens: 0,
+  });
+  expect(events[1].creditsUsed).toBeGreaterThan(0);
+});

--- a/apps/web/tests/gemini-stream-usage.test.ts
+++ b/apps/web/tests/gemini-stream-usage.test.ts
@@ -59,6 +59,8 @@ it('stores streaming tokens and dollar amount once, separately from customer cre
   });
   expect(events[1].dollarAmount).toBeUndefined();
   expect(events[1].creditsUsed).toBeGreaterThan(0);
+  expect(events[0].requestId).toEqual(expect.any(String));
+  expect(events[0].requestId).not.toBe('');
   expect(events[0].requestId).toBe(events[1].requestId);
 });
 
@@ -99,6 +101,8 @@ it('retains primary usage when a stream without audio falls back', async () => {
     model: 'gemini-2.5-flash-preview-tts',
     outputTokens: 12,
   });
+  expect(events[0].requestId).toEqual(expect.any(String));
+  expect(events[0].requestId).not.toBe('');
   expect(new Set(events.map((event) => event.requestId)).size).toBe(1);
 });
 

--- a/apps/web/tests/gemini-stream-usage.test.ts
+++ b/apps/web/tests/gemini-stream-usage.test.ts
@@ -1,0 +1,122 @@
+import { FinishReason, type GenerateContentResponse } from '@google/genai';
+import { afterEach, beforeEach, expect, it, vi } from 'vitest';
+
+import { POST } from '@/app/api/generate-voice/route';
+import { hasUserPaid, insertUsageEvent } from '@/lib/supabase/queries';
+import {
+  createDefaultStreamChunk,
+  mockUploadFileToR2,
+  resetMockGoogleGenAIFactory,
+  setMockGoogleGenAIFactory,
+} from './setup';
+
+// Exercise the retained streaming path without enabling it for production.
+vi.mock('@/lib/ai', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/ai')>()),
+  GEMINI_STREAMING_ENABLED: true,
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(hasUserPaid).mockResolvedValueOnce(true);
+});
+afterEach(() => resetMockGoogleGenAIFactory());
+
+async function generate() {
+  const response = await POST(
+    new Request('http://localhost/api/generate-voice', {
+      body: JSON.stringify({
+        stream: true,
+        text: 'Hello world',
+        voiceId: 'voice-achernar-31-id',
+      }),
+      headers: { 'content-type': 'application/json' },
+      method: 'POST',
+    }),
+  );
+  expect(response.headers.get('content-type')).toContain('text/event-stream');
+  return response.text();
+}
+
+it('stores streaming tokens and dollar amount once, separately from customer credits', async () => {
+  setMockGoogleGenAIFactory(() => ({
+    models: {
+      async *generateContentStream() {
+        yield createDefaultStreamChunk();
+      },
+    },
+  }));
+  expect(await generate()).toContain('event: done');
+  const events = vi.mocked(insertUsageEvent).mock.calls.map(([event]) => event);
+  expect(events).toHaveLength(2);
+  expect(events[0]).toMatchObject({
+    creditsUsed: 0,
+    dollarAmount: 0.000_251,
+    eventKind: 'provider_attempt',
+    inputTokens: 11,
+    outputTokens: 12,
+    totalTokens: 23,
+  });
+  expect(events[1].dollarAmount).toBeUndefined();
+  expect(events[1].creditsUsed).toBeGreaterThan(0);
+  expect(events[0].requestId).toBe(events[1].requestId);
+});
+
+it('retains primary usage when a stream without audio falls back', async () => {
+  let attempts = 0;
+  setMockGoogleGenAIFactory(() => ({
+    models: {
+      async *generateContentStream() {
+        attempts += 1;
+        if (attempts === 1) {
+          yield {
+            candidates: [{ finishReason: FinishReason.STOP }],
+            usageMetadata: {
+              candidatesTokenCount: 50,
+              promptTokenCount: 100,
+              totalTokenCount: 150,
+            },
+          } as GenerateContentResponse;
+        } else {
+          yield createDefaultStreamChunk();
+        }
+      },
+    },
+  }));
+  expect(await generate()).toContain('event: done');
+  const events = vi.mocked(insertUsageEvent).mock.calls.map(([event]) => event);
+  expect(events).toHaveLength(3);
+  expect(events[0]).toMatchObject({
+    dollarAmount: 0.0011,
+    inputTokens: 100,
+    metadata: { outcome: 'no_audio' },
+    model: 'gemini-3.1-flash-tts-preview',
+    outputTokens: 50,
+  });
+  expect(events[1]).toMatchObject({
+    dollarAmount: 0.000_126,
+    inputTokens: 11,
+    model: 'gemini-2.5-flash-preview-tts',
+    outputTokens: 12,
+  });
+  expect(new Set(events.map((event) => event.requestId)).size).toBe(1);
+});
+
+it('retains provider usage when audio upload fails', async () => {
+  setMockGoogleGenAIFactory(() => ({
+    models: {
+      async *generateContentStream() {
+        yield createDefaultStreamChunk();
+      },
+    },
+  }));
+  mockUploadFileToR2.mockRejectedValueOnce(new Error('upload unavailable'));
+  expect(await generate()).toContain('event: error');
+  expect(insertUsageEvent).toHaveBeenCalledExactlyOnceWith(
+    expect.objectContaining({
+      creditsUsed: 0,
+      dollarAmount: 0.000_251,
+      eventKind: 'provider_attempt',
+    }),
+  );
+});

--- a/apps/web/tests/gemini-usage.test.ts
+++ b/apps/web/tests/gemini-usage.test.ts
@@ -66,6 +66,21 @@ describe('Gemini token parsing', () => {
 });
 
 describe('Gemini provider attempts', () => {
+  it('keeps unpriced model cost unknown while retaining token counts', async () => {
+    await trackGeminiGeneration(
+      { ...context, model: 'unpriced-model' },
+      async () => response({ candidatesTokenCount: 20, promptTokenCount: 10 }),
+    );
+    expect(insertUsageEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        dollarAmount: null,
+        inputTokens: 10,
+        metadata: expect.objectContaining({ costStatus: 'unknown' }),
+        outputTokens: 20,
+      }),
+    );
+  });
+
   it('returns the response before the deferred insert starts', async () => {
     let deferred: (() => void | Promise<void>) | undefined;
     vi.mocked(after).mockImplementationOnce((callback) => {

--- a/apps/web/tests/gemini-usage.test.ts
+++ b/apps/web/tests/gemini-usage.test.ts
@@ -255,10 +255,50 @@ describe('Gemini provider attempts', () => {
       expect.objectContaining({
         inputTokens: 10,
         metadata: expect.objectContaining({
+          aborted: true,
           completed: false,
-          outcome: 'aborted',
+          outcome: 'incomplete',
         }),
         outputTokens: 30,
+      }),
+    );
+  });
+
+  it('preserves the provider outcome when the client has disconnected', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    await trackGeminiGeneration(
+      { ...context, signal: controller.signal },
+      async () => response({ candidatesTokenCount: 20, promptTokenCount: 10 }),
+    );
+    expect(insertUsageEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          aborted: true,
+          completed: true,
+          outcome: 'success',
+        }),
+      }),
+    );
+  });
+
+  it('marks an early stream break as incomplete without an abort signal', async () => {
+    async function* chunks() {
+      yield response({ candidatesTokenCount: 20 });
+    }
+    for await (const _chunk of trackGeminiStream(context, async () =>
+      chunks(),
+    )) {
+      break;
+    }
+    expect(insertUsageEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          aborted: false,
+          completed: false,
+          outcome: 'incomplete',
+        }),
+        outputTokens: 20,
       }),
     );
   });

--- a/apps/web/tests/gemini-usage.test.ts
+++ b/apps/web/tests/gemini-usage.test.ts
@@ -1,4 +1,5 @@
 import { FinishReason, type GenerateContentResponse } from '@google/genai';
+import { after } from 'next/server';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { insertUsageEvent } from '@/lib/supabase/queries';
@@ -32,6 +33,10 @@ const response = (
     usageMetadata,
   }) as GenerateContentResponse;
 
+vi.mock('next/server', () => ({
+  after: vi.fn((callback: () => Promise<void>) => callback()),
+}));
+
 beforeEach(() => vi.clearAllMocks());
 
 describe('Gemini token parsing', () => {
@@ -61,7 +66,22 @@ describe('Gemini token parsing', () => {
 });
 
 describe('Gemini provider attempts', () => {
-  it('records tokens and estimated cost before the app consumes the response', async () => {
+  it('returns the response before the deferred insert starts', async () => {
+    let deferred: (() => void | Promise<void>) | undefined;
+    vi.mocked(after).mockImplementationOnce((callback) => {
+      deferred = callback as () => void | Promise<void>;
+    });
+    const result = response({ candidatesTokenCount: 20, promptTokenCount: 10 });
+    await expect(
+      trackGeminiGeneration(context, async () => result),
+    ).resolves.toBe(result);
+    expect(insertUsageEvent).not.toHaveBeenCalled();
+    expect(deferred).toBeTypeOf('function');
+    await deferred?.();
+    expect(insertUsageEvent).toHaveBeenCalledOnce();
+  });
+
+  it('records tokens and estimated cost in the scheduled callback', async () => {
     const result = response({
       candidatesTokenCount: 1000,
       promptTokenCount: 100,

--- a/apps/web/tests/gemini-usage.test.ts
+++ b/apps/web/tests/gemini-usage.test.ts
@@ -113,7 +113,7 @@ describe('Gemini provider attempts', () => {
         inputTokens: 100,
         metadata: expect.objectContaining({
           costStatus: 'estimated',
-          httpStatus: 200,
+          httpStatus: null,
           outcome: 'success',
         }),
         outputTokens: 1000,
@@ -159,7 +159,7 @@ describe('Gemini provider attempts', () => {
     },
   );
 
-  it('records blocked HTTP 200 and retains partial counts', async () => {
+  it('records blocked SDK responses and retains partial counts', async () => {
     await trackGeminiGeneration(context, async () =>
       response({ promptTokenCount: 5 }, FinishReason.SAFETY),
     );
@@ -168,7 +168,7 @@ describe('Gemini provider attempts', () => {
         dollarAmount: null,
         inputTokens: 5,
         metadata: expect.objectContaining({
-          httpStatus: 200,
+          httpStatus: null,
           outcome: 'content_blocked',
         }),
         outputTokens: null,

--- a/apps/web/tests/gemini-usage.test.ts
+++ b/apps/web/tests/gemini-usage.test.ts
@@ -1,0 +1,254 @@
+import { FinishReason, type GenerateContentResponse } from '@google/genai';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { insertUsageEvent } from '@/lib/supabase/queries';
+import {
+  trackGeminiGeneration,
+  trackGeminiStream,
+} from '@/lib/tts/gemini-usage';
+import { extractMetadata } from '@/lib/utils';
+
+const context = {
+  inputChars: 50,
+  model: 'gemini-3.1-flash-tts-preview',
+  requestId: 'request',
+  sourceType: 'tts' as const,
+  userId: 'user',
+};
+const response = (
+  usageMetadata: GenerateContentResponse['usageMetadata'],
+  finishReason = FinishReason.STOP,
+): GenerateContentResponse =>
+  ({
+    candidates: [
+      {
+        content: {
+          parts: [{ inlineData: { data: 'AA==', mimeType: 'audio/pcm' } }],
+        },
+        finishReason,
+      },
+    ],
+    responseId: 'google-response',
+    usageMetadata,
+  }) as GenerateContentResponse;
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('Gemini token parsing', () => {
+  it('preserves zero and partial counts without inventing missing values', () => {
+    expect(
+      extractMetadata(
+        true,
+        response({ promptTokenCount: 0, totalTokenCount: 7 }),
+      ),
+    ).toEqual({ promptTokenCount: '0', totalTokenCount: '7' });
+    expect(
+      extractMetadata(
+        true,
+        response({
+          candidatesTokenCount: 0,
+          promptTokenCount: 0,
+          totalTokenCount: 0,
+        }),
+      ),
+    ).toEqual({
+      candidatesTokenCount: '0',
+      promptTokenCount: '0',
+      totalTokenCount: '0',
+    });
+    expect(extractMetadata(true, response({}))).toBeUndefined();
+  });
+});
+
+describe('Gemini provider attempts', () => {
+  it('records tokens and estimated cost before the app consumes the response', async () => {
+    const result = response({
+      candidatesTokenCount: 1000,
+      promptTokenCount: 100,
+      totalTokenCount: 1100,
+    });
+    expect(await trackGeminiGeneration(context, async () => result)).toBe(
+      result,
+    );
+    expect(insertUsageEvent).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({
+        creditsUsed: 0,
+        dollarAmount: 0.0201,
+        eventKind: 'provider_attempt',
+        inputTokens: 100,
+        metadata: expect.objectContaining({
+          costStatus: 'estimated',
+          httpStatus: 200,
+          outcome: 'success',
+        }),
+        outputTokens: 1000,
+        totalTokens: 1100,
+      }),
+    );
+  });
+
+  it.each([400, 500])(
+    'excludes HTTP %s without swallowing the provider error',
+    async (status) => {
+      const error = Object.assign(new Error('provider error'), { status });
+      await expect(
+        trackGeminiGeneration(context, async () => {
+          throw error;
+        }),
+      ).rejects.toBe(error);
+      expect(insertUsageEvent).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([429, 503, undefined])(
+    'records HTTP %s failures with unknown cost',
+    async (status) => {
+      const error = Object.assign(new Error('provider error'), { status });
+      await expect(
+        trackGeminiGeneration(context, async () => {
+          throw error;
+        }),
+      ).rejects.toBe(error);
+      expect(insertUsageEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          dollarAmount: null,
+          inputTokens: null,
+          metadata: expect.objectContaining({
+            costStatus: 'unknown',
+            httpStatus: status ?? null,
+            outcome: 'error',
+          }),
+          outputTokens: null,
+        }),
+      );
+    },
+  );
+
+  it('records blocked HTTP 200 and retains partial counts', async () => {
+    await trackGeminiGeneration(context, async () =>
+      response({ promptTokenCount: 5 }, FinishReason.SAFETY),
+    );
+    expect(insertUsageEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        dollarAmount: null,
+        inputTokens: 5,
+        metadata: expect.objectContaining({
+          httpStatus: 200,
+          outcome: 'content_blocked',
+        }),
+        outputTokens: null,
+      }),
+    );
+  });
+
+  it('keeps stream snapshots cumulative and merges partial terminal metadata', async () => {
+    async function* chunks() {
+      yield response({ candidatesTokenCount: 20, promptTokenCount: 10 });
+      yield response({ candidatesTokenCount: 30 });
+      yield response({ totalTokenCount: 40 });
+    }
+    for await (const _chunk of trackGeminiStream(context, async () =>
+      chunks(),
+    )) {
+      /* consume */
+    }
+    expect(insertUsageEvent).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({
+        dollarAmount: 0.000_61,
+        inputTokens: 10,
+        outputTokens: 30,
+        totalTokens: 40,
+      }),
+    );
+  });
+
+  it('preserves partial stream usage when the connection fails', async () => {
+    const error = new Error('connection lost');
+    async function* chunks() {
+      yield response({ candidatesTokenCount: 30, promptTokenCount: 10 });
+      throw error;
+    }
+    await expect(
+      (async () => {
+        for await (const _chunk of trackGeminiStream(context, async () =>
+          chunks(),
+        )) {
+          /* consume */
+        }
+      })(),
+    ).rejects.toBe(error);
+    expect(insertUsageEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        inputTokens: 10,
+        metadata: expect.objectContaining({ outcome: 'error' }),
+        outputTokens: 30,
+      }),
+    );
+  });
+
+  it('records each fallback attempt separately with the actual model and shared request ID', async () => {
+    await trackGeminiGeneration(context, async () => {
+      throw Object.assign(new Error('unavailable'), { status: 503 });
+    }).catch(() => undefined);
+    await trackGeminiGeneration(
+      { ...context, model: 'gemini-2.5-flash-preview-tts' },
+      async () => response({ candidatesTokenCount: 20, promptTokenCount: 10 }),
+    );
+    expect(insertUsageEvent).toHaveBeenCalledTimes(2);
+    expect(insertUsageEvent).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        dollarAmount: 0.000_205,
+        model: 'gemini-2.5-flash-preview-tts',
+        requestId: 'request',
+      }),
+    );
+  });
+
+  it('records a client cancellation with the usage already received', async () => {
+    const controller = new AbortController();
+    async function* chunks() {
+      yield response({ candidatesTokenCount: 30, promptTokenCount: 10 });
+    }
+    for await (const _chunk of trackGeminiStream(
+      { ...context, signal: controller.signal },
+      async () => chunks(),
+    )) {
+      controller.abort();
+      break;
+    }
+    expect(insertUsageEvent).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({
+        inputTokens: 10,
+        metadata: expect.objectContaining({
+          completed: false,
+          outcome: 'aborted',
+        }),
+        outputTokens: 30,
+      }),
+    );
+  });
+
+  it('excludes a structured Google 400 error from usage events', async () => {
+    const error = new Error(
+      JSON.stringify({
+        error: { code: 400, message: 'invalid', status: 'INVALID_ARGUMENT' },
+      }),
+    );
+    await expect(
+      trackGeminiGeneration(context, async () => {
+        throw error;
+      }),
+    ).rejects.toBe(error);
+    expect(insertUsageEvent).not.toHaveBeenCalled();
+  });
+
+  it('does not fail generation when telemetry insertion throws', async () => {
+    vi.mocked(insertUsageEvent).mockRejectedValueOnce(
+      new Error('database unavailable'),
+    );
+    const result = response({ candidatesTokenCount: 20, promptTokenCount: 10 });
+    await expect(
+      trackGeminiGeneration(context, async () => result),
+    ).resolves.toBe(result);
+  });
+});

--- a/apps/web/tests/generate-voice.test.ts
+++ b/apps/web/tests/generate-voice.test.ts
@@ -599,6 +599,7 @@ describe('Generate Voice API Route', () => {
           voiceName: 'tara',
         },
         quantity: 11, // "Hello world".length
+        requestId: expect.any(String),
         sourceId: 'test-audio-file-id',
         sourceType: 'tts',
         unit: 'chars',
@@ -783,6 +784,7 @@ describe('Generate Voice API Route', () => {
           voiceName: 'eve',
         },
         quantity: 13,
+        requestId: expect.any(String),
         sourceId: 'test-audio-file-id',
         sourceType: 'tts',
         unit: 'chars',
@@ -1100,10 +1102,19 @@ describe('Generate Voice API Route', () => {
         voiceId: 'voice-kore-id',
       });
 
+      expect(insertUsageEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          creditsUsed: 0,
+          dollarAmount: 0.000_251,
+          eventKind: 'provider_attempt',
+          inputTokens: 11,
+          outputTokens: 12,
+          totalTokens: 23,
+        }),
+      );
       // Verify usage event was logged for Gemini voice
       expect(insertUsageEvent).toHaveBeenCalledWith({
         creditsUsed: 26,
-        dollarAmount: 0.000_251,
         metadata: {
           duration: '12',
           model: 'gemini-2.5-pro-preview-tts',
@@ -1117,6 +1128,7 @@ describe('Generate Voice API Route', () => {
           voiceName: 'kore',
         },
         quantity: text.length,
+        requestId: expect.any(String),
         sourceId: 'test-audio-file-id',
         sourceType: 'tts',
         unit: 'chars',
@@ -1379,9 +1391,8 @@ describe('Generate Voice API Route', () => {
       expect(insertUsageEvent).toHaveBeenCalledWith(
         expect.objectContaining({
           dollarAmount: 0.000_126,
-          metadata: expect.objectContaining({
-            model: 'gemini-2.5-flash-preview-tts',
-          }),
+          eventKind: 'provider_attempt',
+          model: 'gemini-2.5-flash-preview-tts',
         }),
       );
 

--- a/docs/devops.md
+++ b/docs/devops.md
@@ -536,7 +536,8 @@ stay NULL. Cost stays NULL unless both input and output counts are available.
 Metadata includes HTTP status, finish/block reason, response ID, and raw usage
 metadata, without prompt text or audio.
 
-Each SDK generation attempt gets one event before audio persistence. Fallbacks
+Each SDK generation attempt schedules one event. Non-streaming inserts run in
+Next.js `after()`; streaming inserts are awaited inside the background task. Fallbacks
 share the application's `request_id` but retain separate model usage. Streaming
 counts are cumulative snapshots, merged by field rather than summed. Google HTTP
 400 and 500 failures are excluded; other errors and HTTP 200 responses without

--- a/docs/devops.md
+++ b/docs/devops.md
@@ -532,14 +532,16 @@ Gemini dashboard, external speech API, and streaming calls record supplier usage
 through `apps/web/lib/tts/gemini-usage.ts`. In `usage_events`,
 `event_kind = 'provider_attempt'` stores numeric `input_tokens`, `output_tokens`,
 `total_tokens`, the actual model, and an estimated `dollar_amount`. Missing counts
-stay NULL. Cost stays NULL unless both input and output counts are available.
-Metadata includes HTTP status, finish/block reason, response ID, and raw usage
-metadata, without prompt text or audio.
+stay NULL. Cost stays NULL unless both input and output counts and model pricing are available.
+Metadata includes parsed error HTTP status, finish/block reason, response ID, and raw usage
+metadata, without prompt text or audio. SDK responses leave HTTP status NULL
+because the SDK exposes no status. Client cancellation is a separate `aborted` flag.
 
 Each SDK generation attempt schedules one event. Non-streaming inserts run in
 Next.js `after()`; streaming inserts are awaited inside the background task. Fallbacks
 share the application's `request_id` but retain separate model usage. Streaming
-counts are cumulative snapshots, merged by field rather than summed. Google HTTP
+counts are treated as cumulative snapshots and merged by field rather than summed.
+This is an accounting assumption; per-chunk deltas would require a different merge. Google HTTP
 400 and 500 failures are excluded; other errors and HTTP 200 responses without
 usable audio are recorded. These records do not prove an invoice charge.
 
@@ -552,7 +554,6 @@ attempts. Existing historical customer events retain their recorded costs.
 Apply `20260908120000_add_gemini_provider_usage.sql` before deploying the code,
 then run `pnpm test:db` against the migrated local database. Streaming remains
 disabled by the existing production flag.
-
 
 Check:
 

--- a/docs/devops.md
+++ b/docs/devops.md
@@ -528,6 +528,31 @@ Check:
 
 ### Gemini / voice generation issues
 
+Gemini dashboard, external speech API, and streaming calls record supplier usage
+through `apps/web/lib/tts/gemini-usage.ts`. In `usage_events`,
+`event_kind = 'provider_attempt'` stores numeric `input_tokens`, `output_tokens`,
+`total_tokens`, the actual model, and an estimated `dollar_amount`. Missing counts
+stay NULL. Cost stays NULL unless both input and output counts are available.
+Metadata includes HTTP status, finish/block reason, response ID, and raw usage
+metadata, without prompt text or audio.
+
+Each SDK generation attempt gets one event before audio persistence. Fallbacks
+share the application's `request_id` but retain separate model usage. Streaming
+counts are cumulative snapshots, merged by field rather than summed. Google HTTP
+400 and 500 failures are excluded; other errors and HTTP 200 responses without
+usable audio are recorded. These records do not prove an invoice charge.
+
+Provider attempts have zero credits. Customer events carry the credit deduction
+and audio-file reference; their Gemini cost and tokens are omitted to avoid
+counting the same generation twice. Customer history, summaries, and daily
+operation counts exclude provider attempts. API cost totals include provider
+attempts. Existing historical customer events retain their recorded costs.
+
+Apply `20260908120000_add_gemini_provider_usage.sql` before deploying the code,
+then run `pnpm test:db` against the migrated local database. Streaming remains
+disabled by the existing production flag.
+
+
 Check:
 
 - `GOOGLE_GENERATIVE_AI_API_KEY`

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -392,6 +392,16 @@ Use a temporary directory outside the repository for logs, downloaded audio,
 environment files, and generated reports. These artifacts may contain user text,
 email addresses, signed URLs, or other production data.
 
+### Provider attempt evidence
+
+Within the user's UTC window, read `usage_events` for both `customer_usage` and
+`provider_attempt` events. Correlate attempts and customer charges by `request_id`;
+fallback attempts retain their actual model. Provider rows hold numeric token
+counts, estimated `dollar_amount`, and outcome metadata even when no audio file
+exists. They consume zero customer credits. NULL tokens or cost mean unknown,
+and an estimate does not prove an invoice charge. See
+[`docs/devops.md`](../docs/devops.md#gemini--voice-generation-issues) for recording rules.
+
 ### 1. Establish the ledger baseline
 
 Run the read-only dispute evidence script to reconcile the complete account

--- a/scripts/compile-dispute-evidence.mts
+++ b/scripts/compile-dispute-evidence.mts
@@ -158,6 +158,7 @@ async function getUsageSummary(
   const { data, error } = await supabase
     .from('usage_events')
     .select('source_type, quantity, credits_used, occurred_at')
+    .eq('event_kind', 'customer_usage')
     .eq('user_id', userId)
     .order('occurred_at', { ascending: true });
 

--- a/skills/investigate-gemini-tts-credit-report/SKILL.md
+++ b/skills/investigate-gemini-tts-credit-report/SKILL.md
@@ -39,7 +39,8 @@ Do not execute it. Require explicit human approval as a separate follow-up.
 3. Query Sentry logs for the scoped UTC window using the organization and
    project in the runbook. Start without a level filter so handled warnings are
    included.
-4. Correlate attempts by user ID, timestamp, message, model, response ID,
+4. Read provider-attempt evidence as described in the runbook, correlating
+   `usage_events` by `request_id`. Correlate attempts by user ID, timestamp, message, model, response ID,
    artifact, and credit reservation/refund context. If the user-ID query is
    empty, broaden the Sentry query by response ID, message, or model before
    falling back.


### PR DESCRIPTION
## Summary

Gemini TTS spend cannot be reconciled reliably when tokens live only on audio files and failed or incomplete generations leave no usage record. Record provider attempts in `usage_events` independently of audio persistence, with numeric token counts and estimated costs, including the retained streaming path. Keep customer credit events separate so costs and operation counts are not counted twice.

## Changes

- Add nullable input/output/total token columns and `event_kind`; preserve zero and partial metadata.
- Track dashboard, external API, and streaming attempts with the actual model and shared request ID across fallbacks. Exclude Google HTTP 400/500 failures; retain other failures and responses without usable audio.
- Update customer reports and API spend aggregation, add regression and pgTAP tests, and document the mechanism in `docs/devops.md`.

## Validation

- 163 relevant Vitest tests passed; 16 existing streaming tests remain skipped. A separate test suite enables streaming only in tests and covers costs, fallback usage, and upload failures.
- Workspace `pnpm fixall` and `pnpm type-check` passed with existing warnings. Local checks used installed Node 26.7 and pnpm 11.7 because the pinned pnpm version could not be fetched. CI should validate the repository's configured runtime.
- Database tests and migration application are pending. No database migration or deployment was performed during implementation.

## Deployment steps

**Apply the database migration before deploying this code to any environment, including previews.** The shared usage insert helper and reporting queries require the new columns. The migration is compatible with the existing application's inserts because `event_kind` defaults to `customer_usage`.

### 1. Validate the migration locally

A human operator should check out this branch and, with the local Supabase stack running, execute from the repository root:

```sh
cd apps/web
supabase migration up --local
pnpm test:db
```

This applies pending local migrations, including `supabase/migrations/20260908120000_add_gemini_provider_usage.sql`. Require the pgTAP suite to pass, including `gemini_usage.test.sql`, before the production rollout.

### 2. Apply the migration to the target Supabase project

From `apps/web`, verify that the CLI is linked to the project used by the target Vercel environment. If needed, link it with `supabase link --project-ref <target-project-ref>`.

```sh
supabase migration list --linked
supabase db push --linked --dry-run
```

Review the pending list. The intended new migration is `20260908120000_add_gemini_provider_usage.sql`; review any additional pending migrations separately before proceeding. Then apply and verify its migration-history entry:

```sh
supabase db push --linked
supabase migration list --linked
```

Use the migration workflow so schema changes and migration history stay aligned. CLI behavior is documented in the [Supabase migration reference](https://supabase.com/docs/reference/cli/supabase-db-push).

### 3. Merge and deploy the app and Telegram function

After local database tests, PR checks, and target migration application succeed, merge this PR into `main` and deploy the web app through its Vercel workflow. Confirm that the deployment contains this PR. No new environment variables are required. Leave `GEMINI_STREAMING_ENABLED` disabled; this PR does not re-enable production streaming.

After applying the target migration, redeploy the `telegram-bot` Supabase edge function from this branch so its active-user statistics exclude provider attempts. Vercel deployment does not deploy this function.

### 4. Verify production records

Generate one Gemini clip through the dashboard and one through `/api/v1/speech`. Inspect recent rows with a read-only query:

```sql
select occurred_at, request_id, event_kind, source_type, model,
       credits_used, input_tokens, output_tokens, total_tokens,
       dollar_amount, metadata ->> 'httpStatus' as http_status,
       metadata ->> 'outcome' as outcome
from public.usage_events
where occurred_at >= now() - interval '15 minutes'
  and source_type in ('tts', 'api_tts')
order by occurred_at desc
limit 100;
```

Confirm each successful generation has a provider attempt with zero credits and a separate customer event under the same request ID. Tokens and estimated cost belong to the provider attempt; the customer event carries the credit deduction. Missing counts or costs must remain NULL. Confirm customer operation counts and API cost totals count each item once, and check Sentry for usage insertion errors. Validate blocked responses, non-400/500 errors, and fallbacks with mocks rather than intentionally inducing paid production failures.

## Scope

- [x] Backend
- [x] Database
- [x] Docs

## Checklist

- [x] I self-reviewed this PR
- [x] I ran `pnpm run fixall`
- [x] I ran `pnpm run type-check`
- [x] I added or updated tests where needed
- [x] I updated docs/comments where needed
- [x] I documented migrations and rollout notes
- [ ] A human applied the local migration and `pnpm test:db` passed
- [ ] A human applied the target database migration before deployment

## Notes for reviewers

`dollar_amount` is an estimate from reported tokens, not proof of a Google invoice charge. Historical rows retain their costs and receive the default customer event kind; no token backfill is included. Usage insertion remains best-effort with Sentry reporting if the database write fails.

If an application rollback is needed, retain the additive schema and recorded provider events. The older customer-history query does not filter provider attempts, so prefer a forward fix for reporting issues after new events exist.

