### PR TITLE
Replace LIMIT/OFFSET pagination with keyset cursor for daily stats

### DIFF
--- a/.agents/notes/implemented/reporting/2026-09-12-daily-stats-local-benchmark.md
+++ b/.agents/notes/implemented/reporting/2026-09-12-daily-stats-local-benchmark.md
@@ -1,0 +1,38 @@
+# Daily-stats local benchmark
+
+## Decision
+
+Use the same development-only `cache=off` patch on both revisions. It skips
+local activity-cache reads and writes. Deleting the cache before each request
+was rejected because requests would still include serialization and disk writes.
+Usage and safety instructions live in the
+[daily-stats README](../../../../../apps/web/app/api/daily-stats/README.md#local-benchmarking).
+
+## Measurement
+
+Measured on 2026-09-12 through `https://sv.dev/api/daily-stats`, with report date
+`2026-09-12`, the same running Next.js development server, and unchanged service
+configuration. Each batch had one excluded warmup and five sequential requests.
+The branch batch ran first, followed by local `main`. No database buffers or
+upstream caches were cleared. No migrations were applied.
+
+| Revision                                          | Median |    Min |    Max | Warmup |
+| ------------------------------------------------- | -----: | -----: | -----: | -----: |
+| main `fd5ceb87410f090eb74df1ff46e31495dd23949a`   | 6.782s | 6.711s | 7.420s | 7.517s |
+| branch `f75d7b5d3c635b51b20aa5513caae5289d674bf9` | 6.602s | 6.450s | 7.472s | 9.768s |
+
+The branch median was 0.180s lower, or 2.66%. This small sample does not establish
+a speedup beyond ordinary network and database variance. Neither batch failed;
+these measurements do not assess retry behavior during gateway failures.
+
+All 12 responses were HTTP 200, confirmed cache bypass, and contained identical
+report bytes. Private reports, headers, and JSON timings are stored locally under
+`scripts/.cache/daily-stats-benchmark/branch-f75d7b5-18kl2C/` and
+`scripts/.cache/daily-stats-benchmark/main-fd5ceb8-kF24vB/`.
+
+## Verification
+
+The original branch was restored and the activity cache SHA-256 was unchanged.
+`pnpm fixall`, `pnpm type-check`, all six daily-stats test files, and the runner's
+syntax and file-scoped Biome checks passed. The six test files contain 98 tests,
+including 12 cache-bypass and production-authentication regression cases.

--- a/.agents/notes/implemented/reporting/2026-09-12-daily-stats-local-benchmark.md
+++ b/.agents/notes/implemented/reporting/2026-09-12-daily-stats-local-benchmark.md
@@ -1,5 +1,20 @@
 # Daily-stats local benchmark
 
+## Motivation
+
+This change came from a production failure, not from the benchmark below. The
+07:00 UTC cron on 2026-09-12 died with `Error: Gateway Timeout` (Sentry issue
+`146561120`, deployment `dpl_C5CjXfESGWDhrpwKPvYyKBvVSS96`). Sentry's
+breadcrumbs name the request: `usage_events` at `offset=5000&limit=1000`
+returned 504 from Supabase's REST gateway after five shallower pages of the same
+query returned 200.
+
+So the benchmark below is not the evidence for the change; it only checks that
+paging differently did not make the ordinary case slower. Read its null result
+that way. The deepest-page cost that keyset paging removes is not reachable at
+the row counts a local dataset holds, and the incident it addresses was a
+gateway 504 on one page, which no timing run reproduces.
+
 ## Decision
 
 Use the same development-only `cache=off` patch on both revisions. It skips

--- a/apps/web/app/api/daily-stats/README.md
+++ b/apps/web/app/api/daily-stats/README.md
@@ -64,8 +64,30 @@ Contribution reads both usage and transactions fresh, even during local cached
 activity debugging, so customer classification and collections use fresh payment
 history. This intentionally requires an all-time transaction read on that path.
 
+## Query load
+
+A single page returning `504 Gateway Timeout` fails the whole run, so
+`fetchAllPages` replays a page up to four times with exponential backoff on
+transient gateway or connection failures (502/503/504, `ETIMEDOUT`, dropped
+sockets) and on retryable SQLSTATEs such as `57014`. Every caller only reads, so
+replaying a page is safe. Non-transient errors still fail the run on the first
+response.
+
+Credit transactions are read once for all time and sliced in memory for every
+reporting window. The per-period reads this replaced were subsets of that same
+range with identical filters and were merged straight back into it, so they
+added load without adding rows. Add new windows as in-memory filters over
+`allCreditTransactions`, not as extra queries.
+
+Every paginated read is wrapped in `_timed`. Leaving one untimed makes a failure
+inside it look like it came from whatever ran next.
+
+Known remaining cost, not yet addressed: `fetchAllPages` walks `LIMIT/OFFSET`, so
+deep pages get progressively more expensive, and `getUsageEventsInRange` embeds
+`profiles(username)` on every row to label three users in the report.
+
 ## Verification
 
-Run `pnpm --filter @sexyvoice/web exec vitest run tests/daily-stats-contribution.test.ts tests/daily-stats-contribution-queries.test.ts tests/daily-stats-completed-calls.test.ts`.
+Run `pnpm --filter @sexyvoice/web exec vitest run tests/daily-stats-contribution.test.ts tests/daily-stats-contribution-queries.test.ts tests/daily-stats-completed-calls.test.ts tests/daily-stats-fetch-all-pages.test.ts`.
 Use read-only queries to investigate actual records. Do not invoke the production
 GET handler for verification; it sends the Telegram report.

--- a/apps/web/app/api/daily-stats/README.md
+++ b/apps/web/app/api/daily-stats/README.md
@@ -90,7 +90,7 @@ These shapes carry the same semantics as the row comparison
 `.agents/skills/supabase-postgres-best-practices/references/data-pagination.md`,
 but as plain ANDs. PostgREST cannot express a row comparison directly; the
 equivalent `(c > v) OR (c = v AND id > lastId)` needs a second top-level `or=`
-param on the two queries that already use `.or()` for their own filters, and
+param on the three queries that already use `.or()` for their own filters, and
 whether PostgREST ANDs repeated `or=` params is not verifiable from here.
 Getting that wrong would silently change which rows a revenue report counts, so
 the AND form is used instead at the cost of one extra request per long run.

--- a/apps/web/app/api/daily-stats/README.md
+++ b/apps/web/app/api/daily-stats/README.md
@@ -66,12 +66,12 @@ history. This intentionally requires an all-time transaction read on that path.
 
 ## Query load
 
-A single page returning `504 Gateway Timeout` fails the whole run, so
+A single page returning `504 Gateway Timeout` fails the whole report, so
 `fetchAllPages` replays a page up to four times with exponential backoff on
 transient gateway or connection failures (502/503/504, `ETIMEDOUT`, dropped
 sockets) and on retryable SQLSTATEs such as `57014`. Every caller only reads, so
-replaying a page is safe. Non-transient errors still fail the run on the first
-response.
+replaying a page is safe. Non-transient errors still fail the report on the
+first response.
 
 `fetchAllPages` pages with a keyset cursor, not `LIMIT/OFFSET`: an offset page
 makes Postgres sort and then discard every row it skips, so the deepest pages
@@ -81,13 +81,20 @@ select both that column and `id`, and order by `(column asc, id asc)`. The seek
 is inclusive (`gte`) and excludes the ids already returned at that exact value,
 so rows sharing a timestamp are neither skipped nor duplicated.
 
-Postgres fixes `now()` at transaction start, so a bulk insert — a promo grant, a
-backfill, a support batch — gives every row it writes the same timestamp. Past
-100 such rows the id list starts crowding the URL, so the cursor switches to
-walking the run by `id` (`eq(value)` + `gt(id, …)`) and then steps past it
-(`gt(value)`). That threshold is deliberately conservative: overshooting it
-risks a 414, which is not transient and fails the run, while undershooting costs
-one extra request.
+Rows can arrive in runs that share one timestamp, and a page can end part-way
+through such a run. Nothing in daily-stats writes, so these are not of its
+making: ordinary traffic inserts a row per user action, seconds apart, and runs
+stay one or two rows long. But `now()` is `transaction_timestamp()`, fixed when
+the transaction opens — so anything writing many rows in one transaction
+elsewhere (a promo grant, a hand-run backfill, a support batch) leaves every row
+it wrote holding the same timestamp, and this read has to page through the block
+they form.
+
+Up to 100 such rows the cursor carries their ids. Past that the id list starts
+crowding the URL, so it walks the run by `id` (`eq(value)` + `gt(id, …)`)
+instead and then steps past it (`gt(value)`). That threshold is deliberately
+conservative: overshooting it risks a 414, which is not transient and fails the
+report, while undershooting costs one extra request.
 These shapes carry the same semantics as the row comparison
 `(created_at, id) > (value, lastId)` in
 `.agents/skills/supabase-postgres-best-practices/references/data-pagination.md`,
@@ -96,7 +103,8 @@ equivalent `(c > v) OR (c = v AND id > lastId)` needs a second top-level `or=`
 param on the three queries that already use `.or()` for their own filters, and
 whether PostgREST ANDs repeated `or=` params is not verifiable from here.
 Getting that wrong would silently change which rows a revenue report counts, so
-the AND form is used instead at the cost of one extra request per long run.
+the AND form is used instead at the cost of one extra request per long run of
+rows.
 
 One guard remains, turning a mis-specified query into an error instead of a
 loop: a cursor value that moves backwards, which means the query is not ordered

--- a/apps/web/app/api/daily-stats/README.md
+++ b/apps/web/app/api/daily-stats/README.md
@@ -97,6 +97,34 @@ their embed: that read feeds the top-customer list, which needs many names.
 Every paginated read is wrapped in `_timed`. Leaving one untimed makes a failure
 inside it look like it came from whatever ran next.
 
+## Local benchmarking
+
+In development, `?cache=off` skips reading and writing
+`apps/web/.daily-stats-cache.json` without deleting the file. Successful bypass
+responses include `X-Daily-Stats-Cache: bypass` and `Cache-Control: no-store`.
+Production ignores this parameter and retains cron authentication.
+
+With `pnpm dev` running, open
+`https://sv.dev/api/daily-stats?date=2026-09-12&cache=off`, or run from the repo root:
+
+```sh
+node scripts/benchmark-daily-stats.mjs --label branch --date 2026-09-12
+```
+
+The runner excludes one warmup and measures five sequential requests. It checks
+HTTP status, the bypass header, and a nonempty text report. Results include total
+time, time to first byte, report hashes, and min/median/max timings. Reports and
+headers stay in private files under the ignored
+`scripts/.cache/daily-stats-benchmark/` directory. Treat these files as financial
+data; do not commit or share them. `--help` lists options.
+
+Compare versions with the same cache bypass patch, date, URL, environment, and
+run count. Switch versions only between runs and warm up each version before
+measuring. Do not benchmark versions concurrently against the same database.
+Database buffers and upstream caches are not cleared. After a client timeout,
+wait for the server request to finish before another run. Local mode does not
+send Telegram reports, but still requires `TELEGRAM_WEBHOOK_URL` to be set.
+
 ## Verification
 
 Run `pnpm --filter @sexyvoice/web exec vitest run tests/daily-stats-contribution.test.ts tests/daily-stats-contribution-queries.test.ts tests/daily-stats-completed-calls.test.ts tests/daily-stats-fetch-all-pages.test.ts`.

--- a/apps/web/app/api/daily-stats/README.md
+++ b/apps/web/app/api/daily-stats/README.md
@@ -85,11 +85,15 @@ Postgres fixes `now()` at transaction start, so a bulk insert — a promo grant,
 backfill, a support batch — gives every row it writes the same timestamp. Past
 200 such rows the ids no longer fit in a URL, so the cursor switches to walking
 the run by `id` (`eq(value)` + `gt(id, …)`) and then steps past it (`gt(value)`).
-Every cursor shape is a plain AND of filters: the shorter
-`(c > v) OR (c = v AND id > lastId)` predicate would need a second top-level
-`or=` param on the two queries that already use `.or()`, and whether PostgREST
-ANDs repeated `or=` params is not verifiable from here — getting it wrong would
-silently change which rows a revenue report counts.
+These shapes carry the same semantics as the row comparison
+`(created_at, id) > (value, lastId)` in
+`.agents/skills/supabase-postgres-best-practices/references/data-pagination.md`,
+but as plain ANDs. PostgREST cannot express a row comparison directly; the
+equivalent `(c > v) OR (c = v AND id > lastId)` needs a second top-level `or=`
+param on the two queries that already use `.or()` for their own filters, and
+whether PostgREST ANDs repeated `or=` params is not verifiable from here.
+Getting that wrong would silently change which rows a revenue report counts, so
+the AND form is used instead at the cost of one extra request per long run.
 
 One guard remains, turning a mis-specified query into an error instead of a
 loop: a cursor value that moves backwards, which means the query is not ordered

--- a/apps/web/app/api/daily-stats/README.md
+++ b/apps/web/app/api/daily-stats/README.md
@@ -83,8 +83,11 @@ so rows sharing a timestamp are neither skipped nor duplicated.
 
 Postgres fixes `now()` at transaction start, so a bulk insert — a promo grant, a
 backfill, a support batch — gives every row it writes the same timestamp. Past
-200 such rows the ids no longer fit in a URL, so the cursor switches to walking
-the run by `id` (`eq(value)` + `gt(id, …)`) and then steps past it (`gt(value)`).
+100 such rows the id list starts crowding the URL, so the cursor switches to
+walking the run by `id` (`eq(value)` + `gt(id, …)`) and then steps past it
+(`gt(value)`). That threshold is deliberately conservative: overshooting it
+risks a 414, which is not transient and fails the run, while undershooting costs
+one extra request.
 These shapes carry the same semantics as the row comparison
 `(created_at, id) > (value, lastId)` in
 `.agents/skills/supabase-postgres-best-practices/references/data-pagination.md`,

--- a/apps/web/app/api/daily-stats/README.md
+++ b/apps/web/app/api/daily-stats/README.md
@@ -73,18 +73,29 @@ sockets) and on retryable SQLSTATEs such as `57014`. Every caller only reads, so
 replaying a page is safe. Non-transient errors still fail the run on the first
 response.
 
+`fetchAllPages` pages with a keyset cursor, not `LIMIT/OFFSET`: an offset page
+makes Postgres sort and then discard every row it skips, so the deepest pages
+are both the slowest and the ones that time out. A query passes its ordering
+column as the cursor and applies it with `applyPageCursor`; it must therefore
+select both that column and `id`, and order by `(column asc, id asc)`. The seek
+is inclusive (`gte`) and excludes the ids already returned at that exact value,
+so rows sharing a timestamp are neither skipped nor duplicated. Two guards turn
+a mis-specified query into an error instead of a loop: a cursor value that moves
+backwards, and more than 200 rows sharing one value.
+
 Credit transactions are read once for all time and sliced in memory for every
 reporting window. The per-period reads this replaced were subsets of that same
 range with identical filters and were merged straight back into it, so they
 added load without adding rows. Add new windows as in-memory filters over
 `allCreditTransactions`, not as extra queries.
 
+Usage events carry no `profiles(username)` embed — PostgREST joins an embed per
+row, and the report labels only its top three users. Resolve names for the few
+ids actually shown with `getProfileUsernamesByIds`. Credit transactions keep
+their embed: that read feeds the top-customer list, which needs many names.
+
 Every paginated read is wrapped in `_timed`. Leaving one untimed makes a failure
 inside it look like it came from whatever ran next.
-
-Known remaining cost, not yet addressed: `fetchAllPages` walks `LIMIT/OFFSET`, so
-deep pages get progressively more expensive, and `getUsageEventsInRange` embeds
-`profiles(username)` on every row to label three users in the report.
 
 ## Verification
 

--- a/apps/web/app/api/daily-stats/README.md
+++ b/apps/web/app/api/daily-stats/README.md
@@ -79,9 +79,21 @@ are both the slowest and the ones that time out. A query passes its ordering
 column as the cursor and applies it with `applyPageCursor`; it must therefore
 select both that column and `id`, and order by `(column asc, id asc)`. The seek
 is inclusive (`gte`) and excludes the ids already returned at that exact value,
-so rows sharing a timestamp are neither skipped nor duplicated. Two guards turn
-a mis-specified query into an error instead of a loop: a cursor value that moves
-backwards, and more than 200 rows sharing one value.
+so rows sharing a timestamp are neither skipped nor duplicated.
+
+Postgres fixes `now()` at transaction start, so a bulk insert — a promo grant, a
+backfill, a support batch — gives every row it writes the same timestamp. Past
+200 such rows the ids no longer fit in a URL, so the cursor switches to walking
+the run by `id` (`eq(value)` + `gt(id, …)`) and then steps past it (`gt(value)`).
+Every cursor shape is a plain AND of filters: the shorter
+`(c > v) OR (c = v AND id > lastId)` predicate would need a second top-level
+`or=` param on the two queries that already use `.or()`, and whether PostgREST
+ANDs repeated `or=` params is not verifiable from here — getting it wrong would
+silently change which rows a revenue report counts.
+
+One guard remains, turning a mis-specified query into an error instead of a
+loop: a cursor value that moves backwards, which means the query is not ordered
+by the column it pages on.
 
 Credit transactions are read once for all time and sliced in memory for every
 reporting window. The per-period reads this replaced were subsets of that same
@@ -127,6 +139,6 @@ send Telegram reports, but still requires `TELEGRAM_WEBHOOK_URL` to be set.
 
 ## Verification
 
-Run `pnpm --filter @sexyvoice/web exec vitest run tests/daily-stats-contribution.test.ts tests/daily-stats-contribution-queries.test.ts tests/daily-stats-completed-calls.test.ts tests/daily-stats-fetch-all-pages.test.ts`.
+Run `pnpm --filter @sexyvoice/web exec vitest run tests/daily-stats-contribution.test.ts tests/daily-stats-contribution-queries.test.ts tests/daily-stats-completed-calls.test.ts tests/daily-stats-fetch-all-pages.test.ts tests/daily-stats-cache.test.ts`.
 Use read-only queries to investigate actual records. Do not invoke the production
 GET handler for verification; it sends the Telegram report.

--- a/apps/web/app/api/daily-stats/contribution-queries.ts
+++ b/apps/web/app/api/daily-stats/contribution-queries.ts
@@ -1,7 +1,7 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
 
 import type { CallSession, ContributionData, UsageEvent } from './contribution';
-import { fetchAllPages, PAGE_SIZE } from './utils';
+import { applyPageCursor, fetchAllPages, PAGE_SIZE } from './utils';
 
 const CALL_COLUMNS =
   'id, user_id, started_at, ended_at, duration_seconds, model, status';
@@ -29,7 +29,7 @@ export async function getContributionData(
   internalIds: string[],
 ): Promise<ContributionData> {
   const [events, windowCalls] = await Promise.all([
-    fetchAllPages<UsageEvent>((offset) => {
+    fetchAllPages<UsageEvent>('occurred_at', (cursor) => {
       let query = client
         .from('usage_events')
         .select(
@@ -38,12 +38,12 @@ export async function getContributionData(
         .gte('occurred_at', start.toISOString())
         .lt('occurred_at', end.toISOString());
       if (internalIds.length) query = query.notIn('user_id', internalIds);
-      return query
+      return applyPageCursor(query, cursor)
         .order('occurred_at')
         .order('id')
-        .range(offset, offset + PAGE_SIZE - 1);
+        .limit(PAGE_SIZE);
     }),
-    fetchAllPages<CallSession>((offset) => {
+    fetchAllPages<CallSession>('started_at', (cursor) => {
       let query = client
         .from('call_sessions')
         .select(CALL_COLUMNS)
@@ -51,10 +51,10 @@ export async function getContributionData(
           `and(ended_at.gte.${start.toISOString()},ended_at.lt.${end.toISOString()}),and(ended_at.is.null,started_at.gte.${start.toISOString()},started_at.lt.${end.toISOString()})`,
         );
       if (internalIds.length) query = query.notIn('user_id', internalIds);
-      return query
+      return applyPageCursor(query, cursor)
         .order('started_at')
         .order('id')
-        .range(offset, offset + PAGE_SIZE - 1);
+        .limit(PAGE_SIZE);
     }),
   ]);
   const calls = new Map(windowCalls.map((call) => [call.id, call]));
@@ -71,13 +71,13 @@ export async function getContributionData(
     ),
   ];
   const missingCalls = await fetchIdBatches(missingIds, (ids) =>
-    fetchAllPages<CallSession>((offset) =>
-      client
-        .from('call_sessions')
-        .select(CALL_COLUMNS)
-        .in('id', ids)
+    fetchAllPages<CallSession>('id', (cursor) =>
+      applyPageCursor(
+        client.from('call_sessions').select(CALL_COLUMNS).in('id', ids),
+        cursor,
+      )
         .order('id')
-        .range(offset, offset + PAGE_SIZE - 1),
+        .limit(PAGE_SIZE),
     ),
   );
   for (const row of missingCalls) {
@@ -92,14 +92,20 @@ export async function getContributionData(
     .filter((call) => !eventCallIds.has(call.id))
     .map((call) => call.id);
   const links = await fetchIdBatches(sessionIds, (ids) =>
-    fetchAllPages<Pick<Tables<'usage_events'>, 'source_id'>>((offset) =>
-      client
-        .from('usage_events')
-        .select('source_id')
-        .eq('source_type', 'live_call')
-        .in('source_id', ids)
-        .order('id')
-        .range(offset, offset + PAGE_SIZE - 1),
+    // `id` is selected only to carry the keyset cursor.
+    fetchAllPages<Pick<Tables<'usage_events'>, 'id' | 'source_id'>>(
+      'id',
+      (cursor) =>
+        applyPageCursor(
+          client
+            .from('usage_events')
+            .select('id, source_id')
+            .eq('source_type', 'live_call')
+            .in('source_id', ids),
+          cursor,
+        )
+          .order('id')
+          .limit(PAGE_SIZE),
     ),
   );
   const linkedCallIds = links.flatMap((row) =>
@@ -119,13 +125,13 @@ export async function getContributionData(
   ];
   const audioUsage: Record<string, unknown> = {};
   const audioFiles = await fetchIdBatches(audioIds, (ids) =>
-    fetchAllPages<Pick<Tables<'audio_files'>, 'id' | 'usage'>>((offset) =>
-      client
-        .from('audio_files')
-        .select('id, usage')
-        .in('id', ids)
+    fetchAllPages<Pick<Tables<'audio_files'>, 'id' | 'usage'>>('id', (cursor) =>
+      applyPageCursor(
+        client.from('audio_files').select('id, usage').in('id', ids),
+        cursor,
+      )
         .order('id')
-        .range(offset, offset + PAGE_SIZE - 1),
+        .limit(PAGE_SIZE),
     ),
   );
   for (const row of audioFiles) audioUsage[row.id] = row.usage;

--- a/apps/web/app/api/daily-stats/queries.ts
+++ b/apps/web/app/api/daily-stats/queries.ts
@@ -1,7 +1,12 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
 
 import type { DailyStatsProfileRelation } from './types';
-import { fetchAllPages, PAGE_SIZE } from './utils';
+import {
+  applyPageCursor,
+  fetchAllPages,
+  formatIdList,
+  PAGE_SIZE,
+} from './utils';
 
 const VOICE_CLONING_MODELS = [
   'resemble-ai/chatterbox-multilingual',
@@ -15,8 +20,6 @@ export const INTERNAL_USER_EMAILS = [
   'alex.kostinskyi@gmail.com',
 ] as const;
 
-export const formatIdList = (ids: readonly string[]) => `(${ids.join(',')})`;
-
 export type DailyStatsCreditTransaction = Pick<
   Tables<'credit_transactions'>,
   | 'amount'
@@ -28,10 +31,12 @@ export type DailyStatsCreditTransaction = Pick<
   | 'user_id'
 > & { profiles: DailyStatsProfileRelation };
 
+// No `profiles(username)` embed: PostgREST joins that per row, and the report
+// only labels three users. See getProfileUsernamesByIds.
 export type DailyStatsUsageEvent = Pick<
   Tables<'usage_events'>,
   'credits_used' | 'id' | 'occurred_at' | 'source_type' | 'user_id'
-> & { profiles: DailyStatsProfileRelation };
+>;
 
 export type DailyStatsAudioFile = Pick<
   Tables<'audio_files'>,
@@ -41,9 +46,10 @@ export type DailyStatsProfile = Pick<
   Tables<'profiles'>,
   'created_at' | 'id' | 'username'
 >;
+// `id` and `started_at` are not reported on; they carry the keyset cursor.
 export type DailyStatsCallSessionDuration = Pick<
   Tables<'call_sessions'>,
-  'duration_seconds'
+  'duration_seconds' | 'id' | 'started_at'
 >;
 
 type DailyStatsSupabaseClient = SupabaseClient;
@@ -65,21 +71,19 @@ export function getUsageEventsInRange(
   end: Date,
   excludeUserIds: readonly string[] = [],
 ): Promise<DailyStatsUsageEvent[]> {
-  return fetchAllPages<DailyStatsUsageEvent>((offset) => {
+  return fetchAllPages<DailyStatsUsageEvent>('occurred_at', (cursor) => {
     let query = supabase
       .from('usage_events')
-      .select(
-        'id, user_id, source_type, credits_used, occurred_at, profiles(username)',
-      )
+      .select('id, user_id, source_type, credits_used, occurred_at')
       .gte('occurred_at', start.toISOString())
       .lt('occurred_at', end.toISOString());
     if (excludeUserIds.length > 0) {
       query = query.notIn('user_id', excludeUserIds);
     }
-    return query
+    return applyPageCursor(query, cursor)
       .order('occurred_at', { ascending: true })
       .order('id', { ascending: true })
-      .range(offset, offset + PAGE_SIZE - 1)
+      .limit(PAGE_SIZE)
       .then(({ data, error }) => ({
         data: (data as DailyStatsUsageEvent[] | null) ?? null,
         error,
@@ -93,7 +97,7 @@ export function getAudioFilesInRange(
   end: Date,
   excludeUserIds: readonly string[] = [],
 ): Promise<DailyStatsAudioFile[]> {
-  return fetchAllPages<DailyStatsAudioFile>((offset) => {
+  return fetchAllPages<DailyStatsAudioFile>('created_at', (cursor) => {
     let query = supabase
       .from('audio_files')
       .select('id, created_at, model')
@@ -105,10 +109,10 @@ export function getAudioFilesInRange(
         `user_id.is.null,user_id.not.in.${formatIdList(excludeUserIds)}`,
       );
     }
-    return query
+    return applyPageCursor(query, cursor)
       .order('created_at', { ascending: true })
       .order('id', { ascending: true })
-      .range(offset, offset + PAGE_SIZE - 1)
+      .limit(PAGE_SIZE)
       .then(({ data, error }) => ({
         data: (data as DailyStatsAudioFile[] | null) ?? null,
         error,
@@ -122,29 +126,32 @@ export function getClonedAudioFilesInRange(
   end: Date,
   excludeUserIds: readonly string[] = [],
 ): Promise<Array<{ created_at: string | null; id: string }>> {
-  return fetchAllPages<{ created_at: string | null; id: string }>((offset) => {
-    let query = supabase
-      .from('audio_files')
-      .select('id, created_at')
-      .in('model', [...VOICE_CLONING_MODELS])
-      .gte('created_at', start.toISOString())
-      .lt('created_at', end.toISOString());
-    if (excludeUserIds.length > 0) {
-      query = query.or(
-        `user_id.is.null,user_id.not.in.${formatIdList(excludeUserIds)}`,
-      );
-    }
-    return query
-      .order('created_at', { ascending: true })
-      .order('id', { ascending: true })
-      .range(offset, offset + PAGE_SIZE - 1)
-      .then(({ data, error }) => ({
-        data:
-          (data as Array<{ created_at: string | null; id: string }> | null) ??
-          null,
-        error,
-      }));
-  });
+  return fetchAllPages<{ created_at: string | null; id: string }>(
+    'created_at',
+    (cursor) => {
+      let query = supabase
+        .from('audio_files')
+        .select('id, created_at')
+        .in('model', [...VOICE_CLONING_MODELS])
+        .gte('created_at', start.toISOString())
+        .lt('created_at', end.toISOString());
+      if (excludeUserIds.length > 0) {
+        query = query.or(
+          `user_id.is.null,user_id.not.in.${formatIdList(excludeUserIds)}`,
+        );
+      }
+      return applyPageCursor(query, cursor)
+        .order('created_at', { ascending: true })
+        .order('id', { ascending: true })
+        .limit(PAGE_SIZE)
+        .then(({ data, error }) => ({
+          data:
+            (data as Array<{ created_at: string | null; id: string }> | null) ??
+            null,
+          error,
+        }));
+    },
+  );
 }
 
 export function getProfilesInRange(
@@ -153,7 +160,7 @@ export function getProfilesInRange(
   end: Date,
   excludeUserIds: readonly string[] = [],
 ): Promise<DailyStatsProfile[]> {
-  return fetchAllPages<DailyStatsProfile>((offset) => {
+  return fetchAllPages<DailyStatsProfile>('created_at', (cursor) => {
     let query = supabase
       .from('profiles')
       .select('id, created_at, username')
@@ -162,10 +169,10 @@ export function getProfilesInRange(
     if (excludeUserIds.length > 0) {
       query = query.notIn('id', excludeUserIds);
     }
-    return query
+    return applyPageCursor(query, cursor)
       .order('created_at', { ascending: true })
       .order('id', { ascending: true })
-      .range(offset, offset + PAGE_SIZE - 1)
+      .limit(PAGE_SIZE)
       .then(({ data, error }) => ({
         data: (data as DailyStatsProfile[] | null) ?? null,
         error,
@@ -179,7 +186,7 @@ export function getCreditTransactionsInRange(
   end: Date,
   excludeUserIds: readonly string[] = [],
 ): Promise<DailyStatsCreditTransaction[]> {
-  return fetchAllPages<DailyStatsCreditTransaction>((offset) => {
+  return fetchAllPages<DailyStatsCreditTransaction>('created_at', (cursor) => {
     let query = supabase
       .from('credit_transactions')
       .select(
@@ -192,10 +199,10 @@ export function getCreditTransactionsInRange(
     if (excludeUserIds.length > 0) {
       query = query.notIn('user_id', excludeUserIds);
     }
-    return query
+    return applyPageCursor(query, cursor)
       .order('created_at', { ascending: true })
       .order('id', { ascending: true })
-      .range(offset, offset + PAGE_SIZE - 1)
+      .limit(PAGE_SIZE)
       .then(({ data, error }) => ({
         data: (data as DailyStatsCreditTransaction[] | null) ?? null,
         error,
@@ -208,7 +215,7 @@ export function getPurchaseTransactionsBefore(
   end: Date,
   excludeUserIds: readonly string[] = [],
 ): Promise<DailyStatsCreditTransaction[]> {
-  return fetchAllPages<DailyStatsCreditTransaction>((offset) => {
+  return fetchAllPages<DailyStatsCreditTransaction>('created_at', (cursor) => {
     let query = supabase
       .from('credit_transactions')
       .select(
@@ -220,10 +227,10 @@ export function getPurchaseTransactionsBefore(
     if (excludeUserIds.length > 0) {
       query = query.notIn('user_id', excludeUserIds);
     }
-    return query
+    return applyPageCursor(query, cursor)
       .order('created_at', { ascending: true })
       .order('id', { ascending: true })
-      .range(offset, offset + PAGE_SIZE - 1)
+      .limit(PAGE_SIZE)
       .then(({ data, error }) => ({
         data: (data as DailyStatsCreditTransaction[] | null) ?? null,
         error,
@@ -236,23 +243,26 @@ export function getCallSessionDurationsBefore(
   end: Date,
   excludeUserIds: readonly string[] = [],
 ): Promise<DailyStatsCallSessionDuration[]> {
-  return fetchAllPages<DailyStatsCallSessionDuration>((offset) => {
-    let query = supabase
-      .from('call_sessions')
-      .select('duration_seconds')
-      .lt('started_at', end.toISOString());
-    if (excludeUserIds.length > 0) {
-      query = query.notIn('user_id', excludeUserIds);
-    }
-    return query
-      .order('started_at', { ascending: true })
-      .order('id', { ascending: true })
-      .range(offset, offset + PAGE_SIZE - 1)
-      .then(({ data, error }) => ({
-        data: (data as DailyStatsCallSessionDuration[] | null) ?? null,
-        error,
-      }));
-  });
+  return fetchAllPages<DailyStatsCallSessionDuration>(
+    'started_at',
+    (cursor) => {
+      let query = supabase
+        .from('call_sessions')
+        .select('duration_seconds, id, started_at')
+        .lt('started_at', end.toISOString());
+      if (excludeUserIds.length > 0) {
+        query = query.notIn('user_id', excludeUserIds);
+      }
+      return applyPageCursor(query, cursor)
+        .order('started_at', { ascending: true })
+        .order('id', { ascending: true })
+        .limit(PAGE_SIZE)
+        .then(({ data, error }) => ({
+          data: (data as DailyStatsCallSessionDuration[] | null) ?? null,
+          error,
+        }));
+    },
+  );
 }
 
 export function getCallSessionsInRange(
@@ -271,7 +281,7 @@ export function getCallSessionsInRange(
       | 'status'
       | 'free_call'
     >
-  >((offset) => {
+  >('started_at', (cursor) => {
     let query = supabase
       .from('call_sessions')
       .select(
@@ -281,10 +291,10 @@ export function getCallSessionsInRange(
       .lt('started_at', end.toISOString());
     if (excludeUserIds.length > 0)
       query = query.notIn('user_id', excludeUserIds);
-    return query
+    return applyPageCursor(query, cursor)
       .order('started_at')
       .order('id')
-      .range(offset, offset + PAGE_SIZE - 1);
+      .limit(PAGE_SIZE);
   });
 }
 
@@ -309,5 +319,33 @@ export function getAllCreditTransactions(
     ALL_TIME_START,
     end,
     excludeUserIds,
+  );
+}
+
+/**
+ * Usernames for a handful of user ids.
+ *
+ * The report labels only its top few users, so it resolves them here instead of
+ * embedding `profiles(username)` on every usage-event row, which makes PostgREST
+ * join per row across the whole 14-day window.
+ */
+export async function getProfileUsernamesByIds(
+  supabase: DailyStatsSupabaseClient,
+  userIds: readonly string[],
+): Promise<Map<string, string>> {
+  if (userIds.length === 0) {
+    return new Map();
+  }
+
+  const { data, error } = await supabase
+    .from('profiles')
+    .select('id, username')
+    .in('id', [...new Set(userIds)]);
+  if (error) throw error;
+
+  return new Map(
+    ((data ?? []) as { id: string; username: string | null }[]).flatMap(
+      (row) => (row.username ? [[row.id, row.username] as const] : []),
+    ),
   );
 }

--- a/apps/web/app/api/daily-stats/queries.ts
+++ b/apps/web/app/api/daily-stats/queries.ts
@@ -302,34 +302,23 @@ export function getCallSessionsInRange(
 const ALL_TIME_START = new Date(0);
 
 /**
- * Credit transactions before `end`, deduplicated by id and sorted
- * chronologically, using the same filters as {@link getCreditTransactionsInRange}.
+ * Credit transactions before `end`, ordered by `(created_at asc, id asc)`
+ * by {@link getCreditTransactionsInRange}, using its filters.
  *
  * Daily stats slices this once in memory for each reporting window instead of
  * re-querying per period: the per-period ranges are subsets of this one, so
  * issuing them concurrently only multiplies PostgREST load.
  */
-export async function getAllCreditTransactions(
+export function getAllCreditTransactions(
   supabase: DailyStatsSupabaseClient,
   end: Date,
   excludeUserIds: readonly string[] = [],
 ): Promise<DailyStatsCreditTransaction[]> {
-  const transactions = await getCreditTransactionsInRange(
+  return getCreditTransactionsInRange(
     supabase,
     ALL_TIME_START,
     end,
     excludeUserIds,
-  );
-
-  // Keyset pagination has no shared snapshot across pages. Dedupe by id in
-  // case a transaction's timestamp changes mid-read, then sort chronologically.
-  return [
-    ...new Map(
-      transactions.map((transaction) => [transaction.id, transaction]),
-    ).values(),
-  ].sort(
-    (a, b) =>
-      new Date(a.created_at).getTime() - new Date(b.created_at).getTime(),
   );
 }
 

--- a/apps/web/app/api/daily-stats/queries.ts
+++ b/apps/web/app/api/daily-stats/queries.ts
@@ -302,23 +302,34 @@ export function getCallSessionsInRange(
 const ALL_TIME_START = new Date(0);
 
 /**
- * Every credit transaction before `end`, using the same filters as
- * {@link getCreditTransactionsInRange}.
+ * Credit transactions before `end`, deduplicated by id and sorted
+ * chronologically, using the same filters as {@link getCreditTransactionsInRange}.
  *
  * Daily stats slices this once in memory for each reporting window instead of
  * re-querying per period: the per-period ranges are subsets of this one, so
  * issuing them concurrently only multiplies PostgREST load.
  */
-export function getAllCreditTransactions(
+export async function getAllCreditTransactions(
   supabase: DailyStatsSupabaseClient,
   end: Date,
   excludeUserIds: readonly string[] = [],
 ): Promise<DailyStatsCreditTransaction[]> {
-  return getCreditTransactionsInRange(
+  const transactions = await getCreditTransactionsInRange(
     supabase,
     ALL_TIME_START,
     end,
     excludeUserIds,
+  );
+
+  // Keyset pagination has no shared snapshot across pages. Dedupe by id in
+  // case a transaction's timestamp changes mid-read, then sort chronologically.
+  return [
+    ...new Map(
+      transactions.map((transaction) => [transaction.id, transaction]),
+    ).values(),
+  ].sort(
+    (a, b) =>
+      new Date(a.created_at).getTime() - new Date(b.created_at).getTime(),
   );
 }
 

--- a/apps/web/app/api/daily-stats/queries.ts
+++ b/apps/web/app/api/daily-stats/queries.ts
@@ -287,3 +287,27 @@ export function getCallSessionsInRange(
       .range(offset, offset + PAGE_SIZE - 1);
   });
 }
+
+// Epoch sentinel for "all-time" reads so callers don't each spell out a date.
+const ALL_TIME_START = new Date(0);
+
+/**
+ * Every credit transaction before `end`, using the same filters as
+ * {@link getCreditTransactionsInRange}.
+ *
+ * Daily stats slices this once in memory for each reporting window instead of
+ * re-querying per period: the per-period ranges are subsets of this one, so
+ * issuing them concurrently only multiplies PostgREST load.
+ */
+export function getAllCreditTransactions(
+  supabase: DailyStatsSupabaseClient,
+  end: Date,
+  excludeUserIds: readonly string[] = [],
+): Promise<DailyStatsCreditTransaction[]> {
+  return getCreditTransactionsInRange(
+    supabase,
+    ALL_TIME_START,
+    end,
+    excludeUserIds,
+  );
+}

--- a/apps/web/app/api/daily-stats/route.ts
+++ b/apps/web/app/api/daily-stats/route.ts
@@ -319,12 +319,15 @@ export async function GET(request: NextRequest) {
       findNextSubscriptionDueForPayment(),
       getActiveSubscriptionsMrr(),
 
-      getCallSessionsInRange(
-        supabase,
-        fourteenDaysAgo,
-        today,
-        internalUserIds,
-      ).then((data) => ({ data, error: null })),
+      _timed(
+        `call_sessions:${ROLLING_WINDOW_LABEL} paginated ${fourteenDaysAgo.toISOString().slice(0, 10)}..${today.toISOString().slice(0, 10)}`,
+        getCallSessionsInRange(
+          supabase,
+          fourteenDaysAgo,
+          today,
+          internalUserIds,
+        ).then((data) => ({ data, error: null })),
+      ),
 
       // (callSessionsTotalCountResult) Total call sessions count
       (() => {
@@ -909,14 +912,15 @@ export async function GET(request: NextRequest) {
   // Contribution uses fresh usage and payment history together. Cached purchases
   // could misclassify fresh usage or understate collections; cached activity
   // metrics are only for local debugging and do not feed this calculation.
-  const contributionData = await getContributionData(
-    supabase,
-    thirtyDaysAgo,
-    today,
-    internalUserIds,
+  const contributionData = await _timed(
+    `contribution:30d paginated ${thirtyDaysAgo.toISOString().slice(0, 10)}..${today.toISOString().slice(0, 10)}`,
+    getContributionData(supabase, thirtyDaysAgo, today, internalUserIds),
   );
   const contributionTransactions = loadedFromValidCache
-    ? await getAllCreditTransactions(supabase, today, internalUserIds)
+    ? await _timed(
+        `credit_transactions:all_time paginated (cached path) < ${today.toISOString().slice(0, 10)}`,
+        getAllCreditTransactions(supabase, today, internalUserIds),
+      )
     : allCreditTransactions;
   const contributionYesterday = summarizeContribution(
     contributionData,

--- a/apps/web/app/api/daily-stats/route.ts
+++ b/apps/web/app/api/daily-stats/route.ts
@@ -402,9 +402,8 @@ export async function GET(request: NextRequest) {
       getAllCreditTransactions(supabase, today, internalUserIds),
     );
 
-    // `fetchAllPages` walks offsets, so pages can overlap if rows shift
-    // mid-read; dedupe by id and sort to keep the chronological invariant the
-    // window filters below rely on.
+    // Keyset pagination has no shared snapshot across pages. Dedupe by id in
+    // case a transaction's timestamp changes mid-read, then sort chronologically.
     allCreditTransactions = [
       ...new Map(
         allTimeCreditTransactions.map((transaction) => [

--- a/apps/web/app/api/daily-stats/route.ts
+++ b/apps/web/app/api/daily-stats/route.ts
@@ -93,7 +93,12 @@ export async function GET(request: NextRequest) {
   const untilNow = dateParam ? new Date(dateParam) : new Date();
   const today = startOfDay(untilNow);
   const cacheReportDate = today.toISOString().slice(0, 10);
-  const useCache = !isProd && fs.existsSync(CACHE_FILE);
+  const bypassCache =
+    !isProd && request.nextUrl.searchParams.get('cache') === 'off';
+  const useCache = !(isProd || bypassCache) && fs.existsSync(CACHE_FILE);
+  const debugHeaders = bypassCache
+    ? { 'Cache-Control': 'no-store', 'X-Daily-Stats-Cache': 'bypass' }
+    : undefined;
   const previousDay = subtractDays(today, 1);
   const twoDaysAgo = subtractDays(today, 2);
   const fourteenDaysAgo = subtractDays(today, ROLLING_WINDOW_DAYS);
@@ -439,7 +444,7 @@ export async function GET(request: NextRequest) {
 
   // Cache results for faster debugging (non-prod only) — written after error
   // checks so we never persist a partial/failed response to disk
-  if (!(isProd || loadedFromValidCache)) {
+  if (!(isProd || bypassCache || loadedFromValidCache)) {
     const cacheData = {
       activeSubscribersCount,
       allCreditTransactions,
@@ -617,7 +622,7 @@ export async function GET(request: NextRequest) {
     const message = `WARNING: No audio files generated yesterday! ${previousDay}-${today}`;
     console.warn({ message });
     if (!isProd) {
-      return NextResponse.json({ ok: true });
+      return NextResponse.json({ ok: true }, { headers: debugHeaders });
     }
     await fetch(webhook, {
       body: JSON.stringify({ chat_id: '202637584', text: message }),
@@ -1430,7 +1435,7 @@ export async function GET(request: NextRequest) {
 
   try {
     if (!isProd) {
-      return new NextResponse(message);
+      return new NextResponse(message, { headers: debugHeaders });
     }
     await fetch(webhook, {
       body: JSON.stringify({

--- a/apps/web/app/api/daily-stats/route.ts
+++ b/apps/web/app/api/daily-stats/route.ts
@@ -24,7 +24,6 @@ import { createAdminClient } from '@/lib/supabase/admin';
 import { getUserIdByStripeCustomerId } from '@/lib/supabase/queries';
 import type { UsageSourceType } from '@/lib/supabase/usage-queries';
 import {
-  formatIdList,
   getAllCreditTransactions,
   getAudioFilesInRange,
   getCallSessionDurationsBefore,
@@ -32,6 +31,7 @@ import {
   getClonedAudioFilesInRange,
   getInternalUserIds,
   getProfilesInRange,
+  getProfileUsernamesByIds,
   getUsageEventsInRange,
 } from './queries';
 import {
@@ -44,6 +44,7 @@ import {
   formatCompactNumber,
   formatCurrencyChange,
   formatDuration,
+  formatIdList,
   getFeatureHealthStatus,
   getProfileUsername,
   isCompletedUserCall,
@@ -169,7 +170,7 @@ export async function GET(request: NextRequest) {
 
   if (useCache) {
     const cached = JSON.parse(fs.readFileSync(CACHE_FILE, 'utf-8'));
-    if (cached.version !== 3 || typeof cached.reportDate !== 'string') {
+    if (cached.version !== 4 || typeof cached.reportDate !== 'string') {
       console.log(
         '♻️ Ignoring incompatible activity cache:',
         CACHE_FILE,
@@ -457,7 +458,7 @@ export async function GET(request: NextRequest) {
       reportDate: cacheReportDate,
       subscriptionsMrr,
       usageEvents14dResult,
-      version: 3,
+      version: 4,
     };
     fs.writeFileSync(CACHE_FILE, JSON.stringify(cacheData, null, 2));
     console.log(
@@ -1164,14 +1165,13 @@ export async function GET(request: NextRequest) {
     .sort(([, a], [, b]) => b - a)
     .slice(0, 3);
 
-  // Get usernames for top usage users from usage events
-  const userIdToUsername = new Map<string, string>();
-  for (const event of usageEvents14dData) {
-    const username = getProfileUsername(event.profiles);
-    if (username && !userIdToUsername.has(event.user_id)) {
-      userIdToUsername.set(event.user_id, username);
-    }
-  }
+  // Resolve just these three usernames. Embedding `profiles(username)` on the
+  // usage-events query instead made PostgREST join per row across the whole
+  // 14-day window to label the same three.
+  const userIdToUsername = await getProfileUsernamesByIds(
+    supabase,
+    topUsageUsers.map(([userId]) => userId),
+  );
 
   // DEBUG: Top users verification
   if (!isProd && process.env.DEBUG) {

--- a/apps/web/app/api/daily-stats/route.ts
+++ b/apps/web/app/api/daily-stats/route.ts
@@ -392,28 +392,10 @@ export async function GET(request: NextRequest) {
       ),
     ]);
 
-    // One all-time read feeds every reporting window below. The seven
-    // per-period queries this replaced were subsets of this same range with
-    // identical filters, and were merged straight back into it by the dedupe
-    // below — so they only multiplied PostgREST load without contributing a
-    // single row the all-time read did not already return.
-    const allTimeCreditTransactions = await _timed(
+    // One all-time read feeds every reporting window below.
+    allCreditTransactions = await _timed(
       `credit_transactions:all_time paginated < ${today.toISOString().slice(0, 10)}`,
       getAllCreditTransactions(supabase, today, internalUserIds),
-    );
-
-    // Keyset pagination has no shared snapshot across pages. Dedupe by id in
-    // case a transaction's timestamp changes mid-read, then sort chronologically.
-    allCreditTransactions = [
-      ...new Map(
-        allTimeCreditTransactions.map((transaction) => [
-          transaction.id,
-          transaction,
-        ]),
-      ).values(),
-    ].sort(
-      (a, b) =>
-        new Date(a.created_at).getTime() - new Date(b.created_at).getTime(),
     );
 
     allTimePurchaseTransactions = allCreditTransactions.filter(

--- a/apps/web/app/api/daily-stats/route.ts
+++ b/apps/web/app/api/daily-stats/route.ts
@@ -25,11 +25,11 @@ import { getUserIdByStripeCustomerId } from '@/lib/supabase/queries';
 import type { UsageSourceType } from '@/lib/supabase/usage-queries';
 import {
   formatIdList,
+  getAllCreditTransactions,
   getAudioFilesInRange,
   getCallSessionDurationsBefore,
   getCallSessionsInRange,
   getClonedAudioFilesInRange,
-  getCreditTransactionsInRange,
   getInternalUserIds,
   getProfilesInRange,
   getUsageEventsInRange,
@@ -142,10 +142,10 @@ export async function GET(request: NextRequest) {
   // biome-ignore lint/suspicious/noExplicitAny: Cache data is dynamically typed
   let apiKeysYesterdayResult: any;
   let allCreditTransactions: Awaited<
-    ReturnType<typeof getCreditTransactionsInRange>
+    ReturnType<typeof getAllCreditTransactions>
   > = [];
   let allTimePurchaseTransactions: Awaited<
-    ReturnType<typeof getCreditTransactionsInRange>
+    ReturnType<typeof getAllCreditTransactions>
   > = [];
   // biome-ignore lint/suspicious/noExplicitAny: Cache data is dynamically typed
   let activeSubscribersCount: any;
@@ -339,15 +339,18 @@ export async function GET(request: NextRequest) {
       callSessionsAllTimeDurationResult,
       profilesRecentResult,
     ] = await Promise.all([
-      getUsageEventsInRange(
-        supabase,
-        fourteenDaysAgo,
-        today,
-        internalUserIds,
-      ).then((data) => ({
-        data,
-        error: null,
-      })),
+      _timed(
+        `usage_events:${ROLLING_WINDOW_LABEL} paginated ${fourteenDaysAgo.toISOString().slice(0, 10)}..${today.toISOString().slice(0, 10)}`,
+        getUsageEventsInRange(
+          supabase,
+          fourteenDaysAgo,
+          today,
+          internalUserIds,
+        ).then((data) => ({
+          data,
+          error: null,
+        })),
+      ),
       _timed(
         `audio_files:yesterday paginated ${previousDay.toISOString().slice(0, 10)}..${today.toISOString().slice(0, 10)}`,
         getAudioFilesInRange(
@@ -369,101 +372,48 @@ export async function GET(request: NextRequest) {
           }),
         ),
       ),
-      getProfilesInRange(
-        supabase,
-        fourteenDaysAgo,
-        today,
-        internalUserIds,
-      ).then((data) => ({
-        data,
-        error: null,
-      })),
-    ]);
-
-    const [
-      yesterdayCreditTransactions,
-      fourteenDayCreditTransactions,
-      thirtyDayCreditTransactions,
-      monthToDateCreditTransactions,
-      previousMonthToDateCreditTransactions,
-      twoMonthsAgoToDateCreditTransactions,
-      threeMonthsAgoToDateCreditTransactions,
-      allTimeCreditTransactions,
-    ] = await Promise.all([
-      getCreditTransactionsInRange(
-        supabase,
-        previousDay,
-        today,
-        internalUserIds,
-      ),
-      getCreditTransactionsInRange(
-        supabase,
-        fourteenDaysAgo,
-        today,
-        internalUserIds,
-      ),
-      getCreditTransactionsInRange(
-        supabase,
-        thirtyDaysAgo,
-        today,
-        internalUserIds,
-      ),
-      getCreditTransactionsInRange(
-        supabase,
-        monthStart,
-        today,
-        internalUserIds,
-      ),
-      getCreditTransactionsInRange(
-        supabase,
-        previousMonthStart,
-        previousMonthPeriodEnd,
-        internalUserIds,
-      ),
-      getCreditTransactionsInRange(
-        supabase,
-        twoMonthsAgoStart,
-        twoMonthsAgoPeriodEnd,
-        internalUserIds,
-      ),
-      getCreditTransactionsInRange(
-        supabase,
-        threeMonthsAgoStart,
-        threeMonthsAgoPeriodEnd,
-        internalUserIds,
-      ),
-      getCreditTransactionsInRange(
-        supabase,
-        new Date('1970-01-01T00:00:00.000Z'),
-        today,
-        internalUserIds,
+      _timed(
+        `profiles:${ROLLING_WINDOW_LABEL} paginated ${fourteenDaysAgo.toISOString().slice(0, 10)}..${today.toISOString().slice(0, 10)}`,
+        getProfilesInRange(
+          supabase,
+          fourteenDaysAgo,
+          today,
+          internalUserIds,
+        ).then((data) => ({
+          data,
+          error: null,
+        })),
       ),
     ]);
 
+    // One all-time read feeds every reporting window below. The seven
+    // per-period queries this replaced were subsets of this same range with
+    // identical filters, and were merged straight back into it by the dedupe
+    // below — so they only multiplied PostgREST load without contributing a
+    // single row the all-time read did not already return.
+    const allTimeCreditTransactions = await _timed(
+      `credit_transactions:all_time paginated < ${today.toISOString().slice(0, 10)}`,
+      getAllCreditTransactions(supabase, today, internalUserIds),
+    );
+
+    // `fetchAllPages` walks offsets, so pages can overlap if rows shift
+    // mid-read; dedupe by id and sort to keep the chronological invariant the
+    // window filters below rely on.
     allCreditTransactions = [
       ...new Map(
-        [
-          ...allTimeCreditTransactions,
-          ...yesterdayCreditTransactions,
-          ...fourteenDayCreditTransactions,
-          ...thirtyDayCreditTransactions,
-          ...monthToDateCreditTransactions,
-          ...previousMonthToDateCreditTransactions,
-          ...twoMonthsAgoToDateCreditTransactions,
-          ...threeMonthsAgoToDateCreditTransactions,
-        ].map((transaction) => [transaction.id, transaction]),
+        allTimeCreditTransactions.map((transaction) => [
+          transaction.id,
+          transaction,
+        ]),
       ).values(),
     ].sort(
       (a, b) =>
         new Date(a.created_at).getTime() - new Date(b.created_at).getTime(),
     );
 
-    allTimePurchaseTransactions = allTimeCreditTransactions
-      .filter((transaction) => transaction.type !== 'refund')
-      .sort(
-        (a, b) =>
-          new Date(a.created_at).getTime() - new Date(b.created_at).getTime(),
-      );
+    allTimePurchaseTransactions = allCreditTransactions.filter(
+      (transaction) => transaction.type !== 'refund',
+    );
   } // end of else (not using cache)
 
   if (audioYesterdayResult?.error) throw audioYesterdayResult.error;
@@ -979,12 +929,7 @@ export async function GET(request: NextRequest) {
     internalUserIds,
   );
   const contributionTransactions = loadedFromValidCache
-    ? await getCreditTransactionsInRange(
-        supabase,
-        new Date(0),
-        today,
-        internalUserIds,
-      )
+    ? await getAllCreditTransactions(supabase, today, internalUserIds)
     : allCreditTransactions;
   const contributionYesterday = summarizeContribution(
     contributionData,

--- a/apps/web/app/api/daily-stats/utils.ts
+++ b/apps/web/app/api/daily-stats/utils.ts
@@ -311,23 +311,28 @@ export type PageCursor =
   | { kind: 'after'; column: string; value: string };
 
 /**
- * When a page ends on a run longer than this, the cursor walks the run by `id`
- * rather than listing its ids. An estimate, not a measured threshold: the
- * filter is percent-encoded into the query string, so each uuid costs ~39 bytes
- * and 100 ids is ~3.9KB — against the 8000 characters postgrest-js itself warns
- * past (`urlLengthLimit`), with the select, range filters, order and limit
- * still to fit.
+ * A page can end part-way through a run of rows sharing one cursor value. Up to
+ * this many, the cursor carries their ids; past it, it walks the run by `id`
+ * instead. An estimate, not a measured threshold: the filter is percent-encoded
+ * into the query string, so each uuid costs ~39 bytes and 100 ids is ~3.9KB —
+ * against the 8000 characters postgrest-js itself warns past
+ * (`urlLengthLimit`), with the select, range filters, order and limit still to
+ * fit.
  *
  * The two directions are not symmetric, which is what sets the value. Erring
  * low costs one extra request. Erring high risks a 414, which is not a
- * transient error and so fails the whole run on its first response — the same
- * class of failure this pagination exists to avoid. So it sits well under what
- * should fit rather than close to it.
+ * transient error and so fails the whole report on its first response — the
+ * same class of failure this pagination exists to avoid. So it sits well under
+ * what should fit rather than close to it. Row correctness does not depend on
+ * the number either way; it only chooses between two correct strategies.
  *
- * Row correctness does not depend on this number either way; it only chooses
- * between two correct strategies. Postgres fixes `now()` at transaction start,
- * so any bulk insert produces a run long enough to reach it: a promo grant, a
- * backfill, a support batch.
+ * Where such a run comes from, since nothing in daily-stats writes: ordinary
+ * traffic inserts a row per user action, seconds apart, so their timestamps
+ * differ and runs stay one or two rows long. But `now()` is
+ * `transaction_timestamp()`, fixed when the transaction opens — so anything
+ * that writes many rows in one transaction elsewhere (a promo grant, a
+ * hand-run backfill, a support batch) leaves every row it wrote holding the
+ * same timestamp, and this read has to page through the block they form.
  */
 const MAX_CURSOR_EXCLUDE_IDS = 100;
 
@@ -525,7 +530,7 @@ const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 /**
  * Fetches one page, replaying it with exponential backoff when Supabase
  * answers with a transient gateway or connection failure. A whole daily-stats
- * run is wasted when a single page fails, so the cheap retry is worth it.
+ * report is wasted when a single page fails, so the cheap retry is worth it.
  */
 async function fetchPage<T>(
   queryBuilder: (

--- a/apps/web/app/api/daily-stats/utils.ts
+++ b/apps/web/app/api/daily-stats/utils.ts
@@ -284,43 +284,78 @@ export const formatIdList = (ids: readonly string[]) => `(${ids.join(',')})`;
 /**
  * Position in a query ordered by `(column asc, id asc)`.
  *
- * `value` is re-read inclusively and `excludeIds` drops the rows already
- * emitted at exactly that value, so rows sharing a timestamp are neither
- * skipped nor returned twice. A strict `>` cursor would lose the ones after
- * the page boundary.
+ * Three shapes, because a run of rows sharing one `column` value cannot always
+ * be stepped over in a single filter:
+ *
+ * - `exclude` — the common case. Re-read `value` inclusively and drop the ids
+ *   already emitted at it. A strict `>` would lose the rest of the run.
+ * - `within` — the run is longer than one cursor can carry ids for, so walk it
+ *   by `id` instead.
+ * - `after`  — the run is exhausted; step past `value`.
+ *
+ * Every shape is a plain AND of filters. The textbook `(c > v) OR (c = v AND
+ * id > lastId)` predicate would be one request shorter in the `within` case,
+ * but it needs a second top-level `or=` param on the two queries that already
+ * use `.or()` for their own filters, and whether PostgREST ANDs repeated `or=`
+ * params is not something this code can verify at runtime. Getting that wrong
+ * silently changes which rows a revenue report counts, so it is not assumed.
  */
-export interface PageCursor {
-  column: string;
-  excludeIds: readonly string[];
-  value: string;
-}
+export type PageCursor =
+  | {
+      kind: 'exclude';
+      column: string;
+      value: string;
+      excludeIds: readonly string[];
+    }
+  | { kind: 'within'; column: string; value: string; afterId: string }
+  | { kind: 'after'; column: string; value: string };
 
 /**
- * Limit cursor ids to keep requests below the gateway's URL limit.
- * PostgreSQL fixes `now()` at transaction start, so bulk inserts can share a
- * timestamp. Pagination aborts if a full page ends with more than 200 rows at
- * the same cursor value, even for valid data, rather than risk an oversized
- * URL or silently drop rows.
+ * When a page ends on a run longer than this, the cursor walks the run by `id`
+ * rather than listing its ids. Sized for the gateway's URL limit (~37 bytes per
+ * uuid), and purely a choice between two correct strategies — exceeding it
+ * costs one extra request, never a dropped row or an aborted run.
+ *
+ * Postgres fixes `now()` at transaction start, so any bulk insert produces a
+ * run this long: a promo grant, a backfill, a support batch.
  */
 const MAX_CURSOR_EXCLUDE_IDS = 200;
 
 interface CursorFilterable {
+  eq: (column: string, value: string) => CursorFilterable;
+  gt: (column: string, value: string) => CursorFilterable;
   gte: (column: string, value: string) => CursorFilterable;
   not: (column: string, operator: string, value: string) => CursorFilterable;
 }
 
-/** Narrows a query to the rows after `cursor`. */
-export function applyPageCursor<Q extends CursorFilterable>(
-  query: Q,
-  cursor: PageCursor | null,
-): Q {
+/**
+ * Narrows a query to the rows after `cursor`, returning it unchanged in type.
+ *
+ * `Q` is deliberately unconstrained: constraining it to `CursorFilterable`
+ * makes TypeScript instantiate PostgREST's builder generics too deeply to
+ * resolve (TS2589). The cast is checked instead by the `applyPageCursor` tests,
+ * which assert the exact filters each cursor shape emits.
+ */
+export function applyPageCursor<Q>(query: Q, cursor: PageCursor | null): Q {
   if (!cursor) {
     return query;
   }
 
-  const seeked = query.gte(cursor.column, cursor.value) as Q;
+  const filterable = query as CursorFilterable;
+
+  if (cursor.kind === 'after') {
+    return filterable.gt(cursor.column, cursor.value) as Q;
+  }
+
+  if (cursor.kind === 'within') {
+    return filterable
+      .eq(cursor.column, cursor.value)
+      .gt('id', cursor.afterId) as Q;
+  }
+
+  const seeked = filterable.gte(cursor.column, cursor.value);
   if (cursor.excludeIds.length === 0) {
-    return seeked;
+    return seeked as Q;
   }
   return seeked.not('id', 'in', formatIdList(cursor.excludeIds)) as Q;
 }
@@ -353,14 +388,22 @@ export async function fetchAllPages<T>(
   while (true) {
     const data: T[] | null = await fetchPage(queryBuilder, cursor);
 
-    if (!data || data.length === 0) {
-      break;
+    if (data?.length) {
+      allData.push(...data);
     }
 
-    allData.push(...data);
-
-    if (data.length < PAGE_SIZE) {
-      break;
+    if (data === null || data.length < PAGE_SIZE) {
+      // A short page ends the read — unless it was walking a run of equal
+      // values, which only means that run is exhausted and rows past it remain.
+      if (cursor?.kind !== 'within') {
+        break;
+      }
+      cursor = {
+        column: cursor.column,
+        kind: 'after',
+        value: cursor.value,
+      };
+      continue;
     }
 
     cursor = nextCursor(data, cursorColumn, cursor);
@@ -395,20 +438,25 @@ function nextCursor<T>(
   }
 
   // Only rows at exactly `value` can come back again under `gte(value)`; rows
-  // at an earlier value are dropped by the seek itself. This page holds every
-  // such row, because a full page is sorted and ends at `value` — so there is
-  // no earlier page's boundary left to carry forward.
+  // at an earlier value are dropped by the seek itself.
   const excludeIds = page
     .filter((row) => readCursorField(row, cursorColumn) === value)
     .map((row) => readCursorField(row, 'id'));
 
+  // Too many to carry as ids. Rows are ordered by id within a value, so every
+  // one read so far is at or below the last — walk the rest by id. This also
+  // rules out a stale exclusion list: a full page that ends where it began is
+  // entirely one value, which always lands here rather than in `exclude`.
   if (excludeIds.length > MAX_CURSOR_EXCLUDE_IDS) {
-    throw new Error(
-      `fetchAllPages: ${excludeIds.length} rows share \`${cursorColumn}\` ${value}; cannot page past them`,
-    );
+    return {
+      afterId: readCursorField(page.at(-1), 'id'),
+      column: cursorColumn,
+      kind: 'within',
+      value,
+    };
   }
 
-  return { column: cursorColumn, excludeIds, value };
+  return { column: cursorColumn, excludeIds, kind: 'exclude', value };
 }
 
 /**
@@ -426,11 +474,12 @@ const TRANSIENT_POSTGRES_CODES = new Set([
 /**
  * Supabase's API gateway sheds load with plain 502/503/504 responses that
  * PostgREST surfaces as a bare `{ message }` with no SQLSTATE, so these have to
- * be matched on text. `timed? ?out` covers the observed `Gateway Timeout` as
- * well as `ETIMEDOUT` and `query timed out`.
+ * be matched on text. The timeout alternation covers the observed
+ * `Gateway Timeout`, nginx's hyphenated `504 Gateway Time-out`, Kong's
+ * `upstream server is timing out`, and `ETIMEDOUT`.
  */
 const TRANSIENT_ERROR_MESSAGE =
-  /bad gateway|service unavailable|temporarily unavailable|canceling statement|connection (?:reset|closed|terminated)|socket hang up|fetch failed|econnreset|timed? ?out/i;
+  /bad gateway|service unavailable|temporarily unavailable|canceling statement|connection (?:reset|closed|terminated)|socket hang up|fetch failed|econnreset|tim(?:ed?[ -]?out|ing out)/i;
 
 export function isTransientQueryError(error: unknown): boolean {
   if (!error || typeof error !== 'object') {

--- a/apps/web/app/api/daily-stats/utils.ts
+++ b/apps/web/app/api/daily-stats/utils.ts
@@ -270,38 +270,88 @@ export const calculateUsageBreakdown = (
 /**
  * Pagination utilities for Supabase queries
  *
- * Supabase has a default limit of 1000 rows per query.
- * Use these utilities to fetch all records from large tables.
+ * PostgREST caps a response at 1000 rows, so reading a whole range means
+ * walking it a page at a time. These helpers do that with a keyset cursor
+ * rather than LIMIT/OFFSET: an offset page makes Postgres sort and then
+ * discard every row it skips, so cost grows with depth and the deepest pages
+ * are the ones that time out at Supabase's gateway.
  */
 
 export const PAGE_SIZE = 1000;
 
+export const formatIdList = (ids: readonly string[]) => `(${ids.join(',')})`;
+
 /**
- * Paginates through all results from a Supabase query.
+ * Position in a query ordered by `(column asc, id asc)`.
+ *
+ * `value` is re-read inclusively and `excludeIds` drops the rows already
+ * emitted at exactly that value, so rows sharing a timestamp are neither
+ * skipped nor returned twice. A strict `>` cursor would lose the ones after
+ * the page boundary.
+ */
+export interface PageCursor {
+  column: string;
+  excludeIds: readonly string[];
+  value: string;
+}
+
+/**
+ * Cap on the ids carried in a cursor: ~37 bytes per uuid, so 200 already puts
+ * the request near the gateway's URL limit. Every column paged on defaults to a
+ * per-row `now()` at microsecond precision, so real boundaries hold one or two
+ * rows. Hitting this means the data is not what these queries assume — fail
+ * loudly rather than build a URL that gets rejected, or silently drop rows.
+ */
+const MAX_CURSOR_EXCLUDE_IDS = 200;
+
+interface CursorFilterable {
+  gte: (column: string, value: string) => CursorFilterable;
+  not: (column: string, operator: string, value: string) => CursorFilterable;
+}
+
+/** Narrows a query to the rows after `cursor`. */
+export function applyPageCursor<Q extends CursorFilterable>(
+  query: Q,
+  cursor: PageCursor | null,
+): Q {
+  if (!cursor) {
+    return query;
+  }
+
+  const seeked = query.gte(cursor.column, cursor.value) as Q;
+  if (cursor.excludeIds.length === 0) {
+    return seeked;
+  }
+  return seeked.not('id', 'in', formatIdList(cursor.excludeIds)) as Q;
+}
+
+/**
+ * Reads every row of a query ordered by `(cursorColumn asc, id asc)`.
+ *
+ * The builder must select both `cursorColumn` and `id` — they carry the cursor
+ * — and apply it with {@link applyPageCursor}.
  *
  * @example
  * ```ts
- * const results = await fetchAllPages<{ user_id: string }>((offset) =>
- *   supabase
- *     .from("table")
- *     .select("user_id")
- *     .range(offset, offset + PAGE_SIZE - 1)
+ * const rows = await fetchAllPages<Row>('created_at', (cursor) =>
+ *   applyPageCursor(supabase.from('t').select('id, created_at'), cursor)
+ *     .order('created_at')
+ *     .order('id')
+ *     .limit(PAGE_SIZE),
  * );
  * ```
- *
- * @param queryBuilder - A function that takes an offset and returns a Supabase query promise
- * @returns All records from the query, concatenated together
  */
 export async function fetchAllPages<T>(
+  cursorColumn: string,
   queryBuilder: (
-    offset: number,
+    cursor: PageCursor | null,
   ) => PromiseLike<{ data: T[] | null; error: unknown }>,
 ): Promise<T[]> {
   const allData: T[] = [];
-  let offset = 0;
+  let cursor: PageCursor | null = null;
 
   while (true) {
-    const data = await fetchPage(queryBuilder, offset);
+    const data: T[] | null = await fetchPage(queryBuilder, cursor);
 
     if (!data || data.length === 0) {
       break;
@@ -313,10 +363,52 @@ export async function fetchAllPages<T>(
       break;
     }
 
-    offset += PAGE_SIZE;
+    cursor = nextCursor(data, cursorColumn, cursor);
   }
 
   return allData;
+}
+
+function readCursorField(row: unknown, column: string): string {
+  const value = (row as Record<string, unknown>)[column];
+  if (typeof value !== 'string') {
+    throw new Error(
+      `fetchAllPages: row has no string \`${column}\` to page on — add it to the select`,
+    );
+  }
+  return value;
+}
+
+function nextCursor<T>(
+  page: T[],
+  cursorColumn: string,
+  previous: PageCursor | null,
+): PageCursor {
+  const value = readCursorField(page.at(-1), cursorColumn);
+
+  // A cursor that goes backwards never terminates: the same page would be read
+  // forever. Means the query is not actually ordered by `cursorColumn` asc.
+  if (previous && value < previous.value) {
+    throw new Error(
+      `fetchAllPages: \`${cursorColumn}\` went backwards (${previous.value} to ${value}); the query must order by it ascending`,
+    );
+  }
+
+  // Only rows at exactly `value` can come back again under `gte(value)`; rows
+  // at an earlier value are dropped by the seek itself. This page holds every
+  // such row, because a full page is sorted and ends at `value` — so there is
+  // no earlier page's boundary left to carry forward.
+  const excludeIds = page
+    .filter((row) => readCursorField(row, cursorColumn) === value)
+    .map((row) => readCursorField(row, 'id'));
+
+  if (excludeIds.length > MAX_CURSOR_EXCLUDE_IDS) {
+    throw new Error(
+      `fetchAllPages: ${excludeIds.length} rows share \`${cursorColumn}\` ${value}; cannot page past them`,
+    );
+  }
+
+  return { column: cursorColumn, excludeIds, value };
 }
 
 /**
@@ -378,15 +470,15 @@ const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
  */
 async function fetchPage<T>(
   queryBuilder: (
-    offset: number,
+    cursor: PageCursor | null,
   ) => PromiseLike<{ data: T[] | null; error: unknown }>,
-  offset: number,
+  cursor: PageCursor | null,
 ): Promise<T[] | null> {
   let lastError: unknown;
 
   for (let attempt = 1; attempt <= PAGE_MAX_ATTEMPTS; attempt++) {
     try {
-      const { data, error } = await queryBuilder(offset);
+      const { data, error } = await queryBuilder(cursor);
       if (!error) {
         return data;
       }
@@ -401,7 +493,7 @@ async function fetchPage<T>(
 
     const delayMs = PAGE_RETRY_BASE_DELAY_MS * 2 ** (attempt - 1);
     console.warn(
-      `♻️  [daily-stats] transient page error at offset ${offset}, retrying in ${delayMs}ms (attempt ${attempt}/${PAGE_MAX_ATTEMPTS})`,
+      `♻️  [daily-stats] transient page error at ${cursor ? `${cursor.column} ${cursor.value}` : 'start'}, retrying in ${delayMs}ms (attempt ${attempt}/${PAGE_MAX_ATTEMPTS})`,
       lastError,
     );
     await wait(delayMs);

--- a/apps/web/app/api/daily-stats/utils.ts
+++ b/apps/web/app/api/daily-stats/utils.ts
@@ -295,7 +295,7 @@ export const formatIdList = (ids: readonly string[]) => `(${ids.join(',')})`;
  *
  * Every shape is a plain AND of filters. The textbook `(c > v) OR (c = v AND
  * id > lastId)` predicate would be one request shorter in the `within` case,
- * but it needs a second top-level `or=` param on the two queries that already
+ * but it needs a second top-level `or=` param on the three queries that already
  * use `.or()` for their own filters, and whether PostgREST ANDs repeated `or=`
  * params is not something this code can verify at runtime. Getting that wrong
  * silently changes which rows a revenue report counts, so it is not assumed.

--- a/apps/web/app/api/daily-stats/utils.ts
+++ b/apps/web/app/api/daily-stats/utils.ts
@@ -296,11 +296,11 @@ export interface PageCursor {
 }
 
 /**
- * Cap on the ids carried in a cursor: ~37 bytes per uuid, so 200 already puts
- * the request near the gateway's URL limit. Every column paged on defaults to a
- * per-row `now()` at microsecond precision, so real boundaries hold one or two
- * rows. Hitting this means the data is not what these queries assume — fail
- * loudly rather than build a URL that gets rejected, or silently drop rows.
+ * Limit cursor ids to keep requests below the gateway's URL limit.
+ * PostgreSQL fixes `now()` at transaction start, so bulk inserts can share a
+ * timestamp. Pagination aborts if a full page ends with more than 200 rows at
+ * the same cursor value, even for valid data, rather than risk an oversized
+ * URL or silently drop rows.
  */
 const MAX_CURSOR_EXCLUDE_IDS = 200;
 

--- a/apps/web/app/api/daily-stats/utils.ts
+++ b/apps/web/app/api/daily-stats/utils.ts
@@ -312,9 +312,12 @@ export type PageCursor =
 
 /**
  * When a page ends on a run longer than this, the cursor walks the run by `id`
- * rather than listing its ids. Sized for the gateway's URL limit (~37 bytes per
- * uuid), and purely a choice between two correct strategies — exceeding it
- * costs one extra request, never a dropped row or an aborted run.
+ * rather than listing its ids. 200 is an estimate, not a measured threshold: at
+ * ~37 bytes per uuid it puts the id list near 7.4KB, comfortably inside the
+ * 8-16KB request lines proxies commonly accept, with the rest of the query
+ * string still to fit. Nothing breaks if it is wrong in either direction — it
+ * only chooses between two correct strategies, one of which costs an extra
+ * request.
  *
  * Postgres fixes `now()` at transaction start, so any bulk insert produces a
  * run this long: a promo grant, a backfill, a support batch.

--- a/apps/web/app/api/daily-stats/utils.ts
+++ b/apps/web/app/api/daily-stats/utils.ts
@@ -312,17 +312,23 @@ export type PageCursor =
 
 /**
  * When a page ends on a run longer than this, the cursor walks the run by `id`
- * rather than listing its ids. 200 is an estimate, not a measured threshold: at
- * ~37 bytes per uuid it puts the id list near 7.4KB, comfortably inside the
- * 8-16KB request lines proxies commonly accept, with the rest of the query
- * string still to fit. Nothing breaks if it is wrong in either direction — it
- * only chooses between two correct strategies, one of which costs an extra
- * request.
+ * rather than listing its ids. An estimate, not a measured threshold: at ~37
+ * bytes per uuid, 100 ids is ~3.7KB of the 8-16KB request line proxies commonly
+ * accept. The rest is not free either — the same URL carries `excludeUserIds`
+ * as a second uuid list, plus the select, range filters, order and limit.
  *
- * Postgres fixes `now()` at transaction start, so any bulk insert produces a
- * run this long: a promo grant, a backfill, a support batch.
+ * The two directions are not symmetric, which is what sets the value. Erring
+ * low costs one extra request. Erring high risks a 414, which is not a
+ * transient error and so fails the whole run on its first response — the same
+ * class of failure this pagination exists to avoid. So it sits well under what
+ * should fit rather than close to it.
+ *
+ * Row correctness does not depend on this number either way; it only chooses
+ * between two correct strategies. Postgres fixes `now()` at transaction start,
+ * so any bulk insert produces a run long enough to reach it: a promo grant, a
+ * backfill, a support batch.
  */
-const MAX_CURSOR_EXCLUDE_IDS = 200;
+const MAX_CURSOR_EXCLUDE_IDS = 100;
 
 interface CursorFilterable {
   eq: (column: string, value: string) => CursorFilterable;

--- a/apps/web/app/api/daily-stats/utils.ts
+++ b/apps/web/app/api/daily-stats/utils.ts
@@ -312,10 +312,11 @@ export type PageCursor =
 
 /**
  * When a page ends on a run longer than this, the cursor walks the run by `id`
- * rather than listing its ids. An estimate, not a measured threshold: at ~37
- * bytes per uuid, 100 ids is ~3.7KB of the 8-16KB request line proxies commonly
- * accept. The rest is not free either — the same URL carries `excludeUserIds`
- * as a second uuid list, plus the select, range filters, order and limit.
+ * rather than listing its ids. An estimate, not a measured threshold: the
+ * filter is percent-encoded into the query string, so each uuid costs ~39 bytes
+ * and 100 ids is ~3.9KB — against the 8000 characters postgrest-js itself warns
+ * past (`urlLengthLimit`), with the select, range filters, order and limit
+ * still to fit.
  *
  * The two directions are not symmetric, which is what sets the value. Erring
  * low costs one extra request. Erring high risks a 414, which is not a

--- a/apps/web/app/api/daily-stats/utils.ts
+++ b/apps/web/app/api/daily-stats/utils.ts
@@ -301,19 +301,7 @@ export async function fetchAllPages<T>(
   let offset = 0;
 
   while (true) {
-    const { data, error } = await queryBuilder(offset);
-
-    if (error) {
-      if (error instanceof Error) {
-        throw error;
-      }
-
-      const msg =
-        typeof error === 'object' && error !== null && 'message' in error
-          ? (error as { message: string }).message
-          : String(error);
-      throw new Error(msg, { cause: error });
-    }
+    const data = await fetchPage(queryBuilder, offset);
 
     if (!data || data.length === 0) {
       break;
@@ -329,4 +317,95 @@ export async function fetchAllPages<T>(
   }
 
   return allData;
+}
+
+/**
+ * Postgres SQLSTATEs worth retrying. Daily stats only reads, so replaying a
+ * page is always safe.
+ */
+const TRANSIENT_POSTGRES_CODES = new Set([
+  '08000', // connection_exception
+  '08003', // connection_does_not_exist
+  '08006', // connection_failure
+  '53300', // too_many_connections
+  '57014', // query_canceled (statement timeout)
+]);
+
+/**
+ * Supabase's API gateway sheds load with plain 502/503/504 responses that
+ * PostgREST surfaces as a bare `{ message }` with no SQLSTATE, so these have to
+ * be matched on text. `timed? ?out` covers the observed `Gateway Timeout` as
+ * well as `ETIMEDOUT` and `query timed out`.
+ */
+const TRANSIENT_ERROR_MESSAGE =
+  /bad gateway|service unavailable|temporarily unavailable|canceling statement|connection (?:reset|closed|terminated)|socket hang up|fetch failed|econnreset|timed? ?out/i;
+
+export function isTransientQueryError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') {
+    return false;
+  }
+
+  const { code, message } = error as { code?: unknown; message?: unknown };
+
+  if (typeof code === 'string' && TRANSIENT_POSTGRES_CODES.has(code)) {
+    return true;
+  }
+
+  return typeof message === 'string' && TRANSIENT_ERROR_MESSAGE.test(message);
+}
+
+function toQueryError(error: unknown): Error {
+  if (error instanceof Error) {
+    return error;
+  }
+
+  const msg =
+    typeof error === 'object' && error !== null && 'message' in error
+      ? (error as { message: string }).message
+      : String(error);
+  return new Error(msg, { cause: error });
+}
+
+export const PAGE_MAX_ATTEMPTS = 4;
+const PAGE_RETRY_BASE_DELAY_MS = 500;
+
+const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Fetches one page, replaying it with exponential backoff when Supabase
+ * answers with a transient gateway or connection failure. A whole daily-stats
+ * run is wasted when a single page fails, so the cheap retry is worth it.
+ */
+async function fetchPage<T>(
+  queryBuilder: (
+    offset: number,
+  ) => PromiseLike<{ data: T[] | null; error: unknown }>,
+  offset: number,
+): Promise<T[] | null> {
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= PAGE_MAX_ATTEMPTS; attempt++) {
+    try {
+      const { data, error } = await queryBuilder(offset);
+      if (!error) {
+        return data;
+      }
+      lastError = error;
+    } catch (error) {
+      lastError = error;
+    }
+
+    if (!isTransientQueryError(lastError) || attempt === PAGE_MAX_ATTEMPTS) {
+      throw toQueryError(lastError);
+    }
+
+    const delayMs = PAGE_RETRY_BASE_DELAY_MS * 2 ** (attempt - 1);
+    console.warn(
+      `♻️  [daily-stats] transient page error at offset ${offset}, retrying in ${delayMs}ms (attempt ${attempt}/${PAGE_MAX_ATTEMPTS})`,
+      lastError,
+    );
+    await wait(delayMs);
+  }
+
+  throw toQueryError(lastError);
 }

--- a/apps/web/tests/daily-stats-cache.test.ts
+++ b/apps/web/tests/daily-stats-cache.test.ts
@@ -22,7 +22,7 @@ const mocks = vi.hoisted(() => ({
     getClonedAudioFilesInRange: vi.fn().mockResolvedValue([]),
     getInternalUserIds: vi.fn().mockResolvedValue([]),
     getProfilesInRange: vi.fn().mockResolvedValue([]),
-    getProfileUsernamesByIds: vi.fn().mockResolvedValue([]),
+    getProfileUsernamesByIds: vi.fn().mockResolvedValue(new Map()),
     getUsageEventsInRange: vi.fn().mockResolvedValue([]),
   },
   readFileSync: vi.fn(),

--- a/apps/web/tests/daily-stats-cache.test.ts
+++ b/apps/web/tests/daily-stats-cache.test.ts
@@ -1,0 +1,296 @@
+import assert from 'node:assert/strict';
+import { join } from 'node:path';
+import { NextRequest } from 'next/server';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { GET } from '@/app/api/daily-stats/route';
+
+const mocks = vi.hoisted(() => ({
+  captureCheckIn: vi.fn(() => 'test-check-in'),
+  captureException: vi.fn(),
+  createAdminClient: vi.fn(),
+  existsSync: vi.fn(),
+  fetch: vi.fn<typeof fetch>(),
+  from: vi.fn(),
+  getContributionData: vi.fn(),
+  getUserIdByStripeCustomerId: vi.fn(),
+  queries: {
+    getAllCreditTransactions: vi.fn().mockResolvedValue([]),
+    getAudioFilesInRange: vi.fn().mockResolvedValue([]),
+    getCallSessionDurationsBefore: vi.fn().mockResolvedValue([]),
+    getCallSessionsInRange: vi.fn().mockResolvedValue([]),
+    getClonedAudioFilesInRange: vi.fn().mockResolvedValue([]),
+    getInternalUserIds: vi.fn().mockResolvedValue([]),
+    getProfilesInRange: vi.fn().mockResolvedValue([]),
+    getProfileUsernamesByIds: vi.fn().mockResolvedValue([]),
+    getUsageEventsInRange: vi.fn().mockResolvedValue([]),
+  },
+  readFileSync: vi.fn(),
+  redis: {
+    countActiveCustomerSubscriptions: vi.fn().mockResolvedValue(0),
+    findNextSubscriptionDueForPayment: vi.fn().mockResolvedValue(null),
+    getActiveSubscriptionsMrr: vi.fn().mockResolvedValue(null),
+  },
+  writeFileSync: vi.fn(),
+}));
+
+// Exercise real request parsing and response headers, not the setup mock.
+vi.unmock('next/server');
+
+vi.mock('node:fs', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('node:fs')>()),
+  existsSync: mocks.existsSync,
+  readFileSync: mocks.readFileSync,
+  writeFileSync: mocks.writeFileSync,
+}));
+vi.mock('@sentry/nextjs', () => ({
+  captureCheckIn: mocks.captureCheckIn,
+  captureException: mocks.captureException,
+}));
+vi.mock('@/lib/supabase/admin', () => ({
+  createAdminClient: mocks.createAdminClient,
+}));
+vi.mock('@/lib/supabase/queries', () => ({
+  getUserIdByStripeCustomerId: mocks.getUserIdByStripeCustomerId,
+}));
+vi.mock('@/lib/redis/queries', () => mocks.redis);
+vi.mock('@/app/api/daily-stats/queries', () => mocks.queries);
+vi.mock('@/app/api/daily-stats/contribution-queries', () => ({
+  getContributionData: mocks.getContributionData,
+}));
+
+const CACHE_FILE = join(process.cwd(), '.daily-stats-cache.json');
+const REPORT_DATE = '2026-09-12';
+const WEBHOOK = 'https://telegram.invalid/daily-stats';
+
+function validCache() {
+  const emptyResult = { count: 0, data: [], error: null };
+  return {
+    activeSubscribersCount: 0,
+    allCreditTransactions: [],
+    allTimePurchaseTransactions: [],
+    apiKeysYesterdayResult: emptyResult,
+    audio14dResult: emptyResult,
+    audioTotalCountResult: emptyResult,
+    audioYesterdayResult: emptyResult,
+    callSessions14dResult: emptyResult,
+    callSessionsAllTimeDurationResult: emptyResult,
+    callSessionsTotalCountResult: emptyResult,
+    clonesResult: emptyResult,
+    nextSubscriptionDueForPayment: null,
+    profilesRecentResult: emptyResult,
+    profilesTotalCountResult: emptyResult,
+    reportDate: REPORT_DATE,
+    subscriptionsMrr: null,
+    usageEvents14dResult: emptyResult,
+    version: 4,
+  };
+}
+
+function request(query = '', authorization?: string) {
+  return new NextRequest(`http://localhost/api/daily-stats${query}`, {
+    headers: authorization ? { authorization } : undefined,
+  });
+}
+
+function expectFreshQueries() {
+  expect(mocks.from).toHaveBeenCalledWith('audio_files');
+  expect(mocks.queries.getAudioFilesInRange).toHaveBeenCalledOnce();
+  expect(mocks.queries.getAllCreditTransactions).toHaveBeenCalledOnce();
+  for (const query of Object.values(mocks.redis)) {
+    expect(query).toHaveBeenCalledOnce();
+  }
+}
+
+function expectNoCacheAccess() {
+  expect(mocks.existsSync).not.toHaveBeenCalled();
+  expect(mocks.readFileSync).not.toHaveBeenCalled();
+  expect(mocks.writeFileSync).not.toHaveBeenCalled();
+}
+
+describe('GET /api/daily-stats cache', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubEnv('NODE_ENV', 'development');
+    vi.stubEnv('CRON_SECRET', 'test-cron-secret');
+    vi.stubEnv('TELEGRAM_WEBHOOK_URL', WEBHOOK);
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(new Date(`${REPORT_DATE}T12:00:00Z`));
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    mocks.fetch.mockReset().mockRejectedValue(new Error('Unexpected fetch'));
+    vi.stubGlobal('fetch', mocks.fetch);
+    mocks.existsSync.mockReturnValue(false);
+    mocks.readFileSync.mockReturnValue('{malformed cache');
+    mocks.from.mockImplementation(() => {
+      // Supabase builders support both fluent filters and Promise resolution.
+      return Object.assign(
+        Promise.resolve({ count: 0, data: [], error: null }),
+        {
+          gte: vi.fn().mockReturnThis(),
+          lt: vi.fn().mockReturnThis(),
+          notIn: vi.fn().mockReturnThis(),
+          or: vi.fn().mockReturnThis(),
+          select: vi.fn().mockReturnThis(),
+        },
+      );
+    });
+    mocks.createAdminClient.mockReturnValue({ from: mocks.from });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    expect(mocks.getContributionData).not.toHaveBeenCalled();
+    expect(mocks.getUserIdByStripeCustomerId).not.toHaveBeenCalled();
+    expect(mocks.captureException).not.toHaveBeenCalled();
+  });
+
+  it.each([true, false])(
+    'cache=off skips reads and writes when cache exists=%s',
+    async (exists) => {
+      mocks.existsSync.mockReturnValue(exists);
+
+      const response = await GET(request('?cache=off'));
+      assert(response);
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual({ ok: true });
+      expect(response.headers.get('Cache-Control')).toBe('no-store');
+      expect(response.headers.get('X-Daily-Stats-Cache')).toBe('bypass');
+      expectNoCacheAccess();
+      expectFreshQueries();
+      expect(mocks.fetch).not.toHaveBeenCalled();
+      expect(mocks.captureCheckIn).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(['', '?cache=on', '?cache=OFF'])(
+    'reads a valid cache without rewriting it for query "%s"',
+    async (query) => {
+      mocks.existsSync.mockReturnValue(true);
+      mocks.readFileSync.mockReturnValue(JSON.stringify(validCache()));
+
+      const response = await GET(request(query));
+      assert(response);
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual({ ok: true });
+      expect(response.headers.get('Cache-Control')).toBeNull();
+      expect(response.headers.get('X-Daily-Stats-Cache')).toBeNull();
+      expect(mocks.existsSync).toHaveBeenCalledWith(CACHE_FILE);
+      expect(mocks.readFileSync).toHaveBeenCalledExactlyOnceWith(
+        CACHE_FILE,
+        'utf-8',
+      );
+      expect(mocks.writeFileSync).not.toHaveBeenCalled();
+      expect(mocks.from).not.toHaveBeenCalled();
+      // Internal-user lookup still runs even when report data is cached.
+      expect(mocks.queries.getInternalUserIds).toHaveBeenCalledOnce();
+      for (const [name, queryMock] of Object.entries(mocks.queries)) {
+        if (name !== 'getInternalUserIds') {
+          expect(queryMock).not.toHaveBeenCalled();
+        }
+      }
+      for (const queryMock of Object.values(mocks.redis)) {
+        expect(queryMock).not.toHaveBeenCalled();
+      }
+      expect(mocks.fetch).not.toHaveBeenCalled();
+    },
+  );
+
+  it('writes fresh results when the default cache is missing', async () => {
+    const response = await GET(request());
+    assert(response);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ ok: true });
+    expect(response.headers.get('X-Daily-Stats-Cache')).toBeNull();
+    expect(mocks.existsSync).toHaveBeenCalledWith(CACHE_FILE);
+    expect(mocks.readFileSync).not.toHaveBeenCalled();
+    expectFreshQueries();
+    expect(mocks.writeFileSync).toHaveBeenCalledExactlyOnceWith(
+      CACHE_FILE,
+      expect.any(String),
+    );
+    const cached = JSON.parse(mocks.writeFileSync.mock.calls[0][1]);
+    expect(cached).toMatchObject({
+      allCreditTransactions: [],
+      audio14dResult: { count: 0 },
+      audioYesterdayResult: { data: [], error: null },
+      reportDate: REPORT_DATE,
+      usageEvents14dResult: { data: [], error: null },
+      version: 4,
+    });
+    expect(mocks.fetch).not.toHaveBeenCalled();
+  });
+
+  describe('production authentication', () => {
+    beforeEach(() => {
+      vi.stubEnv('NODE_ENV', 'production');
+      mocks.existsSync.mockReturnValue(true);
+    });
+
+    it.each([
+      ['', undefined],
+      ['', 'Bearer wrong-secret'],
+      ['?cache=off', undefined],
+      ['?cache=off', 'Bearer wrong-secret'],
+    ])('rejects query "%s" with authorization %s', async (query, auth) => {
+      const response = await GET(request(query, auth));
+      assert(response);
+
+      expect(response.status).toBe(401);
+      expect(await response.json()).toMatchObject({ error: 'Unauthorized' });
+      expect(response.headers.get('X-Daily-Stats-Cache')).toBeNull();
+      expectNoCacheAccess();
+      expect(mocks.createAdminClient).not.toHaveBeenCalled();
+      for (const queryMock of Object.values(mocks.queries)) {
+        expect(queryMock).not.toHaveBeenCalled();
+      }
+      for (const queryMock of Object.values(mocks.redis)) {
+        expect(queryMock).not.toHaveBeenCalled();
+      }
+      expect(mocks.fetch).not.toHaveBeenCalled();
+      expect(mocks.captureCheckIn).not.toHaveBeenCalled();
+    });
+
+    it.each(['', '?cache=off'])(
+      'accepts the cron secret and ignores disk cache for query "%s"',
+      async (query) => {
+        mocks.fetch.mockResolvedValueOnce(new Response('{}'));
+
+        const response = await GET(request(query, 'Bearer test-cron-secret'));
+        assert(response);
+
+        expect(response.status).toBe(200);
+        expect(await response.json()).toEqual({ ok: true });
+        expect(response.headers.get('Cache-Control')).toBeNull();
+        expect(response.headers.get('X-Daily-Stats-Cache')).toBeNull();
+        expectNoCacheAccess();
+        expectFreshQueries();
+        expect(mocks.fetch).toHaveBeenCalledExactlyOnceWith(
+          WEBHOOK,
+          expect.objectContaining({
+            body: expect.stringContaining(
+              'No audio files generated yesterday!',
+            ),
+            method: 'POST',
+          }),
+        );
+        expect(mocks.captureCheckIn).toHaveBeenCalledTimes(2);
+        expect(mocks.captureCheckIn).toHaveBeenNthCalledWith(1, {
+          monitorSlug: 'telegram-bot-daily-stats',
+          status: 'in_progress',
+        });
+        expect(mocks.captureCheckIn).toHaveBeenNthCalledWith(2, {
+          checkInId: 'test-check-in',
+          monitorSlug: 'telegram-bot-daily-stats',
+          status: 'ok',
+        });
+      },
+    );
+  });
+});

--- a/apps/web/tests/daily-stats-contribution-queries.test.ts
+++ b/apps/web/tests/daily-stats-contribution-queries.test.ts
@@ -67,7 +67,7 @@ const end = new Date('2026-09-06T00:00:00Z');
 // Rows carry the keyset cursor columns; paging reads them off the last row.
 const at = (i: number) => new Date(start.getTime() + i * 1000).toISOString();
 describe('all-time credit transaction reads', () => {
-  test('keeps the last duplicate, restores chronological order, and retains refunds', async () => {
+  test('paginates in query order with date and user filters, retaining refunds', async () => {
     const firstPage: DailyStatsCreditTransaction[] = Array.from(
       { length: PAGE_SIZE },
       (_, id) => ({
@@ -81,20 +81,17 @@ describe('all-time credit transaction reads', () => {
         user_id: 'user',
       }),
     );
-    const updatedTransaction = {
-      ...firstPage[0],
-      created_at: at(PAGE_SIZE),
-    };
+
     const refund: DailyStatsCreditTransaction = {
       ...firstPage[0],
       amount: -10,
-      created_at: at(PAGE_SIZE + 1),
+      created_at: at(PAGE_SIZE),
       id: 'refund',
       type: 'refund',
     };
     let page = 0;
     const { client, requests } = database(() => ({
-      data: page++ === 0 ? firstPage : [updatedTransaction, refund],
+      data: page++ === 0 ? firstPage : [refund],
       error: null,
     }));
 
@@ -102,17 +99,23 @@ describe('all-time credit transaction reads', () => {
       'internal',
     ]);
 
-    expect(transactions).toEqual([
-      ...firstPage.slice(1),
-      updatedTransaction,
-      refund,
-    ]);
+    expect(transactions).toEqual([...firstPage, refund]);
     expect(requests).toHaveLength(2);
     for (const request of requests) {
       expect(request.table).toBe('credit_transactions');
       expect(request.operations).toContainEqual([
         'in',
         ['type', ['purchase', 'topup', 'refund']],
+      ]);
+      expect(request.operations).toContainEqual([
+        'not',
+        ['description', 'ilike', '%manual%'],
+      ]);
+      expect(
+        request.operations.filter(([method]) => method === 'order'),
+      ).toEqual([
+        ['order', ['created_at', { ascending: true }]],
+        ['order', ['id', { ascending: true }]],
       ]);
       expect(request.operations).toContainEqual([
         'gte',

--- a/apps/web/tests/daily-stats-contribution-queries.test.ts
+++ b/apps/web/tests/daily-stats-contribution-queries.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from 'vitest';
 
 import { getContributionData } from '../app/api/daily-stats/contribution-queries';
 import { getCallSessionsInRange } from '../app/api/daily-stats/queries';
+import { PAGE_SIZE } from '../app/api/daily-stats/utils';
 
 interface QueryResult {
   data: unknown[] | null;
@@ -32,7 +33,7 @@ function database(
         'not',
         'or',
         'order',
-        'range',
+        'limit',
         'in',
         'eq',
       ]) {
@@ -58,15 +59,20 @@ function database(
 }
 const start = new Date('2026-08-07T00:00:00Z');
 const end = new Date('2026-09-06T00:00:00Z');
+
+// Rows carry the keyset cursor columns; paging reads them off the last row.
+const at = (i: number) => new Date(start.getTime() + i * 1000).toISOString();
 describe('contribution reads', () => {
   test('paginates events and excludes internal users', async () => {
-    const { client, requests } = database((table, ops) => {
-      const offset = ops.find(([method]) => method === 'range')?.[1][0];
-      const count = table === 'usage_events' && offset === 0 ? 1000 : 0;
+    let eventPages = 0;
+    const { client, requests } = database((table) => {
+      if (table !== 'usage_events') return { data: [], error: null };
+      const count = eventPages++ === 0 ? PAGE_SIZE : 0;
       return {
         data: Array.from({ length: count }, (_, id) => ({
           dollar_amount: 1,
           id: `${id}`,
+          occurred_at: at(id),
           source_id: null,
           source_type: 'tts',
         })),
@@ -74,16 +80,31 @@ describe('contribution reads', () => {
       };
     });
     const result = await getContributionData(client, start, end, ['internal']);
-    expect(result.events).toHaveLength(1000);
+    expect(result.events).toHaveLength(PAGE_SIZE);
 
-    expect(
-      requests.filter((request) => request.table === 'usage_events'),
-    ).toHaveLength(2);
+    const eventReads = requests.filter(
+      (request) => request.table === 'usage_events',
+    );
+    expect(eventReads).toHaveLength(2);
     expect(
       requests.every((request) =>
         request.operations.some(([method]) => method === 'notIn'),
       ),
     ).toBe(true);
+
+    // First page seeks from the window start only.
+    expect(
+      eventReads[0].operations.filter(([method]) => method === 'gte'),
+    ).toEqual([['gte', ['occurred_at', start.toISOString()]]]);
+    // Second page re-seeks from the last row read and drops that row's id.
+    expect(eventReads[1].operations).toContainEqual([
+      'gte',
+      ['occurred_at', at(PAGE_SIZE - 1)],
+    ]);
+    expect(eventReads[1].operations).toContainEqual([
+      'not',
+      ['id', 'in', `(${PAGE_SIZE - 1})`],
+    ]);
   });
   test('cross-window link checks omit date filters and batch audio metadata', async () => {
     const { client, requests } = database((table, ops) => {
@@ -121,25 +142,34 @@ describe('contribution reads', () => {
     ).toBe(false);
   });
   test('call activity reads paginate past 1000 calls', async () => {
-    const { client, requests } = database((_table, ops) => {
-      const offset = ops.find(([method]) => method === 'range')?.[1][0];
+    let page = 0;
+    const { client, requests } = database(() => {
+      const current = page++;
       return {
-        data: Array.from({ length: offset === 0 ? 1000 : 1 }, (_, id) => ({
-          id: `${offset}-${id}`,
-        })),
+        data: Array.from(
+          { length: current === 0 ? PAGE_SIZE : 1 },
+          (_, id) => ({
+            id: `${current}-${id}`,
+            started_at: at(current * PAGE_SIZE + id),
+          }),
+        ),
         error: null,
       };
     });
     const calls = await getCallSessionsInRange(client, start, end, [
       'internal',
     ]);
-    expect(calls).toHaveLength(1001);
+    expect(calls).toHaveLength(PAGE_SIZE + 1);
     expect(requests).toHaveLength(2);
     expect(requests[0].operations).toContainEqual([
       'notIn',
       ['user_id', ['internal']],
     ]);
-    expect(calls[1000].id).toBe('1000-0');
+    expect(calls[PAGE_SIZE].id).toBe('1-0');
+    expect(requests[1].operations).toContainEqual([
+      'gte',
+      ['started_at', at(PAGE_SIZE - 1)],
+    ]);
   });
   test('runs ID lookups concurrently with at most four batches and skips known links', async () => {
     let active = 0;

--- a/apps/web/tests/daily-stats-contribution-queries.test.ts
+++ b/apps/web/tests/daily-stats-contribution-queries.test.ts
@@ -2,7 +2,11 @@ import type { SupabaseClient } from '@supabase/supabase-js';
 import { describe, expect, test } from 'vitest';
 
 import { getContributionData } from '../app/api/daily-stats/contribution-queries';
-import { getCallSessionsInRange } from '../app/api/daily-stats/queries';
+import {
+  type DailyStatsCreditTransaction,
+  getAllCreditTransactions,
+  getCallSessionsInRange,
+} from '../app/api/daily-stats/queries';
 import { PAGE_SIZE } from '../app/api/daily-stats/utils';
 
 interface QueryResult {
@@ -62,6 +66,70 @@ const end = new Date('2026-09-06T00:00:00Z');
 
 // Rows carry the keyset cursor columns; paging reads them off the last row.
 const at = (i: number) => new Date(start.getTime() + i * 1000).toISOString();
+describe('all-time credit transaction reads', () => {
+  test('keeps the last duplicate, restores chronological order, and retains refunds', async () => {
+    const firstPage: DailyStatsCreditTransaction[] = Array.from(
+      { length: PAGE_SIZE },
+      (_, id) => ({
+        amount: 10,
+        created_at: at(id),
+        description: 'Credit purchase',
+        id: `${id}`,
+        metadata: {},
+        profiles: null,
+        type: 'purchase',
+        user_id: 'user',
+      }),
+    );
+    const updatedTransaction = {
+      ...firstPage[0],
+      created_at: at(PAGE_SIZE),
+    };
+    const refund: DailyStatsCreditTransaction = {
+      ...firstPage[0],
+      amount: -10,
+      created_at: at(PAGE_SIZE + 1),
+      id: 'refund',
+      type: 'refund',
+    };
+    let page = 0;
+    const { client, requests } = database(() => ({
+      data: page++ === 0 ? firstPage : [updatedTransaction, refund],
+      error: null,
+    }));
+
+    const transactions = await getAllCreditTransactions(client, end, [
+      'internal',
+    ]);
+
+    expect(transactions).toEqual([
+      ...firstPage.slice(1),
+      updatedTransaction,
+      refund,
+    ]);
+    expect(requests).toHaveLength(2);
+    for (const request of requests) {
+      expect(request.table).toBe('credit_transactions');
+      expect(request.operations).toContainEqual([
+        'in',
+        ['type', ['purchase', 'topup', 'refund']],
+      ]);
+      expect(request.operations).toContainEqual([
+        'gte',
+        ['created_at', new Date(0).toISOString()],
+      ]);
+      expect(request.operations).toContainEqual([
+        'lt',
+        ['created_at', end.toISOString()],
+      ]);
+      expect(request.operations).toContainEqual([
+        'notIn',
+        ['user_id', ['internal']],
+      ]);
+    }
+  });
+});
+
 describe('contribution reads', () => {
   test('paginates events and excludes internal users', async () => {
     let eventPages = 0;

--- a/apps/web/tests/daily-stats-fetch-all-pages.test.ts
+++ b/apps/web/tests/daily-stats-fetch-all-pages.test.ts
@@ -69,11 +69,17 @@ function tableReader(rows: Row[]) {
   const sorted = sortRows(rows);
   return (cursor: PageCursor | null) => {
     let visible = sorted;
-    if (cursor) {
+    if (cursor?.kind === 'exclude') {
       const excluded = new Set(cursor.excludeIds);
       visible = sorted.filter(
         (row) => row.created_at >= cursor.value && !excluded.has(row.id),
       );
+    } else if (cursor?.kind === 'within') {
+      visible = sorted.filter(
+        (row) => row.created_at === cursor.value && row.id > cursor.afterId,
+      );
+    } else if (cursor?.kind === 'after') {
+      visible = sorted.filter((row) => row.created_at > cursor.value);
     }
     return Promise.resolve({ data: visible.slice(0, PAGE_SIZE), error: null });
   };
@@ -138,17 +144,72 @@ describe('fetchAllPages keyset paging', () => {
         'row-00998',
         'row-00999',
       ],
+      kind: 'exclude',
       value: collision,
     });
   });
 
-  test('refuses to page when too many rows share one cursor value', async () => {
+  // A bulk insert shares one `now()`, so these runs are ordinary data.
+  test('reads a run longer than the cursor can carry ids for', async () => {
+    const frozen = distinctAt(0);
+    // 400 rows at one value, ending the first page mid-run.
+    const rows = makeRows(PAGE_SIZE + 500, (i) =>
+      i >= 800 && i < 1200 ? frozen : distinctAt(i + 1),
+    );
+
+    const read = await fetchAllPages<Row>('created_at', tableReader(rows));
+
+    expect(read).toEqual(sortRows(rows));
+    expect(new Set(read.map((r) => r.id)).size).toBe(rows.length);
+  });
+
+  test('reads a run longer than a whole page', async () => {
+    const frozen = distinctAt(0);
+    const rows = makeRows(PAGE_SIZE * 3, (i) =>
+      i < PAGE_SIZE * 2 ? frozen : distinctAt(i + 1),
+    );
+
+    const read = await fetchAllPages<Row>('created_at', tableReader(rows));
+
+    expect(read).toEqual(sortRows(rows));
+    expect(new Set(read.map((r) => r.id)).size).toBe(rows.length);
+  });
+
+  test('reads a table that is entirely one cursor value', async () => {
     const frozen = distinctAt(0);
     const rows = makeRows(PAGE_SIZE * 2, () => frozen);
 
-    await expect(
-      fetchAllPages<Row>('created_at', tableReader(rows)),
-    ).rejects.toThrow(/rows share `created_at`/);
+    const read = await fetchAllPages<Row>('created_at', tableReader(rows));
+
+    expect(read).toEqual(sortRows(rows));
+  });
+
+  test('walks a long run by id, then steps past it', async () => {
+    const frozen = distinctAt(0);
+    const rows = makeRows(PAGE_SIZE + 10, (i) =>
+      i < PAGE_SIZE ? frozen : distinctAt(i + 1),
+    );
+    const kinds: (PageCursor | null)[] = [];
+    const reader = tableReader(rows);
+
+    await fetchAllPages<Row>('created_at', (cursor) => {
+      kinds.push(cursor);
+      return reader(cursor);
+    });
+
+    // Page 1 is all `frozen`, so the cursor walks by id rather than listing
+    // 1000 ids, then advances past the value once the run is exhausted.
+    expect(kinds[1]).toEqual({
+      afterId: 'row-00999',
+      column: 'created_at',
+      kind: 'within',
+      value: frozen,
+    });
+    expect(kinds[2]).toEqual({
+      column: 'created_at',
+      kind: 'after',
+      value: frozen,
+    });
   });
 
   test('refuses a cursor that moves backwards rather than looping forever', async () => {
@@ -187,6 +248,14 @@ describe('applyPageCursor', () => {
     const calls: [string, ...string[]][] = [];
     const builder = {
       calls,
+      eq(column: string, value: string) {
+        calls.push(['eq', column, value]);
+        return builder;
+      },
+      gt(column: string, value: string) {
+        calls.push(['gt', column, value]);
+        return builder;
+      },
       gte(column: string, value: string) {
         calls.push(['gte', column, value]);
         return builder;
@@ -211,6 +280,7 @@ describe('applyPageCursor', () => {
     applyPageCursor(query, {
       column: 'occurred_at',
       excludeIds: ['a', 'b'],
+      kind: 'exclude',
       value: '2026-09-01T00:00:00.000Z',
     });
 
@@ -220,12 +290,43 @@ describe('applyPageCursor', () => {
     ]);
   });
 
+  test('walks a long run by id with plain AND filters, no `or`', () => {
+    const query = fakeQuery();
+
+    applyPageCursor(query, {
+      afterId: 'row-42',
+      column: 'occurred_at',
+      kind: 'within',
+      value: '2026-09-01T00:00:00.000Z',
+    });
+
+    expect(query.calls).toEqual([
+      ['eq', 'occurred_at', '2026-09-01T00:00:00.000Z'],
+      ['gt', 'id', 'row-42'],
+    ]);
+  });
+
+  test('steps past an exhausted run', () => {
+    const query = fakeQuery();
+
+    applyPageCursor(query, {
+      column: 'occurred_at',
+      kind: 'after',
+      value: '2026-09-01T00:00:00.000Z',
+    });
+
+    expect(query.calls).toEqual([
+      ['gt', 'occurred_at', '2026-09-01T00:00:00.000Z'],
+    ]);
+  });
+
   test('skips the exclusion filter when nothing shares the boundary', () => {
     const query = fakeQuery();
 
     applyPageCursor(query, {
       column: 'created_at',
       excludeIds: [],
+      kind: 'exclude',
       value: '2026-09-01T00:00:00.000Z',
     });
 
@@ -274,6 +375,7 @@ describe('fetchAllPages', () => {
     expect(seen[2]).toEqual({
       column: 'created_at',
       excludeIds: [lastOfFirstPage.id],
+      kind: 'exclude',
       value: lastOfFirstPage.created_at,
     });
   });

--- a/apps/web/tests/daily-stats-fetch-all-pages.test.ts
+++ b/apps/web/tests/daily-stats-fetch-all-pages.test.ts
@@ -151,16 +151,26 @@ describe('fetchAllPages keyset paging', () => {
 
   // A bulk insert shares one `now()`, so these runs are ordinary data.
   test('reads a run longer than the cursor can carry ids for', async () => {
-    const frozen = distinctAt(0);
-    // 400 rows at one value, ending the first page mid-run.
+    // The run must sort into the middle, not the front: a page that ends
+    // part-way through it is what forces `exclude` to hand over to `within`.
+    const frozen = distinctAt(700);
+    // 500 rows at one value, so page 1 ends 300 rows into the run.
     const rows = makeRows(PAGE_SIZE + 500, (i) =>
-      i >= 800 && i < 1200 ? frozen : distinctAt(i + 1),
+      i >= 700 && i < 1200 ? frozen : distinctAt(i),
     );
+    const kinds: string[] = [];
+    const reader = tableReader(rows);
 
-    const read = await fetchAllPages<Row>('created_at', tableReader(rows));
+    const read = await fetchAllPages<Row>('created_at', (cursor) => {
+      kinds.push(cursor ? cursor.kind : 'start');
+      return reader(cursor);
+    });
 
     expect(read).toEqual(sortRows(rows));
     expect(new Set(read.map((r) => r.id)).size).toBe(rows.length);
+    // Asserted, not assumed: an earlier version of this test read the run from
+    // the front and never left `exclude`, so it passed without the code it names.
+    expect(kinds).toEqual(['start', 'within', 'after']);
   });
 
   test('reads a run longer than a whole page', async () => {

--- a/apps/web/tests/daily-stats-fetch-all-pages.test.ts
+++ b/apps/web/tests/daily-stats-fetch-all-pages.test.ts
@@ -150,13 +150,16 @@ describe('fetchAllPages keyset paging', () => {
   });
 
   // A bulk insert shares one `now()`, so these runs are ordinary data.
-  test('reads a run longer than the cursor can carry ids for', async () => {
-    // The run must sort into the middle, not the front: a page that ends
-    // part-way through it is what forces `exclude` to hand over to `within`.
-    const frozen = distinctAt(700);
-    // 500 rows at one value, so page 1 ends 300 rows into the run.
-    const rows = makeRows(PAGE_SIZE + 500, (i) =>
-      i >= 700 && i < 1200 ? frozen : distinctAt(i),
+  test('hands `exclude` over to `within` inside a long run', async () => {
+    // Two conditions, and both matter. The page has to end *inside* the run,
+    // so the run cannot sort to the front. And it has to end no more than
+    // MAX_CURSOR_EXCLUDE_IDS rows in, or the very first cursor is already
+    // `within` and the handover never happens. 50 rows in leaves margin either
+    // side of the current cap.
+    const frozen = distinctAt(950);
+    // 1300 rows at one value: page 1 ends 50 rows in, page 2 is then all run.
+    const rows = makeRows(PAGE_SIZE + 1400, (i) =>
+      i >= 950 && i < 2250 ? frozen : distinctAt(i),
     );
     const kinds: string[] = [];
     const reader = tableReader(rows);
@@ -168,9 +171,12 @@ describe('fetchAllPages keyset paging', () => {
 
     expect(read).toEqual(sortRows(rows));
     expect(new Set(read.map((r) => r.id)).size).toBe(rows.length);
-    // Asserted, not assumed: an earlier version of this test read the run from
-    // the front and never left `exclude`, so it passed without the code it names.
-    expect(kinds).toEqual(['start', 'within', 'after']);
+    // Asserted, not assumed. Two earlier versions of this test named a path
+    // they never took — the first read the run from the front and stayed in
+    // `exclude`, the second jumped straight to `within`. The ids dropped on the
+    // way into `within` must all sort below its `afterId`, or they are skipped;
+    // this sequence is the only place that invariant is exercised.
+    expect(kinds).toEqual(['start', 'exclude', 'within', 'after']);
   });
 
   test('reads a run longer than a whole page', async () => {

--- a/apps/web/tests/daily-stats-fetch-all-pages.test.ts
+++ b/apps/web/tests/daily-stats-fetch-all-pages.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, test, vi } from 'vitest';
 
 import {
+  applyPageCursor,
   fetchAllPages,
   isTransientQueryError,
   PAGE_MAX_ATTEMPTS,
   PAGE_SIZE,
+  type PageCursor,
 } from '../app/api/daily-stats/utils';
 
 const GATEWAY_TIMEOUT = { message: 'Gateway Timeout' };
@@ -47,29 +49,233 @@ describe('isTransientQueryError', () => {
   });
 });
 
-describe('fetchAllPages', () => {
-  test('retries a transient gateway failure and keeps paginating', async () => {
-    const firstPage = Array.from({ length: PAGE_SIZE }, (_, i) => ({ id: i }));
-    const offsets: number[] = [];
-    let failures = 0;
+interface Row {
+  created_at: string;
+  id: string;
+}
 
-    const rows = await runWithFakeTimers(() =>
-      fetchAllPages<{ id: number }>((offset) => {
-        offsets.push(offset);
-        if (offset === 0 && failures === 0) {
-          failures++;
-          return Promise.resolve({ data: null, error: GATEWAY_TIMEOUT });
-        }
+const sortRows = (rows: Row[]) =>
+  [...rows].sort(
+    (a, b) =>
+      a.created_at.localeCompare(b.created_at) || a.id.localeCompare(b.id),
+  );
+
+/**
+ * Stands in for PostgREST: applies the cursor exactly as `applyPageCursor`
+ * builds it (`gte(column, value)` plus `not id in (...)`), ordered and capped
+ * at PAGE_SIZE.
+ */
+function tableReader(rows: Row[]) {
+  const sorted = sortRows(rows);
+  return (cursor: PageCursor | null) => {
+    let visible = sorted;
+    if (cursor) {
+      const excluded = new Set(cursor.excludeIds);
+      visible = sorted.filter(
+        (row) => row.created_at >= cursor.value && !excluded.has(row.id),
+      );
+    }
+    return Promise.resolve({ data: visible.slice(0, PAGE_SIZE), error: null });
+  };
+}
+
+const makeRows = (count: number, at: (i: number) => string): Row[] =>
+  Array.from({ length: count }, (_, i) => ({
+    created_at: at(i),
+    id: `row-${String(i).padStart(5, '0')}`,
+  }));
+
+// Distinct, ordered timestamps.
+const distinctAt = (i: number) =>
+  new Date(Date.UTC(2026, 0, 1) + i * 1000).toISOString();
+
+describe('fetchAllPages keyset paging', () => {
+  test('reads a multi-page table exactly once, in order', async () => {
+    const rows = makeRows(PAGE_SIZE * 2 + 137, distinctAt);
+
+    const read = await fetchAllPages<Row>('created_at', tableReader(rows));
+
+    expect(read).toEqual(sortRows(rows));
+  });
+
+  test('does not skip or duplicate rows sharing a timestamp across a page boundary', async () => {
+    const collision = distinctAt(999);
+    // 40 rows straddling the first page boundary all share one timestamp.
+    const rows = makeRows(PAGE_SIZE * 2, (i) =>
+      i >= 980 && i < 1020 ? collision : distinctAt(i),
+    );
+
+    const read = await fetchAllPages<Row>('created_at', tableReader(rows));
+
+    expect(read).toEqual(sortRows(rows));
+    expect(new Set(read.map((r) => r.id)).size).toBe(rows.length);
+  });
+
+  test('excludes every id at the boundary, not just the last row', async () => {
+    const collision = distinctAt(999);
+    // The page boundary lands inside a run of equal timestamps, so the next
+    // seek re-reads all of them and must exclude each one.
+    const rows = makeRows(PAGE_SIZE + 50, (i) =>
+      i >= 995 ? collision : distinctAt(i),
+    );
+
+    const cursors: (PageCursor | null)[] = [];
+    const reader = tableReader(rows);
+
+    const read = await fetchAllPages<Row>('created_at', (cursor) => {
+      cursors.push(cursor);
+      return reader(cursor);
+    });
+
+    expect(read).toEqual(sortRows(rows));
+    // Rows 995..999 close the first page and all share `collision`.
+    expect(cursors[1]).toEqual({
+      column: 'created_at',
+      excludeIds: [
+        'row-00995',
+        'row-00996',
+        'row-00997',
+        'row-00998',
+        'row-00999',
+      ],
+      value: collision,
+    });
+  });
+
+  test('refuses to page when too many rows share one cursor value', async () => {
+    const frozen = distinctAt(0);
+    const rows = makeRows(PAGE_SIZE * 2, () => frozen);
+
+    await expect(
+      fetchAllPages<Row>('created_at', tableReader(rows)),
+    ).rejects.toThrow(/rows share `created_at`/);
+  });
+
+  test('refuses a cursor that moves backwards rather than looping forever', async () => {
+    // A query not actually ordered by the cursor column: every page ends
+    // earlier than the last, so the seek would never advance.
+    const page = makeRows(PAGE_SIZE, distinctAt);
+    let call = 0;
+
+    await expect(
+      fetchAllPages<Row>('created_at', () => {
+        call++;
         return Promise.resolve({
-          data: offset === 0 ? firstPage : [{ id: PAGE_SIZE }],
+          data:
+            call === 1 ? page : sortRows(page).slice(0, PAGE_SIZE).reverse(),
           error: null,
         });
       }),
+    ).rejects.toThrow(/went backwards/);
+  });
+
+  test('reports a missing cursor column rather than looping', async () => {
+    const rows = Array.from({ length: PAGE_SIZE }, (_, i) => ({
+      id: `r-${i}`,
+    }));
+
+    await expect(
+      fetchAllPages('created_at', () =>
+        Promise.resolve({ data: rows, error: null }),
+      ),
+    ).rejects.toThrow(/no string `created_at`/);
+  });
+});
+
+describe('applyPageCursor', () => {
+  function fakeQuery() {
+    const calls: [string, ...string[]][] = [];
+    const builder = {
+      calls,
+      gte(column: string, value: string) {
+        calls.push(['gte', column, value]);
+        return builder;
+      },
+      not(column: string, operator: string, value: string) {
+        calls.push(['not', column, operator, value]);
+        return builder;
+      },
+    };
+    return builder;
+  }
+
+  test('leaves the first page unfiltered', () => {
+    const query = fakeQuery();
+    expect(applyPageCursor(query, null)).toBe(query);
+    expect(query.calls).toEqual([]);
+  });
+
+  test('seeks inclusively and excludes the ids already returned', () => {
+    const query = fakeQuery();
+
+    applyPageCursor(query, {
+      column: 'occurred_at',
+      excludeIds: ['a', 'b'],
+      value: '2026-09-01T00:00:00.000Z',
+    });
+
+    expect(query.calls).toEqual([
+      ['gte', 'occurred_at', '2026-09-01T00:00:00.000Z'],
+      ['not', 'id', 'in', '(a,b)'],
+    ]);
+  });
+
+  test('skips the exclusion filter when nothing shares the boundary', () => {
+    const query = fakeQuery();
+
+    applyPageCursor(query, {
+      column: 'created_at',
+      excludeIds: [],
+      value: '2026-09-01T00:00:00.000Z',
+    });
+
+    expect(query.calls).toEqual([
+      ['gte', 'created_at', '2026-09-01T00:00:00.000Z'],
+    ]);
+  });
+});
+
+describe('fetchAllPages', () => {
+  test('retries a transient gateway failure and keeps paginating', async () => {
+    // Distinct timestamps, so each page boundary excludes exactly one id.
+    const firstPage = Array.from({ length: PAGE_SIZE }, (_, i) => ({
+      created_at: `2026-09-01T00:00:${String(i % 60).padStart(2, '0')}.${String(i).padStart(4, '0')}Z`,
+      id: `row-${i}`,
+    }));
+    const lastOfFirstPage = firstPage[PAGE_SIZE - 1];
+    const seen: (PageCursor | null)[] = [];
+    let failures = 0;
+
+    const rows = await runWithFakeTimers(() =>
+      fetchAllPages<{ created_at: string; id: string }>(
+        'created_at',
+        (cursor) => {
+          seen.push(cursor);
+          if (cursor === null && failures === 0) {
+            failures++;
+            return Promise.resolve({ data: null, error: GATEWAY_TIMEOUT });
+          }
+          return Promise.resolve({
+            data:
+              cursor === null
+                ? firstPage
+                : [{ created_at: '2026-09-02T00:00:00.000Z', id: 'tail' }],
+            error: null,
+          });
+        },
+      ),
     );
 
     expect(rows).toHaveLength(PAGE_SIZE + 1);
-    // Page 0 is replayed, then pagination advances normally.
-    expect(offsets).toEqual([0, 0, PAGE_SIZE]);
+    // First page is replayed from the same (null) cursor, then the cursor
+    // advances to the last row of that page and excludes it.
+    expect(seen[0]).toBeNull();
+    expect(seen[1]).toBeNull();
+    expect(seen[2]).toEqual({
+      column: 'created_at',
+      excludeIds: [lastOfFirstPage.id],
+      value: lastOfFirstPage.created_at,
+    });
   });
 
   test('gives up after the attempt budget and preserves the cause', async () => {
@@ -77,7 +283,7 @@ describe('fetchAllPages', () => {
 
     await expect(
       runWithFakeTimers(() =>
-        fetchAllPages(() => {
+        fetchAllPages('created_at', () => {
           attempts++;
           return Promise.resolve({ data: null, error: GATEWAY_TIMEOUT });
         }),
@@ -92,7 +298,7 @@ describe('fetchAllPages', () => {
 
     await expect(
       runWithFakeTimers(() =>
-        fetchAllPages(() => {
+        fetchAllPages('created_at', () => {
           attempts++;
           return Promise.resolve({
             data: null,
@@ -109,7 +315,7 @@ describe('fetchAllPages', () => {
     let attempts = 0;
 
     const rows = await runWithFakeTimers(() =>
-      fetchAllPages<{ id: number }>(() => {
+      fetchAllPages<{ id: number }>('created_at', () => {
         attempts++;
         if (attempts === 1) {
           return Promise.reject(new Error('fetch failed'));

--- a/apps/web/tests/daily-stats-fetch-all-pages.test.ts
+++ b/apps/web/tests/daily-stats-fetch-all-pages.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, test, vi } from 'vitest';
+
+import {
+  fetchAllPages,
+  isTransientQueryError,
+  PAGE_MAX_ATTEMPTS,
+  PAGE_SIZE,
+} from '../app/api/daily-stats/utils';
+
+const GATEWAY_TIMEOUT = { message: 'Gateway Timeout' };
+
+// Drives `fetchAllPages` past its backoff without waiting on real timers.
+async function runWithFakeTimers<T>(run: () => Promise<T>): Promise<T> {
+  vi.useFakeTimers();
+  try {
+    const promise = run();
+    const settled = promise.then(
+      (value) => ({ value }),
+      (error: unknown) => ({ error }),
+    );
+    await vi.runAllTimersAsync();
+    const result = await settled;
+    if ('error' in result) throw result.error;
+    return result.value;
+  } finally {
+    vi.useRealTimers();
+  }
+}
+
+describe('isTransientQueryError', () => {
+  test.each([
+    ['gateway timeout from the Supabase edge', { message: 'Gateway Timeout' }],
+    ['statement timeout SQLSTATE', { code: '57014', message: 'canceled' }],
+    ['connection failure SQLSTATE', { code: '08006', message: 'nope' }],
+    ['dropped socket', { message: 'socket hang up' }],
+  ])('treats %s as transient', (_label, error) => {
+    expect(isTransientQueryError(error)).toBe(true);
+  });
+
+  test.each([
+    ['a constraint violation', { code: '23505', message: 'duplicate key' }],
+    ['a malformed filter', { message: 'failed to parse filter' }],
+    ['a non-object', 'Gateway Timeout'],
+    ['null', null],
+  ])('does not treat %s as transient', (_label, error) => {
+    expect(isTransientQueryError(error)).toBe(false);
+  });
+});
+
+describe('fetchAllPages', () => {
+  test('retries a transient gateway failure and keeps paginating', async () => {
+    const firstPage = Array.from({ length: PAGE_SIZE }, (_, i) => ({ id: i }));
+    const offsets: number[] = [];
+    let failures = 0;
+
+    const rows = await runWithFakeTimers(() =>
+      fetchAllPages<{ id: number }>((offset) => {
+        offsets.push(offset);
+        if (offset === 0 && failures === 0) {
+          failures++;
+          return Promise.resolve({ data: null, error: GATEWAY_TIMEOUT });
+        }
+        return Promise.resolve({
+          data: offset === 0 ? firstPage : [{ id: PAGE_SIZE }],
+          error: null,
+        });
+      }),
+    );
+
+    expect(rows).toHaveLength(PAGE_SIZE + 1);
+    // Page 0 is replayed, then pagination advances normally.
+    expect(offsets).toEqual([0, 0, PAGE_SIZE]);
+  });
+
+  test('gives up after the attempt budget and preserves the cause', async () => {
+    let attempts = 0;
+
+    await expect(
+      runWithFakeTimers(() =>
+        fetchAllPages(() => {
+          attempts++;
+          return Promise.resolve({ data: null, error: GATEWAY_TIMEOUT });
+        }),
+      ),
+    ).rejects.toThrow('Gateway Timeout');
+
+    expect(attempts).toBe(PAGE_MAX_ATTEMPTS);
+  });
+
+  test('does not retry a non-transient error', async () => {
+    let attempts = 0;
+
+    await expect(
+      runWithFakeTimers(() =>
+        fetchAllPages(() => {
+          attempts++;
+          return Promise.resolve({
+            data: null,
+            error: { code: '42703', message: 'column does not exist' },
+          });
+        }),
+      ),
+    ).rejects.toThrow('column does not exist');
+
+    expect(attempts).toBe(1);
+  });
+
+  test('retries a rejected query builder promise', async () => {
+    let attempts = 0;
+
+    const rows = await runWithFakeTimers(() =>
+      fetchAllPages<{ id: number }>(() => {
+        attempts++;
+        if (attempts === 1) {
+          return Promise.reject(new Error('fetch failed'));
+        }
+        return Promise.resolve({ data: [{ id: 1 }], error: null });
+      }),
+    );
+
+    expect(rows).toEqual([{ id: 1 }]);
+    expect(attempts).toBe(2);
+  });
+});

--- a/docs/devops.md
+++ b/docs/devops.md
@@ -569,4 +569,7 @@ The production `/api/daily-stats` handler delivers a Telegram message. Use the
 focused tests or read-only queries for verification. Contribution inputs bypass
 the local activity cache; database failures abort the report instead of showing
 zero usage. Reporting definitions and test commands are in the
-[daily-stats README](../apps/web/app/api/daily-stats/README.md).
+[daily-stats README](../apps/web/app/api/daily-stats/README.md). For local timing
+comparisons, use the development-only cache bypass and runner described in
+[Local benchmarking](../apps/web/app/api/daily-stats/README.md#local-benchmarking).
+The runner rejects responses that do not confirm the cache bypass.

--- a/scripts/benchmark-daily-stats.mjs
+++ b/scripts/benchmark-daily-stats.mjs
@@ -1,0 +1,267 @@
+#!/usr/bin/env node
+
+import { execFile } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { mkdir, mkdtemp, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parseArgs, promisify } from 'node:util';
+
+const exec = promisify(execFile);
+const repoRoot = fileURLToPath(new URL('../', import.meta.url));
+const help = `Usage: node scripts/benchmark-daily-stats.mjs --label <name> --date YYYY-MM-DD [options]
+
+  --label       Required filename label: letters, digits, underscores, hyphens
+                Start with a letter or digit; maximum 80 characters
+  --date        Required valid calendar date, YYYY-MM-DD
+  --url         Default: https://sv.dev/api/daily-stats
+                Local hosts only: localhost, 127.0.0.1, [::1], sv.dev
+  --runs        Measured requests, 1..20; default: 5
+  --output-dir  Default: scripts/.cache/daily-stats-benchmark
+                Relative paths resolve from the repository root
+  --help, -h    Show this help without making requests
+
+Runs one excluded warmup, then sequential measurements with cache=off.
+Requires curl and trusted local TLS certificates; never follows redirects.
+Each request has a 300-second limit. Failures abort without retrying.
+After a timeout, wait for the server request to finish before rerunning.
+Reports and headers stay in private local files. Console output excludes reports.
+`;
+
+function options() {
+  let values;
+  try {
+    ({ values } = parseArgs({
+      options: {
+        date: { type: 'string' },
+        help: { short: 'h', type: 'boolean' },
+        label: { type: 'string' },
+        'output-dir': {
+          default: 'scripts/.cache/daily-stats-benchmark',
+          type: 'string',
+        },
+        runs: { default: '5', type: 'string' },
+        url: { default: 'https://sv.dev/api/daily-stats', type: 'string' },
+      },
+    }));
+  } catch (cause) {
+    throw new Error('Invalid arguments. Use --help for usage.', { cause });
+  }
+  if (values.help) return null;
+  if (!/^[a-zA-Z0-9][a-zA-Z0-9_-]{0,79}$/.test(values.label ?? '')) {
+    throw new Error('--label is required and must be a safe filename label.');
+  }
+  const date = new Date(`${values.date}T00:00:00.000Z`);
+  if (
+    !/^\d{4}-\d{2}-\d{2}$/.test(values.date ?? '') ||
+    values.date.startsWith('0000-') ||
+    !Number.isFinite(date.getTime()) ||
+    date.toISOString().slice(0, 10) !== values.date
+  ) {
+    throw new Error(
+      '--date must be a valid calendar date in YYYY-MM-DD format.',
+    );
+  }
+  if (!/^(?:[1-9]|1\d|20)$/.test(values.runs)) {
+    throw new Error('--runs must be an integer from 1 to 20.');
+  }
+  let url;
+  try {
+    url = new URL(values.url);
+  } catch (cause) {
+    throw new Error('--url must be a valid local HTTP or HTTPS URL.', {
+      cause,
+    });
+  }
+  if (
+    !(
+      ['http:', 'https:'].includes(url.protocol) &&
+      ['localhost', '127.0.0.1', '[::1]', 'sv.dev'].includes(url.hostname)
+    ) ||
+    url.username ||
+    url.password ||
+    url.hash
+  ) {
+    throw new Error(
+      '--url must use an allowed local host without credentials or a fragment.',
+    );
+  }
+  if (!values['output-dir'].trim()) {
+    throw new Error('--output-dir must not be empty.');
+  }
+  url.searchParams.set('date', values.date);
+  url.searchParams.set('cache', 'off');
+  return {
+    date: values.date,
+    label: values.label,
+    outputDir: path.resolve(repoRoot, values['output-dir']),
+    runs: Number(values.runs),
+    url,
+  };
+}
+
+function summarize(attempts) {
+  const measured = attempts.filter((item) => item.ok && item.phase === 'run');
+  const stats = (key) => {
+    const sorted = measured.map((item) => item[key]).sort((a, b) => a - b);
+    if (!sorted.length) return null;
+    const middle = Math.floor(sorted.length / 2);
+    return {
+      max: sorted.at(-1),
+      median:
+        sorted.length % 2
+          ? sorted[middle]
+          : (sorted[middle - 1] + sorted[middle]) / 2,
+      min: sorted[0],
+    };
+  };
+  return {
+    successfulRuns: measured.length,
+    time_starttransfer: stats('time_starttransfer'),
+    time_total: stats('time_total'),
+    units: 'seconds',
+  };
+}
+
+async function request(url, attempt) {
+  await writeFile(attempt.headersPath, '', { flag: 'wx', mode: 0o600 });
+  await writeFile(attempt.bodyPath, '', { flag: 'wx', mode: 0o600 });
+  // Ignore curlrc and proxies so local requests cannot be redirected elsewhere.
+  const args = [
+    '--disable',
+    '--silent',
+    '--noproxy',
+    '*',
+    '--proto',
+    '=http,https',
+    '--max-time',
+    '300',
+    '--dump-header',
+    attempt.headersPath,
+    '--output',
+    attempt.bodyPath,
+    '--write-out',
+    '%{time_total}\t%{time_starttransfer}\t%{http_code}',
+  ];
+  if (url.hostname === 'sv.dev' || url.hostname === 'localhost') {
+    const port = url.port || (url.protocol === 'https:' ? '443' : '80');
+    args.push('--resolve', `${url.hostname}:${port}:127.0.0.1`);
+  }
+  args.push('--url', url.href);
+  let stdout;
+  let curlFailure;
+  try {
+    ({ stdout } = await exec('curl', args, { maxBuffer: 64 * 1024 }));
+  } catch (error) {
+    stdout = error.stdout ?? '';
+    // Never print child-process errors: they can contain headers or body data.
+    attempt.curlExitCode = error.code ?? null;
+    curlFailure =
+      error.code === 28
+        ? 'curl timed out; wait for the server request to finish before rerunning.'
+        : 'curl failed; check curl availability, local server, and TLS trust.';
+  }
+  const timing = stdout
+    .trim()
+    .match(/^(\d+(?:\.\d+)?)\t(\d+(?:\.\d+)?)\t(\d{3})$/);
+  if (timing) {
+    attempt.time_total = Number(timing[1]);
+    attempt.time_starttransfer = Number(timing[2]);
+    attempt.http_code = Number(timing[3]);
+  }
+  if (curlFailure) throw new Error(curlFailure);
+  if (!timing) throw new Error('Missing or invalid curl timing output.');
+  if (attempt.http_code !== 200) {
+    throw new Error(`Expected HTTP 200; received ${attempt.http_code}.`);
+  }
+  const rawHeaders = await readFile(attempt.headersPath, 'utf8');
+  const finalHeaders = rawHeaders
+    .split(/\r?\n\r?\n/)
+    .filter((block) => /^HTTP\/\S+\s+\d{3}/.test(block))
+    .at(-1);
+  const headers = new Headers();
+  for (const line of (finalHeaders ?? '').split(/\r?\n/).slice(1)) {
+    const colon = line.indexOf(':');
+    if (colon > 0) {
+      headers.append(line.slice(0, colon).trim(), line.slice(colon + 1).trim());
+    }
+  }
+  if (headers.get('x-daily-stats-cache') !== 'bypass') {
+    throw new Error('Expected X-Daily-Stats-Cache: bypass.');
+  }
+  if (
+    headers.get('content-type')?.split(';')[0].trim().toLowerCase() !==
+    'text/plain'
+  ) {
+    throw new Error(
+      'Expected a text/plain report, not JSON or another response type.',
+    );
+  }
+  const body = await readFile(attempt.bodyPath);
+  if (!body.toString('utf8').trim()) throw new Error('Report body is empty.');
+  attempt.sha256 = createHash('sha256').update(body).digest('hex');
+  attempt.ok = true;
+}
+
+async function main() {
+  const config = options();
+  if (!config) {
+    console.log(help);
+    return;
+  }
+  process.umask(0o077);
+  await mkdir(config.outputDir, { mode: 0o700, recursive: true });
+  const directory = await mkdtemp(
+    path.join(config.outputDir, `${config.label}-`),
+  );
+  const resultsPath = path.join(directory, 'results.json');
+  const results = {
+    attempts: [],
+    date: config.date,
+    failure: null,
+    label: config.label,
+    requestedRuns: config.runs,
+    startedAt: new Date().toISOString(),
+    summary: summarize([]),
+    url: config.url.href,
+  };
+  const save = () =>
+    writeFile(resultsPath, `${JSON.stringify(results, null, 2)}\n`, {
+      mode: 0o600,
+    });
+  await save();
+  console.log(`${config.label} results: ${resultsPath}`);
+  for (let index = 0; index <= config.runs; index++) {
+    const name = index === 0 ? 'warmup' : `run-${index}`;
+    const attempt = {
+      bodyPath: path.join(directory, `${name}.txt`),
+      headersPath: path.join(directory, `${name}.headers`),
+      index,
+      ok: false,
+      phase: index === 0 ? 'warmup' : 'run',
+    };
+    results.attempts.push(attempt);
+    try {
+      await request(config.url, attempt);
+      console.log(
+        `${config.label} ${name}: total=${attempt.time_total}s ttfb=${attempt.time_starttransfer}s sha256=${attempt.sha256}`,
+      );
+    } catch (error) {
+      results.failure = { message: error.message, request: name };
+      process.exitCode = 1;
+    }
+    results.summary = summarize(results.attempts);
+    await save();
+    if (results.failure) break;
+  }
+  console.log(`${config.label} summary: ${JSON.stringify(results.summary)}`);
+  if (results.failure) {
+    // Failure details are in the private JSON; do not echo response-derived errors.
+    console.error(`${config.label} failed: ${resultsPath}`);
+  }
+}
+
+main().catch((error) => {
+  console.error(error.message);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary

The 07:00 UTC daily-stats cron died with `Error: Gateway Timeout` (Sentry `146561120`). Sentry's breadcrumbs name the request: `usage_events` at `offset=5000&limit=1000` returned 504 from Supabase's REST gateway, after five shallower pages of the same query returned 200.

This makes a single page failing survivable, removes the deep-offset cost that made the last page the most likely to fail, and cuts the load the run puts on PostgREST.

## Changes

- **Transient-error retry** — a single 504 no longer fails the whole run. `isTransientQueryError` plus four attempts with exponential backoff, matching gateway/socket/timeout shapes and retryable SQLSTATEs such as `57014`. Non-transient errors still fail on the first response.
- **Keyset cursor pagination** — `fetchAllPages` seeks instead of skipping. An offset page makes Postgres sort and discard every row before it, so the deepest pages were both the slowest and the ones that timed out.
- **Seven credit-transaction reads collapsed into one** — the per-period queries were strict subsets of `[epoch, today)` with identical filters and were merged straight back together, so they added load without adding rows. Every window is now sliced in memory from one all-time read.
- **Per-row `profiles(username)` embed dropped from usage events** — PostgREST resolved that embed per row across the whole window to label three users. `getProfileUsernamesByIds` now resolves just the ids shown.
- **Timing on every paginated read** — three were unwrapped, which is why the original failure looked like it came from the block that runs next.
- **Non-prod `?cache=off` bypass**, plus `scripts/benchmark-daily-stats.mjs` and its notes.

## How the cursor handles rows sharing a timestamp

Postgres fixes `now()` at transaction start, so any bulk insert — a promo grant, a backfill, a support batch — gives every row it writes the same timestamp. The cursor has three shapes, all plain ANDs of filters:

| shape | filter | when |
| --- | --- | --- |
| `exclude` | `gte(value)` + `not id in (…)` | the common case |
| `within` | `eq(value)` + `gt(id, lastId)` | the run outgrows the id list |
| `after` | `gt(value)` | the run is exhausted |

This carries the same semantics as the row comparison in `.agents/skills/supabase-postgres-best-practices/references/data-pagination.md`. PostgREST has no row comparison, and the equivalent `(c > v) OR (c = v AND id > lastId)` needs a second top-level `or=` param on the three queries that already pass their own `.or(...)`. Whether PostgREST ANDs repeated `or=` params was not verifiable here, and getting it wrong would silently change which rows a revenue report counts — so the AND form is used instead, at one extra request per long run. **Still worth settling:** one query chaining two `.or()` calls against a real project would confirm it, and if it composes the row-comparison form is a clear simplification.

One guard remains — a cursor value that moves backwards, meaning the query is not ordered by the column it pages on. The id cap is not a guard: exceeding it switches strategy, it does not fail. It sits well under what should fit because the directions are asymmetric — erring low costs a request, erring high risks a 414, which is not transient and so fails the run.

## Verification

- `pnpm fixall`, `pnpm type-check`, 104 daily-stats tests across 6 files.
- Cursor logic mutation-tested: a strict cursor, a first-row cursor, dropping either guard, `gte`-for-`gt` in the id walk or the step past, never escalating strategy, and raising the cap above `PAGE_SIZE` all fail the suite.
- Run against real Supabase on both revisions: 12 responses, all 200, **identical report bytes**. The benchmark's 2.66% median delta is within noise and is not the justification — see the note, which says so explicitly. No timing run reproduces a gateway 504.

## Scope

- [x] Backend
- [x] Database (pagination strategy, not schema)
- [x] Docs

## Checklist

- [x] I self-reviewed this PR
- [x] I ran `pnpm run fixall`
- [x] I ran `pnpm run type-check`
- [x] I added or updated tests where needed
- [x] I updated docs/comments where needed

---
_Description updated by [Claude Code](https://claude.ai/code): the original said the cursor throws when more than 200 rows share a value, which stopped being true in ccfdf43 — it now switches strategy instead, and the cap moved to 100 in ceeb2f5. Revert if you'd rather keep the original wording._